### PR TITLE
revision: add trailing blank line to file_structure.txt

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -77,3 +77,4 @@ Machine-local (NOT synced):
   ~/.claude/session-env/         session state
   ~/.claude/shell-snapshots/     shell state
   ~/.claude/telemetry/           telemetry data
+


### PR DESCRIPTION
## Summary
- Adds a blank line at the end of `docs/file_structure.txt` for consistent file formatting

## Test plan
- [x] Verified file ends with trailing blank line
- [x] No functional changes — whitespace only

🤖 Generated with [Claude Code](https://claude.com/claude-code)