### PR TITLE
revision: add success comment to run_workflow_route

### DIFF
--- a/scripts/services/gh-monitor.sh
+++ b/scripts/services/gh-monitor.sh
@@ -351,6 +351,7 @@ run_workflow_route() {
 
     if [[ "$workflow_exit" -eq 0 ]]; then
         react_to_comment "$repo" "$comment_id" "hooray"
+        post_pr_comment "$repo" "$pr_number" "✅ Completed ${route_name} workflow. Changes pushed to this PR."
         echo "    ${route_name} completed successfully."
     else
         react_to_comment "$repo" "$comment_id" "-1"


### PR DESCRIPTION
## Summary
- Added a PR comment on the success path in `run_workflow_route()` in `scripts/services/gh-monitor.sh`
- After the hooray reaction, posts: "✅ Completed <route_name> workflow. Changes pushed to this PR."
- This matches the existing failure path which already posts error comments, giving consistent user feedback for both outcomes

## Test plan
- [ ] Verify `bash -n` syntax check passes (done)
- [ ] Trigger a successful workflow route and confirm the success comment appears on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)