### PR TITLE
build-phase: gh-monitor service for @claude PR comment automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Claude Code project-local files
 .claude/
+
+# Service config (may contain machine-specific settings)
+scripts/services/*.config.env

--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,11 @@ set -euo pipefail
 # --- Parse flags --------------------------------------------------------------
 
 INTERACTIVE=true
+INSTALL_SERVICES=false
 for arg in "$@"; do
     case "$arg" in
         --non-interactive|-n) INTERACTIVE=false ;;
+        --with-services) INSTALL_SERVICES=true ;;
         *) echo "Unknown option: $arg"; exit 1 ;;
     esac
 done
@@ -212,9 +214,71 @@ if [ "$backup_needed" = true ]; then
     echo "  Backups saved to: $BACKUP_DIR"
 fi
 
+# --- Step 4: Services (opt-in) -----------------------------------------------
+
+if [ "$INSTALL_SERVICES" = true ]; then
+    echo ""
+    echo "Step 4: Services"
+    echo ""
+
+    SYSTEMD_DIR="$HOME/.config/systemd/user"
+    SERVICES_DIR="$REPO_DIR/scripts/services"
+    CONFIG_ENV="$SERVICES_DIR/gh-monitor.config.env"
+    CONFIG_EXAMPLE="$SERVICES_DIR/gh-monitor.config.env.example"
+
+    mkdir -p "$SYSTEMD_DIR"
+
+    # Symlink service and timer units
+    for unit in gh-monitor.service gh-monitor.timer; do
+        if [ -L "$SYSTEMD_DIR/$unit" ] && [ "$(readlink -f "$SYSTEMD_DIR/$unit")" = "$(readlink -f "$SERVICES_DIR/$unit")" ]; then
+            info "$unit — already linked"
+        else
+            ln -sf "$SERVICES_DIR/$unit" "$SYSTEMD_DIR/$unit"
+            info "$unit → linked"
+        fi
+    done
+
+    # Copy config example if no config exists
+    if [ ! -f "$CONFIG_ENV" ] && [ -f "$CONFIG_EXAMPLE" ]; then
+        cp "$CONFIG_EXAMPLE" "$CONFIG_ENV"
+        info "gh-monitor.config.env — created from example (edit as needed)"
+    elif [ -f "$CONFIG_ENV" ]; then
+        info "gh-monitor.config.env — already exists"
+    fi
+
+    # Reload systemd and enable timer
+    systemctl --user daemon-reload
+    info "systemd daemon reloaded"
+
+    if systemctl --user enable gh-monitor.timer 2>&1; then
+        info "gh-monitor.timer enabled"
+    else
+        warn "Failed to enable gh-monitor.timer — check systemd user session"
+    fi
+
+    if systemctl --user start gh-monitor.timer 2>&1; then
+        info "gh-monitor.timer started"
+    else
+        warn "Failed to start gh-monitor.timer — check systemd user session"
+    fi
+
+    echo ""
+    echo "  Service management commands:"
+    echo "    systemctl --user status gh-monitor.timer    # check timer"
+    echo "    systemctl --user status gh-monitor.service  # check last run"
+    echo "    journalctl --user -u gh-monitor.service -f  # follow logs"
+    echo "    systemctl --user stop gh-monitor.timer      # stop polling"
+    echo "    systemctl --user disable gh-monitor.timer   # disable on boot"
+fi
+
 echo ""
-echo "Next steps:"
-echo "  • Edit config/CLAUDE.md with your global instructions"
-echo "  • Edit config/settings.json with your global settings"
-echo "  • Run 'claude' to verify everything works"
+if [ "$all_good" = true ]; then
+    echo "Next steps:"
+    echo "  • Edit config/CLAUDE.md with your global instructions"
+    echo "  • Edit config/settings.json with your global settings"
+    if [ "$INSTALL_SERVICES" = false ]; then
+        echo "  • Run './install.sh --with-services' to set up the GitHub monitor"
+    fi
+    echo "  • Run 'claude' to verify everything works"
+fi
 echo ""

--- a/scripts/services/gh-monitor.config.env.example
+++ b/scripts/services/gh-monitor.config.env.example
@@ -1,0 +1,25 @@
+# gh-monitor configuration
+# -----------------------------------------------
+# Copy this file to gh-monitor.config.env and edit as needed.
+# All variables have sensible defaults in the script — this file overrides them.
+# Do NOT commit gh-monitor.config.env if it contains secrets.
+
+# Repos to monitor (space-separated owner/repo)
+GH_MONITOR_REPOS="helloskyy-io/Claude-Dot-Files"
+
+# Concurrency: max simultaneous workflows
+GH_MONITOR_MAX_CONCURRENT=1
+
+# Route enablement (set to false to disable specific routes)
+GH_MONITOR_ENABLE_REVISION=true
+GH_MONITOR_ENABLE_REVISION_MAJOR=true
+GH_MONITOR_ENABLE_HELP=true
+
+# Dry run mode (detect comments, log what would happen, but don't run workflows)
+GH_MONITOR_DRY_RUN=false
+
+# Backlog limit: skip comments older than N days
+GH_MONITOR_BACKLOG_DAYS=7
+
+# Path to workflow scripts (default: auto-detected from repo root)
+# GH_MONITOR_WORKFLOW_DIR="${HOME}/Repos/claude-dot-files/scripts/workflows"

--- a/scripts/services/gh-monitor.service
+++ b/scripts/services/gh-monitor.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=GitHub monitor for @claude PR comment automation
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/%u/Repos/claude-dot-files/scripts/services/gh-monitor.sh
+Environment=HOME=/home/%u
+
+[Install]
+WantedBy=default.target

--- a/scripts/services/gh-monitor.sh
+++ b/scripts/services/gh-monitor.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# gh-monitor.sh — GitHub monitor for @claude PR comment automation
+#
+# Polls configured GitHub repos for PR comments mentioning @claude,
+# routes them to the appropriate workflow script, and tracks state
+# via emoji reactions.
+#
+# Usage:
+#   ./gh-monitor.sh              # normal polling run
+#   ./gh-monitor.sh --dry-run    # detect comments but don't run workflows
+#
+# Designed to run as a systemd oneshot service triggered by gh-monitor.timer.
+# Uses bash + gh CLI only — zero Claude/AI tokens burned on polling.
+#
+# See docs/standards/services.md for the conventions this script follows.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Script location and repo root
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Source config file if it exists (all vars have defaults below)
+# ---------------------------------------------------------------------------
+CONFIG_FILE="${SCRIPT_DIR}/gh-monitor.config.env"
+if [[ -f "$CONFIG_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$CONFIG_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults (applied if not set by config)
+# ---------------------------------------------------------------------------
+: "${GH_MONITOR_REPOS:=""}"
+: "${GH_MONITOR_MAX_CONCURRENT:=1}"
+: "${GH_MONITOR_ENABLE_REVISION:=true}"
+: "${GH_MONITOR_ENABLE_REVISION_MAJOR:=true}"
+: "${GH_MONITOR_ENABLE_HELP:=true}"
+: "${GH_MONITOR_DRY_RUN:=false}"
+: "${GH_MONITOR_BACKLOG_DAYS:=7}"
+: "${GH_MONITOR_WORKFLOW_DIR:="${REPO_ROOT}/scripts/workflows"}"
+
+# CLI flag override
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) GH_MONITOR_DRY_RUN=true ;;
+        *) echo "Error: unknown option '$arg'" >&2; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# State directory and lock file
+# ---------------------------------------------------------------------------
+STATE_DIR="${REPO_ROOT}/.claude/state"
+LOCK_FILE="${STATE_DIR}/gh-monitor.lock"
+mkdir -p "$STATE_DIR"
+
+# ---------------------------------------------------------------------------
+# Environment checks
+# ---------------------------------------------------------------------------
+for cmd in gh jq; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: '$cmd' not found in PATH" >&2
+        exit 1
+    fi
+done
+
+# Verify gh authentication
+if ! gh auth status &>/dev/null; then
+    echo "Error: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+fi
+
+# Verify repos are configured
+if [[ -z "$GH_MONITOR_REPOS" ]]; then
+    echo "Error: GH_MONITOR_REPOS is empty. Configure repos in ${CONFIG_FILE}" >&2
+    exit 1
+fi
+
+# Verify workflow directory exists
+if [[ ! -d "$GH_MONITOR_WORKFLOW_DIR" ]]; then
+    echo "Error: workflow directory not found at ${GH_MONITOR_WORKFLOW_DIR}" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Concurrency guard (lock file with PID for stale detection)
+# Note: while the lock is held, manual gh-monitor.sh runs will also be blocked.
+# ---------------------------------------------------------------------------
+if [[ -f "$LOCK_FILE" ]]; then
+    LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null || echo "")
+    if [[ -n "$LOCK_PID" ]] && kill -0 "$LOCK_PID" 2>/dev/null; then
+        echo "Another instance is running (PID ${LOCK_PID}). Skipping."
+        exit 0
+    fi
+    echo "Stale lock file found (PID ${LOCK_PID} not running). Removing."
+    rm -f "$LOCK_FILE"
+fi
+trap 'rm -f "$LOCK_FILE"' EXIT
+echo $$ > "$LOCK_FILE"
+
+# ---------------------------------------------------------------------------
+# Rate limit check
+# ---------------------------------------------------------------------------
+check_rate_limit() {
+    local remaining
+    remaining=$(gh api rate_limit --jq '.resources.core.remaining' 2>/dev/null || echo "0")
+    if [[ "$remaining" -lt 50 ]]; then
+        echo "Warning: GitHub API rate limit low (${remaining} remaining). Backing off."
+        return 1
+    fi
+    return 0
+}
+
+if ! check_rate_limit; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Banner
+# ---------------------------------------------------------------------------
+echo "================================================================"
+echo "  GH-MONITOR"
+echo "================================================================"
+echo "  Repos     : ${GH_MONITOR_REPOS}"
+echo "  Dry run   : ${GH_MONITOR_DRY_RUN}"
+echo "  Backlog   : ${GH_MONITOR_BACKLOG_DAYS} days"
+echo "  Workflows : ${GH_MONITOR_WORKFLOW_DIR}"
+echo "  Timestamp : $(date '+%Y-%m-%d %H:%M:%S')"
+echo "================================================================"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Calculate the cutoff date for backlog processing (UTC to match GitHub's timestamps)
+BACKLOG_CUTOFF=$(date -u -d "${GH_MONITOR_BACKLOG_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -v-${GH_MONITOR_BACKLOG_DAYS}d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || echo "")
+if [[ -z "$BACKLOG_CUTOFF" ]]; then
+    echo "Warning: could not compute backlog cutoff date. All comments will be eligible."
+fi
+
+# Check if a comment already has one of our state reactions
+# State reactions: eyes (processing), hooray (success), -1 (failed), confused (clarification)
+comment_has_reaction() {
+    local repo="$1"
+    local comment_id="$2"
+    local our_reactions
+    our_reactions=$(gh api "repos/${repo}/issues/comments/${comment_id}/reactions" \
+        --jq '[.[] | select(.content == "eyes" or .content == "hooray" or .content == "-1" or .content == "confused")] | length' \
+        2>/dev/null || echo "error")
+
+    # If the API call failed, treat as "has reaction" to avoid duplicate processing
+    if [[ "$our_reactions" == "error" ]]; then
+        echo "    Warning: could not check reactions for comment ${comment_id}, skipping to be safe."
+        return 0
+    fi
+
+    [[ "$our_reactions" -gt 0 ]]
+}
+
+# React to a comment with a specific emoji
+react_to_comment() {
+    local repo="$1"
+    local comment_id="$2"
+    local reaction="$3"
+
+    if [[ "$GH_MONITOR_DRY_RUN" == "true" ]]; then
+        echo "  [DRY RUN] Would react with ${reaction} on comment ${comment_id}"
+        return 0
+    fi
+
+    gh api "repos/${repo}/issues/comments/${comment_id}/reactions" \
+        -f content="$reaction" \
+        --silent 2>/dev/null || true
+}
+
+# Post a comment on a PR
+post_pr_comment() {
+    local repo="$1"
+    local pr_number="$2"
+    local body="$3"
+
+    if [[ "$GH_MONITOR_DRY_RUN" == "true" ]]; then
+        echo "  [DRY RUN] Would post comment on PR #${pr_number}"
+        return 0
+    fi
+
+    gh api "repos/${repo}/issues/${pr_number}/comments" \
+        -f body="$body" \
+        --silent 2>/dev/null || true
+}
+
+# Parse the @claude command from a comment body
+# Returns: route and description separated by a tab
+parse_command() {
+    local body="$1"
+
+    # Strip code blocks (``` ... ```) to avoid matching @claude inside them
+    local cleaned
+    cleaned=$(echo "$body" | sed '/^```/,/^```/d')
+
+    # Match @claude at start of line or start of comment
+    local match
+    match=$(echo "$cleaned" | grep -m1 -iE '^\s*@claude\b' || echo "")
+
+    if [[ -z "$match" ]]; then
+        echo ""
+        return
+    fi
+
+    # Extract the part after @claude
+    local after_mention
+    after_mention=$(echo "$match" | sed -E 's/^\s*@claude\s*//i')
+
+    # Determine route
+    if echo "$after_mention" | grep -qiE '^help\s*$'; then
+        echo "help"
+        return
+    fi
+
+    if echo "$after_mention" | grep -qiE '^revision-major:\s*'; then
+        local desc
+        desc=$(echo "$after_mention" | sed -E 's/^revision-major:\s*//i')
+        printf "revision-major\t%s" "$desc"
+        return
+    fi
+
+    if echo "$after_mention" | grep -qiE '^revision:\s*'; then
+        local desc
+        desc=$(echo "$after_mention" | sed -E 's/^revision:\s*//i')
+        printf "revision\t%s" "$desc"
+        return
+    fi
+
+    # Unrecognized route
+    printf "unknown\t%s" "$after_mention"
+}
+
+# Generate help text
+generate_help_text() {
+    cat <<'HELPEOF'
+## Available Commands
+
+| Command | Description |
+|---------|------------|
+| `@claude revision: <description>` | Run a minor revision workflow on this PR |
+| `@claude revision-major: <description>` | Run a major revision workflow on this PR |
+| `@claude help` | Show this help message |
+
+### Examples
+
+```
+@claude revision: fix the typo in the README header
+@claude revision-major: restructure the authentication module to use JWT
+@claude help
+```
+
+### Notes
+- Every command requires an explicit route prefix (`revision:`, `revision-major:`, or `help`)
+- Commands are processed by a local poller (not GitHub Actions) — responses may take a few minutes
+- Only one workflow runs at a time per machine
+HELPEOF
+}
+
+# Count currently running workflow processes (scoped to our workflow scripts)
+count_running_workflows() {
+    local count
+    count=$(pgrep -f "${GH_MONITOR_WORKFLOW_DIR}/(revision|revision-major)\.sh" 2>/dev/null | wc -l || echo "0")
+    echo "$count"
+}
+
+# Run a workflow route (shared logic for revision and revision-major)
+# Args: route_name enable_flag script_name repo pr_number comment_id description
+run_workflow_route() {
+    local route_name="$1"
+    local enable_flag="$2"
+    local script_name="$3"
+    local repo="$4"
+    local pr_number="$5"
+    local comment_id="$6"
+    local description="$7"
+
+    if [[ "$enable_flag" != "true" ]]; then
+        echo "    ${route_name} route is disabled. Skipping."
+        ((SKIPPED++)) || true
+        return 0
+    fi
+
+    if [[ -z "$description" || ${#description} -lt 10 ]]; then
+        react_to_comment "$repo" "$comment_id" "confused"
+        local clarify_body="I need a more specific description for this ${route_name}. Please provide details."
+        clarify_body+=$'\n\n'"Example: \`@claude ${route_name}: <describe what you want changed>\`"
+        clarify_body+=$'\n\n'"Type \`@claude help\` for available commands."
+        post_pr_comment "$repo" "$pr_number" "$clarify_body"
+        echo "    Insufficient context — posted clarification request."
+        ((PROCESSED++)) || true
+        return 0
+    fi
+
+    # Check concurrency
+    local running
+    running=$(count_running_workflows)
+    if [[ "$running" -ge "$GH_MONITOR_MAX_CONCURRENT" ]]; then
+        echo "    Max concurrent workflows reached (${running}/${GH_MONITOR_MAX_CONCURRENT}). Skipping."
+        ((SKIPPED++)) || true
+        return 0
+    fi
+
+    react_to_comment "$repo" "$comment_id" "eyes"
+
+    if [[ "$GH_MONITOR_DRY_RUN" == "true" ]]; then
+        echo "    [DRY RUN] Would run: ${script_name} \"${description}\" --pr ${pr_number}"
+        react_to_comment "$repo" "$comment_id" "hooray"
+        ((PROCESSED++)) || true
+        return 0
+    fi
+
+    # Run the workflow
+    echo "    Launching ${script_name}..."
+    local workflow_exit=0
+    (
+        cd "$REPO_ROOT"
+        "${GH_MONITOR_WORKFLOW_DIR}/${script_name}" "$description" --pr "$pr_number"
+    ) || workflow_exit=$?
+
+    if [[ "$workflow_exit" -eq 0 ]]; then
+        react_to_comment "$repo" "$comment_id" "hooray"
+        echo "    ${route_name} completed successfully."
+    else
+        react_to_comment "$repo" "$comment_id" "-1"
+        local error_body="${route_name} workflow failed (exit code: ${workflow_exit}). Check the logs for details."
+        error_body+=$'\n\n'"Triggered by: \`@claude ${route_name}: ${description}\`"
+        post_pr_comment "$repo" "$pr_number" "$error_body"
+        echo "    ${route_name} FAILED (exit ${workflow_exit})."
+        ((ERRORS++)) || true
+    fi
+    ((PROCESSED++)) || true
+}
+
+# ---------------------------------------------------------------------------
+# Main processing loop
+# ---------------------------------------------------------------------------
+PROCESSED=0
+SKIPPED=0
+ERRORS=0
+
+for REPO in $GH_MONITOR_REPOS; do
+    echo ""
+    echo "--- Checking ${REPO} ---"
+
+    # Get open PRs with comments
+    PR_NUMBERS=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+        --jq '.[].number' 2>/dev/null || echo "")
+
+    if [[ -z "$PR_NUMBERS" ]]; then
+        echo "  No open PRs found."
+        continue
+    fi
+
+    for PR_NUMBER in $PR_NUMBERS; do
+        # Get comments on this PR
+        COMMENTS_JSON=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '[.[] | {id: .id, body: .body, created_at: .created_at, user: .user.login}]' \
+            2>/dev/null || echo "[]")
+
+        # Filter for @claude mentions
+        COMMENT_IDS=$(echo "$COMMENTS_JSON" | jq -r '.[] | select(.body | test("(?i)^\\s*@claude\\b"; "m")) | .id' 2>/dev/null || echo "")
+
+        if [[ -z "$COMMENT_IDS" ]]; then
+            continue
+        fi
+
+        for COMMENT_ID in $COMMENT_IDS; do
+            # Extract all comment fields in a single jq pass (use --argjson for safe interpolation)
+            COMMENT_DETAILS=$(echo "$COMMENTS_JSON" | jq -r --argjson cid "$COMMENT_ID" \
+                '.[] | select(.id == $cid) | "\(.created_at)\t\(.user)"')
+            COMMENT_DATE=$(echo "$COMMENT_DETAILS" | cut -f1)
+            COMMENT_USER=$(echo "$COMMENT_DETAILS" | cut -f2)
+            COMMENT_BODY=$(echo "$COMMENTS_JSON" | jq -r --argjson cid "$COMMENT_ID" '.[] | select(.id == $cid) | .body')
+
+            # Skip if too old (backlog limit)
+            if [[ -n "$BACKLOG_CUTOFF" ]]; then
+                if [[ "$COMMENT_DATE" < "$BACKLOG_CUTOFF" ]]; then
+                    echo "  PR #${PR_NUMBER} comment ${COMMENT_ID}: skipped (older than ${GH_MONITOR_BACKLOG_DAYS} days)"
+                    ((SKIPPED++)) || true
+                    continue
+                fi
+            fi
+
+            # Check for existing reactions (dedup)
+            if comment_has_reaction "$REPO" "$COMMENT_ID"; then
+                continue
+            fi
+
+            echo "  PR #${PR_NUMBER} comment ${COMMENT_ID} by ${COMMENT_USER}: processing..."
+
+            # Parse the command
+            PARSED=$(parse_command "$COMMENT_BODY")
+            ROUTE=$(echo "$PARSED" | cut -f1)
+            DESCRIPTION=$(echo "$PARSED" | cut -sf2-)
+
+            if [[ -z "$ROUTE" ]]; then
+                # No @claude mention found at line start (might be inside code block)
+                continue
+            fi
+
+            echo "    Route: ${ROUTE}"
+            if [[ -n "$DESCRIPTION" ]]; then
+                echo "    Description: ${DESCRIPTION}"
+            fi
+
+            case "$ROUTE" in
+                help)
+                    if [[ "$GH_MONITOR_ENABLE_HELP" != "true" ]]; then
+                        echo "    Help route is disabled. Skipping."
+                        ((SKIPPED++)) || true
+                        continue
+                    fi
+
+                    react_to_comment "$REPO" "$COMMENT_ID" "eyes"
+                    HELP_TEXT=$(generate_help_text)
+                    post_pr_comment "$REPO" "$PR_NUMBER" "$HELP_TEXT"
+                    react_to_comment "$REPO" "$COMMENT_ID" "hooray"
+                    echo "    Posted help text."
+                    ((PROCESSED++)) || true
+                    ;;
+
+                revision)
+                    run_workflow_route "revision" "$GH_MONITOR_ENABLE_REVISION" "revision.sh" \
+                        "$REPO" "$PR_NUMBER" "$COMMENT_ID" "$DESCRIPTION"
+                    ;;
+
+                revision-major)
+                    run_workflow_route "revision-major" "$GH_MONITOR_ENABLE_REVISION_MAJOR" "revision-major.sh" \
+                        "$REPO" "$PR_NUMBER" "$COMMENT_ID" "$DESCRIPTION"
+                    ;;
+
+                unknown)
+                    react_to_comment "$REPO" "$COMMENT_ID" "confused"
+                    UNKNOWN_BODY="I didn't recognize that command. Every command requires an explicit route prefix."
+                    UNKNOWN_BODY+=$'\n\n'"Type \`@claude help\` to see available commands and syntax."
+                    post_pr_comment "$REPO" "$PR_NUMBER" "$UNKNOWN_BODY"
+                    echo "    Unknown route — posted clarification."
+                    ((PROCESSED++)) || true
+                    ;;
+            esac
+        done
+    done
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================================================"
+echo "  GH-MONITOR COMPLETE"
+echo "================================================================"
+echo "  Processed : ${PROCESSED}"
+echo "  Skipped   : ${SKIPPED}"
+echo "  Errors    : ${ERRORS}"
+echo "  Timestamp : $(date '+%Y-%m-%d %H:%M:%S')"
+echo "================================================================"

--- a/scripts/services/gh-monitor.timer
+++ b/scripts/services/gh-monitor.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run GitHub monitor every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Added `gh-monitor` systemd service that polls GitHub for `@claude` PR comments and routes them to existing workflow scripts (revision.sh, revision-major.sh)
- Pure bash + `gh` CLI polling — zero Claude/AI tokens burned
- Updated `install.sh` with `--with-services` flag for opt-in systemd deployment

## Files
- `scripts/services/gh-monitor.sh` — main polling script with routing, reaction-based dedup, concurrency guard, rate limit checking, dry run mode
- `scripts/services/gh-monitor.service` — systemd oneshot unit
- `scripts/services/gh-monitor.timer` — 5-minute timer with `Persistent=true`
- `scripts/services/gh-monitor.config.env.example` — documented config template
- `install.sh` — added `--with-services` flag
- `.gitignore` — exclude live service config files

## Deviation Summary
**Matched plan:** All planned features implemented — polling, routing (revision, revision-major, help, unknown), reaction-based dedup, concurrency guard, backlog processing, rate limit checking, dry run mode, error handling with PR comments, systemd integration, install.sh update.

**No divergences from plan.**

**Deferred (out of scope for v1):**
- Cross-repo workflow execution (workflows only designed for this repo currently)
- Max-turns config passthrough to workflow scripts

## Review Findings
**Addressed (11):**
- Fixed `comment_has_reaction` dead API call and error-safe dedup
- Fixed jq injection via `--argjson`
- Fixed `\n` literals in PR comment bodies
- Fixed backlog cutoff timezone (UTC)
- Simplified then restored PID-based lock file with stale detection
- Scoped `count_running_workflows` to our workflow scripts
- Fixed install.sh systemctl error handling
- Added backlog cutoff failure warning
- Removed dead config vars from example
- Fixed redundant redirect

**Deferred (4):** Cross-repo execution (v1 correct), service path hardcoding (matches standard), code block parsing scope (sufficient), shellcheck unquoted expansion (intentional)

## Refactoring Suggestions
**Implemented (3):**
- Extracted `run_workflow_route` function — eliminated ~100 lines of duplicated revision/revision-major logic
- Combined triple jq pass into single extraction for date+user fields
- Restored PID-based stale lock detection to prevent silent permanent lockout

**Deferred (4):** parse_command interface split, process_pr extraction, pgrep interpolation, install.sh cosmetic

## Test Results
- Syntax validation: PASS (both scripts)
- Dry run mode: PASS (no-config error, env var override, full run)
- Parse routing: 6/6 PASS (help, revision, revision-major, unknown, code blocks, case insensitive)
- Unknown flag handling: PASS
- File permissions: PASS (script executable, units not executable)

## Success Criteria
- [x] Timer fires every 5 minutes (`OnUnitActiveSec=5min`)
- [x] `@claude revision: X` triggers revision.sh
- [x] `@claude revision-major: Y` triggers revision-major.sh
- [x] `@claude help` posts helpful comment
- [x] Same comment never processed twice (reaction dedup)
- [x] Failed runs react and post error comment
- [x] Vague requests get clarifying comment
- [x] Zero Claude tokens burned on polling
- [x] Survives machine reboot (`Persistent=true`)
- [x] Dry run mode works

🤖 Generated with [Claude Code](https://claude.com/claude-code)