### PR TITLE
revision-major: rename define-project.sh to plan-new.sh

### DIFF
--- a/config/skills/architecture-decisions.md
+++ b/config/skills/architecture-decisions.md
@@ -340,10 +340,10 @@ Writing ADRs for decisions you made without documentation. The real context is a
 - This skill activates for those decisions
 - Build-phase should pause and write the ADR, not plow through
 
-### define-project.sh
+### plan-new.sh
 - Project definition creates many ADRs (tech stack, auth, database, etc.)
 - Each foundational decision should get an ADR
-- This skill is heavily used during define-project
+- This skill is heavily used during plan-new
 
 ## Quick Decision Guide
 

--- a/config/skills/documentation-structure.md
+++ b/config/skills/documentation-structure.md
@@ -666,7 +666,7 @@ This skill is foundational for workflows that create documentation:
 - May create guide docs for new features
 - This skill activates heavily
 
-### `define-project.sh` (new project setup)
+### `plan-new.sh` (new project setup)
 - Creates the entire documentation structure from scratch
 - Uses this skill for all four buckets
 - This skill is a primary dependency

--- a/config/skills/planning-methodology.md
+++ b/config/skills/planning-methodology.md
@@ -402,7 +402,7 @@ Don't solve all of these in v1 — but **acknowledge them** in the plan so the d
 - Claude executes the plan task by task
 - Quality of the plan directly determines quality of the output
 
-### define-project.sh (new projects)
+### plan-new.sh (new projects)
 - Uses project-definition skill for the initial project setup
 - Then uses planning-methodology for phase-level plans within the project
 

--- a/config/skills/project-definition.md
+++ b/config/skills/project-definition.md
@@ -10,7 +10,7 @@ This skill is for the **greenfield case** — starting a new project or major in
 **When this skill activates:**
 - Starting a new project
 - Beginning a major greenfield initiative within an existing org
-- Running the `define-project.sh` workflow
+- Running the `plan-new.sh` workflow
 
 **When this skill does NOT activate:**
 - Adding features to an existing project → use `planning-methodology`
@@ -549,9 +549,9 @@ If Phase 1 alone isn't valuable, you've built a horizontal slice that ships noth
 
 ## Integration With Workflows
 
-This skill is specifically designed for `define-project.sh`. It's heavy machinery — don't invoke it for small tasks.
+This skill is specifically designed for `plan-new.sh`. It's heavy machinery — don't invoke it for small tasks.
 
-### define-project.sh
+### plan-new.sh
 - Primary consumer of this skill
 - Produces all the deliverables listed above
 - Creates the full documentation scaffolding

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -291,12 +291,12 @@ Main autonomous path. Takes a plan document path as input and implements what it
 
 #### plan-new workflow (formerly define-project) — Greenfield Project Definition ✅ COMPLETE
 
-Heaviest workflow. For new projects or major features — produces the foundation documents that prevent drift and disappointment later. Implemented as `scripts/workflows/define-project.sh` (rename to `plan-new.sh` pending).
+Heaviest workflow. For new projects or major features — produces the foundation documents that prevent drift and disappointment later. Implemented as `scripts/workflows/plan-new.sh`.
 
-- [x] **Build `scripts/workflows/define-project.sh`** — 14-stage workflow: requirements → stakeholders → tech stack → architecture → phases → epics → dependencies → security → roadmap → documentation → architect review → planner review → resolve → submit. 225 max turns. Built by revision-major.sh (PR #15).
+- [x] **Build `scripts/workflows/plan-new.sh`** — 14-stage workflow: requirements → stakeholders → tech stack → architecture → phases → epics → dependencies → security → roadmap → documentation → architect review → planner review → resolve → submit. 225 max turns. Built by revision-major.sh (PR #15).
 - [x] **Supporting skills already built** — Planning methodology, architecture decisions, project definition, and documentation structure skills all exist.
 - [x] **Review stages added** — Architect and planner agents review the planning output before submission (Stages 11-13). Added via gh-monitor `@claude revision-major:` comment on PR #15. First successful gh-monitor live test.
-- [ ] **Rename to `plan-new.sh`** — Align with the naming convention: `plan-*` prefix for planning workflows.
+- [x] **Rename to `plan-new.sh`** — Align with the naming convention: `plan-*` prefix for planning workflows.
 - [ ] **Test on a real project** — Define a real small project from scratch, evaluate output quality.
 
 #### plan-revision workflow — Revise Existing Planning Docs ✅ COMPLETE
@@ -341,7 +341,7 @@ Build skills incrementally based on what workflows need. Not a one-time phase �
 **Planning skills:**
 - [x] **Planning methodology skill** — `config/skills/planning-methodology.md`: how to plan features, break down work, identify dependencies and risks. Most frequently activated planning skill. Covers when to plan vs when to just start, the 7-stage planning process, task templates, dependency mapping, risk identification, success criteria, and phase-level work organization.
 - [x] **Architecture decisions skill** — `config/skills/architecture-decisions.md`: when to write an ADR, reversibility spectrum (two-way/medium/one-way doors), trade-off analysis methodology, research process, and red flags. Moderate activation (when making design choices within existing projects).
-- [x] **Project definition skill** — `config/skills/project-definition.md`: 11-stage process for defining a new project from scratch — requirements gathering, stakeholders & success criteria, tech stack selection, high-level architecture, phase breakdown, epic identification, dependency mapping, initial security review, roadmap, documentation layout, CLAUDE.md setup. Scales from very small (<2 weeks) to large (1+ years) projects. Rare activation (only for greenfield projects via `define-project.sh`).
+- [x] **Project definition skill** — `config/skills/project-definition.md`: 11-stage process for defining a new project from scratch — requirements gathering, stakeholders & success criteria, tech stack selection, high-level architecture, phase breakdown, epic identification, dependency mapping, initial security review, roadmap, documentation layout, CLAUDE.md setup. Scales from very small (<2 weeks) to large (1+ years) projects. Rare activation (only for greenfield projects via `plan-new.sh`).
 
 **Refactoring skills:**
 - [x] **Refactoring methodology skill** — `config/skills/refactoring-methodology.md`: when to refactor vs leave alone, evaluating suggestions (accept/reject/defer), safe refactoring patterns, dangerous patterns, measuring impact. Pairs with refactoring-evaluator agent.

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -58,6 +58,7 @@ claude-dot-files/
 │       ├── lib/
 │       │   ├── format-stream.sh           # Shared stream-json formatter for live display
 │       │   └── run-claude.sh              # Shared run_claude helper (verbose/quiet invocation)
+│       ├── plan-new.sh                    # PLAN-NEW workflow — greenfield project definition (14 stages)
 │       ├── review-runs.sh                 # REVIEW-RUNS workflow — CPI log analysis and reporting
 │       ├── revision.sh                    # REVISION workflow — minor corrections to existing code
 │       └── revision-major.sh              # REVISION-MAJOR workflow — significant rework (9 stages)

--- a/docs/guide/dual_workflow_model.md
+++ b/docs/guide/dual_workflow_model.md
@@ -245,7 +245,7 @@ Given this model, the scope of what we actually build is narrower than it might 
   - `revision.sh` — minor corrections (built)
   - `revision-major.sh` — significant rework (planned)
   - `build-phase.sh` — architect & build a phase (planned)
-  - `define-project.sh` — research & planning (planned)
+  - `plan-new.sh` — research & planning (built)
 
 **For Stage C (PR Comments):**
 - GitHub Actions workflow file (`.github/workflows/claude-pr-handler.yml`)

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -20,7 +20,7 @@ scripts/
     ├── revision.sh             # minor corrections
     ├── revision-major.sh       # significant rework
     ├── build-phase.sh          # architect and build
-    └── define-project.sh       # research and planning
+    └── plan-new.sh             # research and planning
 ```
 
 ### Naming
@@ -28,7 +28,7 @@ Script names use kebab-case matching the workflow's purpose, with `.sh` suffix:
 - `revision.sh` — minor corrections workflow
 - `revision-major.sh` — significant rework workflow
 - `build-phase.sh` — architect and build a phase workflow
-- `define-project.sh` — research and planning workflow
+- `plan-new.sh` — research and planning workflow
 
 **Note:** Workflows are bash scripts, NOT slash commands. Slash commands live in `config/commands/` and are for prompt-template injection in interactive mode. Workflow scripts live in `scripts/workflows/` and are full bash programs that wrap `claude -p` invocations with logging, visibility, and structured stages. These are different things — don't confuse the notation.
 
@@ -262,7 +262,7 @@ Tell Claude to focus only on the task. Research has shown unscoped exploration (
 | Minor (revision) | 30 |
 | Medium (revision-major) | 75 |
 | Large (build-phase) | 150 |
-| Extra large (define-project) | 225 |
+| Extra large (plan-new) | 225 |
 
 Start conservative. Bump up only if runs hit the limit and fail.
 

--- a/scripts/workflows/plan-new.sh
+++ b/scripts/workflows/plan-new.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# define-project.sh — the DEFINE-PROJECT workflow
+# plan-new.sh — the PLAN-NEW workflow
 # Research and planning workflow for defining new projects from scratch.
 #
 # This is the heaviest autonomous workflow. Unlike revision workflows that fix
@@ -30,23 +30,23 @@
 #  14. SUBMIT — commit, push, PR with comprehensive summary
 #
 # Usage:
-#   ./define-project.sh "project name"
-#   ./define-project.sh "project name" "additional context here"
-#   ./define-project.sh "project name" "additional context here" --verbose
-#   ./define-project.sh "project name" --pr <pr-number>
+#   ./plan-new.sh "project name"
+#   ./plan-new.sh "project name" "additional context here"
+#   ./plan-new.sh "project name" "additional context here" --verbose
+#   ./plan-new.sh "project name" --pr <pr-number>
 #
 # Examples:
-#   ./define-project.sh "skyycommand"
-#   ./define-project.sh "skyycommand" "AI-driven VM placement engine for Proxmox clusters"
-#   ./define-project.sh "webhook-gateway" "lightweight service for routing GitHub webhooks" --verbose
-#   ./define-project.sh "skyycommand" "focus on the inference pipeline first" --pr 15
+#   ./plan-new.sh "skyycommand"
+#   ./plan-new.sh "skyycommand" "AI-driven VM placement engine for Proxmox clusters"
+#   ./plan-new.sh "webhook-gateway" "lightweight service for routing GitHub webhooks" --verbose
+#   ./plan-new.sh "skyycommand" "focus on the inference pipeline first" --pr 15
 #
 # Flags:
 #   --pr <number>   Update an existing PR instead of creating a new one
 #   --verbose, -v   Stream formatted Claude output live
 #
 # Logging:
-#   Every run writes a structured JSONL log to .claude/logs/define-project-<ts>.jsonl
+#   Every run writes a structured JSONL log to .claude/logs/plan-new-<ts>.jsonl
 #
 # See docs/guide/dual_workflow_model.md for the full
 # architectural context behind this workflow.
@@ -165,17 +165,17 @@ cd "$REPO_ROOT"
 # Naming and paths
 # ---------------------------------------------------------------------------
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-WORKTREE_NAME="define-project-${TIMESTAMP}"
+WORKTREE_NAME="plan-new-${TIMESTAMP}"
 
 LOG_DIR="${REPO_ROOT}/.claude/logs"
-LOG_FILE="${LOG_DIR}/define-project-${TIMESTAMP}.jsonl"
+LOG_FILE="${LOG_DIR}/plan-new-${TIMESTAMP}.jsonl"
 mkdir -p "$LOG_DIR"
 
 # ---------------------------------------------------------------------------
 # Summary banner
 # ---------------------------------------------------------------------------
 echo "================================================================"
-echo "  DEFINE-PROJECT WORKFLOW"
+echo "  PLAN-NEW WORKFLOW"
 echo "================================================================"
 echo "  Project     : ${PROJECT_NAME}"
 if [[ -n "$CONTEXT" ]]; then
@@ -411,7 +411,7 @@ if [[ -n "$PR_NUMBER" ]]; then
     echo "→ Creating worktree at ${WORKTREE_PATH}..."
     git worktree add -f "$WORKTREE_PATH" "origin/${PR_BRANCH}"
 
-    PROMPT="You are executing the DEFINE-PROJECT workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
+    PROMPT="You are executing the PLAN-NEW workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
 
 This workflow defines a new project from scratch. Follow all 14 stages thoroughly.
 
@@ -430,7 +430,7 @@ ${SHARED_STAGES}
 ${RULES}"
 
     echo
-    echo "→ Launching Claude in define-project mode (updating PR #${PR_NUMBER})..."
+    echo "→ Launching Claude in plan-new mode (updating PR #${PR_NUMBER})..."
     echo
 
     (
@@ -440,7 +440,7 @@ ${RULES}"
 
 else
     # ---- New branch path --------------------------------------------------
-    PROMPT="You are executing the DEFINE-PROJECT workflow on a new branch.
+    PROMPT="You are executing the PLAN-NEW workflow on a new branch.
 
 This workflow defines a new project from scratch. Follow all 14 stages thoroughly.
 
@@ -451,7 +451,7 @@ ${SHARED_STAGES}
 ## Stage 14: SUBMIT
 - Stage and commit all changes with a clear message. Use format: \"feat: define ${PROJECT_NAME} project foundation\"
 - Push the branch
-- Create a new PR using 'gh pr create'. Title format: \"define-project: ${PROJECT_NAME} foundation\". In the body, include:
+- Create a new PR using 'gh pr create'. Title format: \"plan-new: ${PROJECT_NAME} foundation\". In the body, include:
   - Summary of all deliverables created
   - Key decisions made (tech stack, architecture, phasing)
   - ADRs written and their conclusions
@@ -463,7 +463,7 @@ ${SHARED_STAGES}
 
 ${RULES}"
 
-    echo "→ Launching Claude in define-project mode (new branch)..."
+    echo "→ Launching Claude in plan-new mode (new branch)..."
     echo
 
     run_claude "$PROMPT" -w "$WORKTREE_NAME"
@@ -471,7 +471,7 @@ fi
 
 echo
 echo "================================================================"
-echo "  DEFINE-PROJECT WORKFLOW COMPLETE"
+echo "  PLAN-NEW WORKFLOW COMPLETE"
 echo "================================================================"
 echo
 echo "Worktree: .claude/worktrees/${WORKTREE_NAME}"


### PR DESCRIPTION
## Summary

- Renamed `scripts/workflows/define-project.sh` → `scripts/workflows/plan-new.sh` to align with the `plan-*` prefix convention (`plan-new` for greenfield, `plan-revision` for revisions)
- Updated all internal script references: header comments, banner title, log file prefix (`plan-new-`), worktree name prefix (`plan-new-`), commit/PR title format, echo messages
- Updated 8 external files: `docs/standards/workflow-scripts.md`, `docs/guide/dual_workflow_model.md`, `docs/development/roadmap.md`, `docs/file_structure.txt`, `config/skills/planning-methodology.md`, `config/skills/documentation-structure.md`, `config/skills/architecture-decisions.md`, `config/skills/project-definition.md`
- Marked "Rename to plan-new.sh" roadmap item as complete

## Deviations from plan

None.

## Review findings addressed

- Fixed `(planned)` → `(built)` status for plan-new.sh in `dual_workflow_model.md`
- Fixed comment alignment in `workflow-scripts.md` tree listing

## Review findings deferred

- README usage example for plan-new.sh (out of scope — README never had define-project examples)
- `(formerly define-project)` parenthetical in roadmap kept as intentional historical note

## Refactoring suggestions

All deferred — cosmetic only (echo asymmetry between PR paths, roadmap parenthetical cleanup). No structural issues found.

## Test results

- `bash -n` syntax check: passed
- Usage output test (no-args invocation): passed, shows correct `plan-new.sh` naming throughout
- File permissions: executable (rwxrwxr-x)
- Final grep for stale `define-project` references: only intentional historical note in roadmap remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)