### PR TITLE
revision: add trailing blank line to docs/file_structure.txt

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -77,3 +77,4 @@ Machine-local (NOT synced):
   ~/.claude/session-env/         session state
   ~/.claude/shell-snapshots/     shell state
   ~/.claude/telemetry/           telemetry data
+


### PR DESCRIPTION
## Summary
- Adds a trailing blank line to `docs/file_structure.txt` for consistent file formatting

## Test plan
- [x] Verified file ends with a blank line after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)