### PR TITLE
revision-major: fix three CPI findings from workflow review

### DIFF
--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -283,6 +283,9 @@ If `gh`, `claude`, `jq`, or the formatter isn't available, fail immediately with
 ### Never Write to main
 Workflow scripts write to worktree branches, not `main` directly. The only way changes reach `main` is through PR review and merge.
 
+### Test Fixture Placement
+Test fixtures must be placed in `/tmp/` or `tests/fixtures/`, never in `.claude/` paths. The `block-dangerous.sh` hook monitors `.claude/` paths and will trigger permission denials on writes there, causing spurious test failures. This applies to any test that creates temporary files, mock configs, or sample data.
+
 ## Template
 
 A minimal workflow script skeleton:

--- a/scripts/workflows/build-phase.sh
+++ b/scripts/workflows/build-phase.sh
@@ -281,6 +281,7 @@ Rules:
 - Follow each stage in order — do not skip stages
 - Be thorough — this is a full build, not a quick fix
 - Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 - Fix Critical review findings before submitting
 - Tests must pass before committing
 - Document deviations from the plan

--- a/scripts/workflows/lib/run-claude.sh
+++ b/scripts/workflows/lib/run-claude.sh
@@ -20,10 +20,42 @@
 : "${VERBOSE:?run-claude.sh: VERBOSE must be set before sourcing}"
 : "${FORMATTER:?run-claude.sh: FORMATTER must be set before sourcing}"
 
+# ---------------------------------------------------------------------------
+# Pre-run rate limit check
+# Sends a minimal probe request to detect rate limiting before the real run.
+# On non-zero exit, checks stderr for rate-limit signals. Non-rate-limit
+# errors are passed through to let the real run surface them.
+# ---------------------------------------------------------------------------
+check_rate_limit() {
+    local max_attempts=3
+    local wait_seconds=30
+    local attempt=1
+
+    while (( attempt <= max_attempts )); do
+        local probe_stderr
+        probe_stderr=$(claude -p "ping" --max-turns 1 --output-format text 2>&1 >/dev/null) && return 0
+
+        if echo "$probe_stderr" | grep -qi "rate.limit\|throttl\|429\|overloaded"; then
+            echo "⚠ Rate limit detected (attempt ${attempt}/${max_attempts}). Waiting ${wait_seconds}s..." >&2
+            sleep "$wait_seconds"
+            wait_seconds=$((wait_seconds * 2))
+            (( attempt++ ))
+        else
+            # Non-rate-limit error — don't block, let the real run surface it
+            return 0
+        fi
+    done
+
+    echo "Error: still rate-limited after ${max_attempts} attempts. Aborting." >&2
+    return 1
+}
+
 run_claude() {
     local prompt="$1"
     shift
     local extra_args=("$@")
+
+    check_rate_limit || return 1
 
     local claude_cmd=(
         claude -p "$prompt"

--- a/scripts/workflows/review-runs.sh
+++ b/scripts/workflows/review-runs.sh
@@ -295,6 +295,7 @@ ${PROMPT_FILE_LIST}
 - Always disclose sample size and confidence level
 - If prior reviews exist in docs/development/reviews/, check them for resolved patterns
 - Focus on patterns, not one-off anomalies (unless severe)
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 EOF
 )
 

--- a/scripts/workflows/revision-major.sh
+++ b/scripts/workflows/revision-major.sh
@@ -243,6 +243,7 @@ Rules:
 - Follow each stage in order — do not skip stages
 - Be thorough — this is a major revision, not a quick fix
 - Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 - Fix Critical review findings before submitting
 - Tests must pass before committing
 - Document deviations from the plan
@@ -328,6 +329,7 @@ Rules:
 - Follow each stage in order — do not skip stages
 - Be thorough — this is a major revision, not a quick fix
 - Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 - Fix Critical review findings before submitting
 - Tests must pass before committing
 - Document deviations from the plan

--- a/scripts/workflows/revision.sh
+++ b/scripts/workflows/revision.sh
@@ -200,6 +200,7 @@ Rules:
 - Do not add features not requested
 - Do not refactor unrelated code
 - Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 - Always verify tests pass before committing
 - If tests cannot be made to pass, stop and clearly report the failure
 - At the end, briefly confirm what was done (1-2 sentences max — the commit message and PR description already convey the details)
@@ -241,6 +242,7 @@ Rules:
 - Do not add features not requested
 - Do not refactor unrelated code
 - Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
 - Always verify tests pass before committing
 - If tests cannot be made to pass, stop and clearly report the failure
 - At the end, report just the PR URL (the PR description already has the details)


### PR DESCRIPTION
## Summary

Fixes three high-confidence CPI findings from the review-runs workflow analysis:

- **File-too-large Read errors**: Added guidance to all workflow script prompts (revision, revision-major, build-phase, review-runs) instructing Claude to use `limit:200` on first reads of known-large files or check size with `wc -l` first
- **Rate limit pressure**: Added `check_rate_limit()` function to `scripts/workflows/lib/run-claude.sh` that probes for rate limiting with exponential backoff (30s → 60s → 120s) before launching the real session — protects all workflows since they all source the shared lib
- **Sensitive path test fixtures**: Documented in `docs/standards/workflow-scripts.md` that test fixtures must be placed in `/tmp/` or `tests/fixtures/`, never in `.claude/` paths which trigger permission denials from `block-dangerous.sh`

## Deviations from plan

None — all three changes implemented as planned.

## Review findings addressed

- **Critical**: Added explicit `|| return 1` guard on `check_rate_limit` call (was relying implicitly on caller's `set -e`)
- **Critical**: Separated stderr from stdout in rate-limit probe; tightened grep pattern from `rate` to `rate.limit` to avoid false positives
- **Warning**: Switched from `seq` loop to `while (( ))` for idiomatic bash
- **Warning**: Improved function comment block accuracy

## Review findings deferred

- **Warning**: Probe adds minimal API call per run (accepted tradeoff — negligible cost for protection)
- **Info**: "cause errors" wording in prompt rule text (clear enough in context)

## Refactoring suggestions implemented

None — all suggestions correctly deferred:
- Probe placement (inside `run_claude` vs top of workflow) — revisit if multi-call patterns emerge
- Duplicated Rules blocks in prompts — within "three lines is OK" threshold
- Hardcoded grep patterns — small function, easy to update inline

## Test results

- `bash -n` syntax validation: 5/5 scripts passed
- Usage message tests: all scripts produce correct output and exit code
- No existing test suite in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)