### PR TITLE
revision: prefix all gh-monitor PR comments with bot indicator

### DIFF
--- a/scripts/services/gh-monitor.sh
+++ b/scripts/services/gh-monitor.sh
@@ -204,7 +204,7 @@ react_to_comment() {
 post_pr_comment() {
     local repo="$1"
     local pr_number="$2"
-    local body="$3"
+    local body="🤖 **[gh-monitor]** $3"
 
     if [[ "$GH_MONITOR_DRY_RUN" == "true" ]]; then
         echo "  [DRY RUN] Would post comment on PR #${pr_number}"


### PR DESCRIPTION
## Summary
- Prefixes every PR comment posted by `gh-monitor.sh` with `🤖 **[gh-monitor]**` to distinguish automated comments from human ones, since gh-monitor posts using the user's own GitHub account.
- Applied in `post_pr_comment()` so all callers (success, failure, help, unknown route, clarification) are covered by a single change.

## Test plan
- [ ] Verify `bash -n` syntax check passes
- [ ] Trigger a `@claude help` comment and confirm the response starts with the bot prefix
- [ ] Trigger a `@claude revision:` with short description to confirm clarification comment has prefix
- [ ] Trigger a successful workflow and confirm success comment has prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)