### PR TITLE
revision-major: extract run_claude into shared lib/run-claude.sh

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -51,7 +51,9 @@ claude-dot-files/
 ├── scripts/
 │   └── workflows/                         # Autonomous workflow scripts (Workflow 2)
 │       ├── lib/
-│       │   └── format-stream.sh           # Shared stream-json formatter for live display
+│       │   ├── format-stream.sh           # Shared stream-json formatter for live display
+│       │   └── run-claude.sh              # Shared run_claude helper (verbose/quiet invocation)
+│       ├── review-runs.sh                 # REVIEW-RUNS workflow — CPI log analysis and reporting
 │       ├── revision.sh                    # REVISION workflow — minor corrections to existing code
 │       └── revision-major.sh              # REVISION-MAJOR workflow — significant rework (9 stages)
 │

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -15,7 +15,8 @@ All workflow scripts live in `scripts/workflows/`. Helper libraries go in `scrip
 scripts/
 └── workflows/
     ├── lib/
-    │   └── format-stream.sh    # shared stream-json formatter
+    │   ├── format-stream.sh    # shared stream-json formatter
+    │   └── run-claude.sh       # shared run_claude helper function
     ├── revision.sh             # minor corrections
     ├── revision-major.sh       # significant rework
     ├── build-phase.sh          # architect and build
@@ -32,10 +33,10 @@ Script names use kebab-case matching the workflow's purpose, with `.sh` suffix:
 **Note:** Workflows are bash scripts, NOT slash commands. Slash commands live in `config/commands/` and are for prompt-template injection in interactive mode. Workflow scripts live in `scripts/workflows/` and are full bash programs that wrap `claude -p` invocations with logging, visibility, and structured stages. These are different things — don't confuse the notation.
 
 ### Executable
-All workflow scripts must be executable (`chmod +x`).
+All workflow scripts must be executable (`chmod +x`). Sourced library files in `lib/` should NOT be marked executable — they are not standalone scripts.
 
 ### Shebang
-Always use `#!/usr/bin/env bash`.
+Always use `#!/usr/bin/env bash`. Sourced library files in `lib/` should omit the shebang.
 
 ### Safety Pragma
 Every workflow script starts with:
@@ -102,40 +103,23 @@ The shared formatter at `scripts/workflows/lib/format-stream.sh` reads JSONL fro
 
 ### 4. Standard run_claude Helper
 
-Every workflow script should define a `run_claude` helper function that encapsulates the verbose/quiet logic:
+Every workflow script must source the shared `run_claude` helper from `scripts/workflows/lib/run-claude.sh`. This avoids duplicating the verbose/quiet invocation logic across every workflow script.
+
+The shared library requires four environment variables to be set before sourcing:
+- `LOG_FILE` — path to the JSONL log file for this run
+- `MAX_TURNS` — maximum conversation turns for claude
+- `VERBOSE` — `true` or `false` for live streaming
+- `FORMATTER` — path to the format-stream.sh formatter script
 
 ```bash
-run_claude() {
-    local prompt="$1"
-    shift
-    local extra_args=("$@")
+# Source the shared run_claude helper (requires LOG_FILE, MAX_TURNS, VERBOSE, FORMATTER)
+source "${SCRIPT_DIR}/lib/run-claude.sh"
+```
 
-    if $VERBOSE; then
-        # Live stream to both log and formatter
-        claude -p "$prompt" \
-            --output-format stream-json \
-            --verbose \
-            --max-turns "$MAX_TURNS" \
-            --dangerously-skip-permissions \
-            "${extra_args[@]}" \
-            | tee "$LOG_FILE" \
-            | "$FORMATTER"
-    else
-        # Quiet mode: capture log, then print final result
-        claude -p "$prompt" \
-            --output-format stream-json \
-            --verbose \
-            --max-turns "$MAX_TURNS" \
-            --dangerously-skip-permissions \
-            "${extra_args[@]}" \
-            > "$LOG_FILE"
+Usage is the same as before — call `run_claude` with a prompt and optional extra args:
 
-        # Extract final result summary
-        jq -r 'select(.type == "result") |
-            "Turns: \(.num_turns // "?") · Cost: $\(.total_cost_usd // 0) · Duration: \((.duration_ms // 0) / 1000)s\n\n\(.result // "Complete.")"' \
-            "$LOG_FILE"
-    fi
-}
+```bash
+run_claude "$PROMPT" -w "$WORKTREE_NAME"
 ```
 
 ### 5. Environment Checks
@@ -373,23 +357,8 @@ echo "  Verbose    : ${VERBOSE}"
 echo "  Log file   : ${LOG_FILE}"
 echo "================================================================"
 
-# ---- run_claude helper ----
-run_claude() {
-    local prompt="$1"
-    shift
-    if $VERBOSE; then
-        claude -p "$prompt" --output-format stream-json --verbose \
-            --max-turns "$MAX_TURNS" --dangerously-skip-permissions "$@" \
-            | tee "$LOG_FILE" | "$FORMATTER"
-    else
-        claude -p "$prompt" --output-format stream-json --verbose \
-            --max-turns "$MAX_TURNS" --dangerously-skip-permissions "$@" \
-            > "$LOG_FILE"
-        jq -r 'select(.type == "result") |
-            "Turns: \(.num_turns) · Cost: $\(.total_cost_usd) · Duration: \((.duration_ms) / 1000)s\n\n\(.result // "Complete.")"' \
-            "$LOG_FILE"
-    fi
-}
+# ---- run_claude helper (shared library) ----
+source "${SCRIPT_DIR}/lib/run-claude.sh"
 
 # ---- Workflow logic ----
 PROMPT=$(cat <<EOF

--- a/scripts/workflows/lib/run-claude.sh
+++ b/scripts/workflows/lib/run-claude.sh
@@ -1,0 +1,48 @@
+# run-claude.sh — shared run_claude helper for workflow scripts
+#
+# Source this file from any workflow script to get the standard run_claude
+# function. This avoids duplicating the verbose/quiet invocation logic across
+# every workflow.
+#
+# Required environment variables (must be set before sourcing):
+#   LOG_FILE    — path to the JSONL log file for this run
+#   MAX_TURNS   — maximum conversation turns for claude
+#   VERBOSE     — "true" or "false" for live streaming
+#   FORMATTER   — path to the format-stream.sh formatter script
+#
+# Usage in a workflow script:
+#   source "${SCRIPT_DIR}/lib/run-claude.sh"
+#   run_claude "$PROMPT" -w "$WORKTREE_NAME"
+
+# Guard: verify required variables are set
+: "${LOG_FILE:?run-claude.sh: LOG_FILE must be set before sourcing}"
+: "${MAX_TURNS:?run-claude.sh: MAX_TURNS must be set before sourcing}"
+: "${VERBOSE:?run-claude.sh: VERBOSE must be set before sourcing}"
+: "${FORMATTER:?run-claude.sh: FORMATTER must be set before sourcing}"
+
+run_claude() {
+    local prompt="$1"
+    shift
+    local extra_args=("$@")
+
+    local claude_cmd=(
+        claude -p "$prompt"
+        --output-format stream-json
+        --verbose
+        --max-turns "$MAX_TURNS"
+        --dangerously-skip-permissions
+        "${extra_args[@]}"
+    )
+
+    if $VERBOSE; then
+        "${claude_cmd[@]}" \
+            | tee "$LOG_FILE" \
+            | "$FORMATTER"
+    else
+        "${claude_cmd[@]}" > "$LOG_FILE"
+
+        jq -r 'select(.type == "result") |
+            "Turns: \(.num_turns // "?") · Cost: $\(.total_cost_usd // 0) · Duration: \((.duration_ms // 0) / 1000)s\n\n\(.result // "Complete.")"' \
+            "$LOG_FILE"
+    fi
+}

--- a/scripts/workflows/review-runs.sh
+++ b/scripts/workflows/review-runs.sh
@@ -241,34 +241,9 @@ printf "%s" "$FILE_LIST"
 echo
 
 # ---------------------------------------------------------------------------
-# run_claude helper (from workflow-scripts standard)
+# run_claude helper (shared library)
 # ---------------------------------------------------------------------------
-run_claude() {
-    local prompt="$1"
-    shift
-    local extra_args=("$@")
-
-    local claude_cmd=(
-        claude -p "$prompt"
-        --output-format stream-json
-        --verbose
-        --max-turns "$MAX_TURNS"
-        --dangerously-skip-permissions
-        "${extra_args[@]}"
-    )
-
-    if $VERBOSE; then
-        "${claude_cmd[@]}" \
-            | tee "$LOG_FILE" \
-            | "$FORMATTER"
-    else
-        "${claude_cmd[@]}" > "$LOG_FILE"
-
-        jq -r 'select(.type == "result") |
-            "Turns: \(.num_turns // "?") · Cost: $\(.total_cost_usd // 0) · Duration: \((.duration_ms // 0) / 1000)s\n\n\(.result // "Complete.")"' \
-            "$LOG_FILE"
-    fi
-}
+source "${SCRIPT_DIR}/lib/run-claude.sh"
 
 # ---------------------------------------------------------------------------
 # Workflow execution — no worktree needed (read-only analysis)

--- a/scripts/workflows/revision-major.sh
+++ b/scripts/workflows/revision-major.sh
@@ -156,34 +156,9 @@ echo "================================================================"
 echo
 
 # ---------------------------------------------------------------------------
-# run_claude helper (from workflow-scripts standard)
+# run_claude helper (shared library)
 # ---------------------------------------------------------------------------
-run_claude() {
-    local prompt="$1"
-    shift
-    local extra_args=("$@")
-
-    local claude_cmd=(
-        claude -p "$prompt"
-        --output-format stream-json
-        --verbose
-        --max-turns "$MAX_TURNS"
-        --dangerously-skip-permissions
-        "${extra_args[@]}"
-    )
-
-    if $VERBOSE; then
-        "${claude_cmd[@]}" \
-            | tee "$LOG_FILE" \
-            | "$FORMATTER"
-    else
-        "${claude_cmd[@]}" > "$LOG_FILE"
-
-        jq -r 'select(.type == "result") |
-            "Turns: \(.num_turns // "?") · Cost: $\(.total_cost_usd // 0) · Duration: \((.duration_ms // 0) / 1000)s\n\n\(.result // "Complete.")"' \
-            "$LOG_FILE"
-    fi
-}
+source "${SCRIPT_DIR}/lib/run-claude.sh"
 
 # ---------------------------------------------------------------------------
 # Workflow execution

--- a/scripts/workflows/revision.sh
+++ b/scripts/workflows/revision.sh
@@ -98,20 +98,12 @@ done
 # ---------------------------------------------------------------------------
 # Environment checks
 # ---------------------------------------------------------------------------
-if ! command -v claude &>/dev/null; then
-    echo "Error: 'claude' CLI not found in PATH" >&2
-    exit 1
-fi
-
-if ! command -v gh &>/dev/null; then
-    echo "Error: 'gh' CLI not found in PATH" >&2
-    exit 1
-fi
-
-if ! command -v jq &>/dev/null; then
-    echo "Error: 'jq' not found in PATH" >&2
-    exit 1
-fi
+for cmd in claude gh jq; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' not found in PATH" >&2
+        exit 1
+    fi
+done
 
 if ! git rev-parse --show-toplevel &>/dev/null; then
     echo "Error: not inside a git repository" >&2
@@ -160,44 +152,9 @@ echo "================================================================"
 echo
 
 # ---------------------------------------------------------------------------
-# Helper: run claude with raw JSONL logging and optional live formatting
+# run_claude helper (shared library)
 # ---------------------------------------------------------------------------
-# Always writes raw JSONL to $LOG_FILE. Raw format is lossless and can be:
-#   - Read by Claude for self-diagnosis when runs go sideways
-#   - Piped through the formatter on-demand for human reading
-#   - Queried with jq for metrics and post-mortem analysis
-#
-# In verbose mode, also streams formatted output live to the terminal.
-# In quiet mode, prints just the final result summary at the end.
-run_claude() {
-    local prompt="$1"
-    shift
-    local extra_args=("$@")
-
-    # Common claude invocation — always uses stream-json
-    local claude_cmd=(
-        claude -p "$prompt"
-        --output-format stream-json
-        --verbose
-        --max-turns "$MAX_TURNS"
-        --dangerously-skip-permissions
-        "${extra_args[@]}"
-    )
-
-    if $VERBOSE; then
-        # Pipeline: claude → tee raw log → formatter → terminal
-        "${claude_cmd[@]}" \
-            | tee "$LOG_FILE" \
-            | "$FORMATTER"
-    else
-        # Quiet mode: write raw log, then print final result summary
-        "${claude_cmd[@]}" > "$LOG_FILE"
-
-        jq -r 'select(.type == "result") |
-            "Turns: \(.num_turns // "?") · Cost: $\(.total_cost_usd // 0) · Duration: \((.duration_ms // 0) / 1000)s\n\n\(.result // "Complete.")"' \
-            "$LOG_FILE"
-    fi
-}
+source "${SCRIPT_DIR}/lib/run-claude.sh"
 
 # ---------------------------------------------------------------------------
 # Workflow execution


### PR DESCRIPTION
## Summary

- Extracted the `run_claude` helper function from `revision.sh`, `revision-major.sh`, and `review-runs.sh` into a shared library at `scripts/workflows/lib/run-claude.sh`
- All three workflows now source the shared lib instead of defining `run_claude` inline (~75 lines removed across 3 files)
- The shared lib requires `LOG_FILE`, `MAX_TURNS`, `VERBOSE`, and `FORMATTER` as environment variables, with guards that error if any are unset

## Additional changes

- Aligned `revision.sh` env checks from individual `if` blocks to the `for cmd in ...` loop pattern used by the other scripts
- Updated `docs/standards/workflow-scripts.md` §4 to document the shared lib sourcing pattern
- Clarified in the standard that sourced lib files should not be executable or have shebangs
- Updated `docs/file_structure.txt` with `run-claude.sh` and `review-runs.sh` entries

## Deviations from plan

None.

## Review findings

**Addressed:**
- [Info] Clarified executable/shebang rules for lib files in the standard

**Deferred (pre-existing, not introduced by this change):**
- [Warning] `if $VERBOSE` command-execution idiom — works today but fragile for non-standard values
- [Warning] No fallback when jq finds no result event in quiet mode
- [Warning] GNU find `-printf` portability in review-runs.sh

## Refactoring suggestions

**Implemented:**
- Aligned `revision.sh` env-check pattern to loop form matching other scripts

**Deferred:**
- `if $VERBOSE` idiom change (pre-existing, scope expansion)
- Standard doc env-check example inconsistency (documentation-only)

## Test results

- All 4 scripts pass `bash -n` syntax validation
- `revision.sh` and `revision-major.sh` show correct usage when called without args
- `review-runs.sh --help` shows correct help
- Shared lib sources correctly and defines `run_claude` when variables are set
- Shared lib guard correctly errors when required variables are unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)