### PR TITLE
revision-major: add standards enforcement to autonomous workflows

### DIFF
--- a/config/agents/standards-auditor.md
+++ b/config/agents/standards-auditor.md
@@ -1,0 +1,70 @@
+---
+name: standards-auditor
+description: Verifies code conformance against project standards — CLAUDE.md chains, docs/standards/, architecture docs, and existing exemplars. Only use when explicitly requested or as part of an autonomous workflow pipeline. Distinct from code-reviewer — reviewer asks "is this correct?" while standards-auditor asks "does this follow the project's established conventions?"
+tools: ["Read", "Grep", "Glob"]
+model: sonnet
+skills:
+  - standards-enforcement
+  - documentation-structure
+---
+
+You are a standards compliance auditor. Your job is to verify that code changes conform to the project's documented standards and established patterns — not correctness or bugs (that's the code-reviewer's job), not structural quality (that's the refactoring-evaluator's job).
+
+## Your Role
+
+- Discover what standards apply to the changed files
+- Find exemplars of correct usage in the existing codebase
+- Audit changes against both written standards and established patterns
+- Report findings with confidence scores and exemplar citations
+
+Follow the standards-enforcement skill for the discovery process, audit methodology, and confidence scoring. Use the documentation-structure skill to understand where standards and documentation should live.
+
+## Audit Checklist
+
+### Must Verify
+- CLAUDE.md chain compliance (root + nested in touched directories)
+- Relevant docs/standards/*.md conformance
+- Architecture doc compliance (if docs/architecture/ exists)
+- Pattern match with existing exemplar files
+
+### Must Cite
+- Which standards documents were consulted
+- Which exemplar files were referenced
+- Confidence level for each finding (High/Medium/Low)
+- The specific rule or exemplar that supports each finding
+
+## Output Format
+
+```
+## Standards Audit: [scope]
+
+### Standards Discovered
+- [CLAUDE.md files read]
+- [Standards docs consulted]
+- [Exemplar files referenced]
+
+### Critical (must fix — explicit standard violated)
+- **[file:line]** — [Confidence: High] [Standard: source] description. Exemplar: [path].
+
+### Warning (should fix — pattern deviation)
+- **[file:line]** — [Confidence: High/Medium] [Standard: source] description. Exemplar: [path].
+
+### Info (minor or low-confidence observations)
+- **[file:line]** — [Confidence: Low/Medium] observation.
+
+### Clean Areas
+- [Areas that conform to standards]
+
+### Summary
+[1-2 sentence conformance assessment]
+```
+
+## Rules
+
+- Be specific: cite file paths, line numbers, and the standard being violated
+- For every finding, cite the source standard AND an exemplar path when available
+- Score confidence on every finding — High, Medium, or Low
+- If the code follows standards well, say so — don't invent violations
+- Don't flag patterns that are consistent with existing exemplars
+- Don't audit against standards that aren't relevant to the changed files
+- Do not modify any files — read-only audit only

--- a/config/skills/standards-enforcement.md
+++ b/config/skills/standards-enforcement.md
@@ -1,0 +1,126 @@
+---
+name: standards-enforcement
+description: How to verify code conformance against project standards — CLAUDE.md chains, docs/standards/, architecture docs, and existing exemplars. Use when auditing changes for standards compliance, reviewing PR conformance, or checking that new code follows established patterns. Pairs with documentation-structure for understanding where standards live.
+---
+
+# Standards Enforcement Methodology
+
+This skill defines **how to verify that code conforms to project standards**. It covers discovering what standards apply, finding exemplars of correct usage, auditing changes against those standards, and reporting findings with confidence scores.
+
+## First Principles
+
+### Standards Are Layered
+Projects define standards at multiple levels. Read them in priority order:
+1. **Root CLAUDE.md** — project-level instructions and overrides
+2. **Nested CLAUDE.md files** — directory-specific rules in touched directories
+3. **docs/standards/*.md** — explicit convention documents
+4. **docs/architecture/** — design decisions that constrain implementation
+5. **Existing code** — exemplar files that demonstrate established patterns
+
+Higher layers override lower ones. If CLAUDE.md says "use tabs" and a standards doc says "use spaces," CLAUDE.md wins.
+
+### Exemplars Are the Ground Truth
+Written standards describe intent. Existing code that follows those standards demonstrates reality. When auditing, **always grep for existing exemplars** before judging new code — the project may have evolved past its written standards.
+
+### Confidence Requires Evidence
+Every finding must cite what standard it violates and what evidence supports the violation. Vague findings ("this doesn't feel right") are not actionable. Cite the standard document, the exemplar, or the CLAUDE.md rule.
+
+### Not Every Standard Applies to Every Change
+A CSS change doesn't need auditing against API design standards. Pull only the standards documents relevant to the files and patterns being changed.
+
+## Discovery Process
+
+Before auditing, discover what standards apply to the changes under review.
+
+### Step 1: Read the CLAUDE.md Chain
+1. Read the root `CLAUDE.md` at the repository root
+2. For each directory containing changed files, check for a nested `CLAUDE.md`
+3. Note any rules, conventions, or references to standards docs
+
+### Step 2: Identify Relevant Standards
+Based on what was changed, pull the specific `docs/standards/*.md` files that apply:
+- Changed a workflow script? → Read `docs/standards/workflow-scripts.md`
+- Changed an agent? → Read `docs/standards/agents.md`
+- Changed a skill? → Read `docs/standards/skills.md`
+- Changed a hook? → Read `docs/standards/hook-scripts.md`
+- Changed a service? → Read `docs/standards/services.md`
+- Changed a slash command? → Read `docs/standards/slash-commands.md`
+- Changed documentation? → Read the documentation-structure skill
+
+Don't read standards docs that aren't relevant to the changes.
+
+### Step 3: Check Architecture Docs
+If `docs/architecture/` exists, scan for ADRs relevant to the changed area. Architecture decisions constrain implementation — a change that contradicts an ADR is a standards violation.
+
+### Step 4: Find Exemplars
+For each type of artifact being changed, grep for existing exemplars:
+- Adding a new agent? → Read 2-3 existing agents in `config/agents/`
+- Adding a new skill? → Read 2-3 existing skills in `config/skills/`
+- Adding a new workflow? → Read an existing workflow in `scripts/workflows/`
+- Adding a new hook? → Read an existing hook in `config/hooks/`
+
+Exemplars tell you what the project actually does, which may differ from what standards documents say. Note discrepancies.
+
+## Audit Process
+
+With standards discovered, audit the changes systematically.
+
+### For Each Changed File:
+1. **Identify applicable standards** — which docs/rules govern this file type?
+2. **Compare against standards** — does the file follow the documented conventions?
+3. **Compare against exemplars** — does the file match how similar files are structured?
+4. **Check CLAUDE.md compliance** — does the file follow project-level rules?
+5. **Score confidence** — how certain are you that this is a real violation?
+
+### Confidence Scoring
+Rate each finding on a 3-tier scale:
+
+- **High confidence** — clear violation of an explicit rule with evidence (e.g., "standards doc says MUST use kebab-case, file uses camelCase")
+- **Medium confidence** — deviation from established patterns without an explicit rule (e.g., "all other agents use Sonnet model, this one doesn't specify")
+- **Low confidence** — possible issue but standards are ambiguous or exemplars are inconsistent (e.g., "some hooks use jq, others use grep, unclear which is standard")
+
+Only report High and Medium confidence findings as violations. Low confidence findings go in an informational section.
+
+## What to Look For
+
+### Structural Conformance
+- Required frontmatter fields present and correct
+- File naming follows conventions (kebab-case, correct directory)
+- File organization matches expected structure
+- Required sections present in expected order
+
+### Pattern Conformance
+- New code follows patterns established by exemplars
+- Integration points use the same patterns as existing integrations
+- Naming conventions match project style
+- Error handling matches project patterns
+
+### CLAUDE.md Compliance
+- Rules from root CLAUDE.md are followed
+- Directory-specific rules from nested CLAUDE.md files are followed
+- Referenced standards are actually read and applied
+
+### Architecture Compliance
+- Changes don't contradict ADR decisions
+- New patterns align with documented architecture
+- Integration points match system design
+
+## Red Flags
+
+Watch for these common standards violations:
+- Missing required frontmatter fields in agents/skills
+- Skills referenced in agent prompts but not listed in `skills:` frontmatter
+- Workflow scripts missing required features (verbose flag, JSONL logging, safety pragma)
+- Hook scripts reading env vars instead of stdin JSON
+- Files in wrong directories or with wrong naming conventions
+- New patterns that ignore existing exemplars
+- Hardcoded values that should use environment variables
+
+## Integration With Workflows
+
+This skill is loaded by the standards-auditor agent during review stages in:
+- **revision-major.sh** — Stage 7 (STANDARDS), after code review and refactoring evaluation
+- **build-phase.sh** — Stage 7 (STANDARDS), same position in the review pipeline
+- **revision.sh** — inline discovery reminder only (no dedicated standards stage)
+
+The standards-auditor focuses on **project-specific conformance** — not general code quality (code-reviewer) or structural improvement (refactoring-evaluator). Its unique value is connecting changes back to the project's documented standards and existing patterns.

--- a/docs/guide/claude_code_agents.md
+++ b/docs/guide/claude_code_agents.md
@@ -10,6 +10,7 @@
 | refactoring-evaluator | Structural improvement evaluation | Read-only | Sonnet | refactoring-methodology | On-demand |
 | test-writer | Generate & run tests | Full access | Sonnet | testing-methodology, testing-scaffolding | On-demand |
 | security-auditor | Vulnerability detection & audit | Read-only | Sonnet | testing-methodology | On-demand |
+| standards-auditor | Standards conformance verification | Read-only | Sonnet | standards-enforcement, documentation-structure | On-demand |
 | workflow-analyst | Workflow log analysis & improvement | Read-only | Sonnet | workflow-analysis | On-demand |
 
 All custom agents are **on-demand only** — Claude's built-in agents handle routine tasks automatically. Invoke these by name when you need depth (e.g., "use the security-auditor to audit src/auth/").

--- a/scripts/workflows/build-phase.sh
+++ b/scripts/workflows/build-phase.sh
@@ -17,9 +17,10 @@
 #   4. TEST — run/write tests
 #   5. REVIEW — code review via code-reviewer agent
 #   6. REFACTOR — refactoring evaluation via refactoring-evaluator agent
-#   7. RESOLVE — decide which suggestions to apply
-#   8. VERIFY — final tests + check success criteria from the plan
-#   9. SUBMIT — commit, push, PR with deviation summary comparing built vs planned
+#   7. STANDARDS — standards audit via standards-auditor agent
+#   8. RESOLVE — decide which suggestions to apply
+#   9. VERIFY — final tests + check success criteria from the plan
+#  10. SUBMIT — commit, push, PR with deviation summary comparing built vs planned
 #
 # Usage:
 #   ./build-phase.sh path/to/plan.md
@@ -215,9 +216,9 @@ ${CONTEXT}
 fi
 
 # ---------------------------------------------------------------------------
-# Shared prompt stages (Stages 1-8 + Rules are identical for both paths)
+# Shared prompt stages (Stages 1-9 + Rules are identical for both paths)
 # ---------------------------------------------------------------------------
-STAGES_1_TO_8=$(cat <<'STAGES_EOF'
+STAGES_1_TO_9=$(cat <<'STAGES_EOF'
 ## Stage 1: LOAD PLAN
 Read the plan document at the path above. Extract:
 - The scope of work (what needs to be built)
@@ -236,6 +237,11 @@ Evaluate whether the plan is actionable:
 If the plan is not actionable, stop and clearly report what's missing. Otherwise, proceed with a brief validation summary.
 
 ## Stage 3: IMPLEMENT
+Before writing code, discover the applicable standards:
+- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+- If docs/architecture/ exists, scan for relevant ADRs
+- Read the specific docs/standards/*.md files relevant to your task area
+
 Build what the plan describes. Work through the scope methodically. Produce a brief summary noting:
 - What was built and why
 - Any deviations from the plan and why they were necessary
@@ -264,15 +270,24 @@ Use the refactoring-evaluator agent to evaluate the changed code for structural 
 
 Document which suggestions you implemented and which you deferred.
 
-## Stage 7: RESOLVE
-Review all changes made across stages 3-6. Produce a consolidated summary:
+## Stage 7: STANDARDS
+Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
+- Critical violations: must fix before proceeding
+- Warnings: should fix if scope allows
+- Info: note for future improvement
+
+Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
+
+## Stage 8: RESOLVE
+Review all changes made across stages 3-7. Produce a consolidated summary:
 - Plan scope vs what was actually built
 - Review findings addressed vs deferred
 - Refactoring suggestions implemented vs deferred
+- Standards audit findings addressed vs deferred
 - Any remaining concerns
 
-## Stage 8: VERIFY
-Run the full relevant test suite one final time to verify everything passes after all changes. Also verify against the success criteria extracted in Stage 1. If anything fails, fix it. Do not proceed to Stage 9 with failing tests or unmet success criteria.
+## Stage 9: VERIFY
+Run the full relevant test suite one final time to verify everything passes after all changes. Also verify against the success criteria extracted in Stage 1. If anything fails, fix it. Do not proceed to Stage 10 with failing tests or unmet success criteria.
 STAGES_EOF
 )
 
@@ -314,13 +329,13 @@ if [[ -n "$PR_NUMBER" ]]; then
 
     PROMPT="You are executing the BUILD-PHASE workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
 
-This workflow builds a planned phase or feature from a plan document. Follow all 9 stages thoroughly.
+This workflow builds a planned phase or feature from a plan document. Follow all 10 stages thoroughly.
 
 Plan document: ${PLAN_PATH}
 ${CONTEXT_BLOCK}
-${STAGES_1_TO_8}
+${STAGES_1_TO_9}
 
-## Stage 9: SUBMIT
+## Stage 10: SUBMIT
 - Stage and commit all changes with a clear message. Use format: \"feat: <short description of what was built>\"
 - Push the branch (this updates PR #${PR_NUMBER})
 - Report a summary of the entire workflow including a deviation summary comparing what was planned vs what was built
@@ -340,13 +355,13 @@ else
     # ---- New branch path --------------------------------------------------
     PROMPT="You are executing the BUILD-PHASE workflow on a new branch.
 
-This workflow builds a planned phase or feature from a plan document. Follow all 9 stages thoroughly.
+This workflow builds a planned phase or feature from a plan document. Follow all 10 stages thoroughly.
 
 Plan document: ${PLAN_PATH}
 ${CONTEXT_BLOCK}
-${STAGES_1_TO_8}
+${STAGES_1_TO_9}
 
-## Stage 9: SUBMIT
+## Stage 10: SUBMIT
 - Stage and commit all changes with a clear message. Use format: \"feat: <short description of what was built>\"
 - Push the branch
 - Create a new PR using 'gh pr create'. Title format: \"build-phase: <short description>\". In the body, include:
@@ -354,6 +369,7 @@ ${STAGES_1_TO_8}
   - Deviation summary: planned vs built (what matched, what diverged, what was deferred)
   - Review findings addressed and deferred
   - Refactoring suggestions implemented and deferred
+  - Standards audit findings addressed and deferred
   - Test results
   - Success criteria checklist (met / not met)
 - Report the PR URL

--- a/scripts/workflows/revision-major.sh
+++ b/scripts/workflows/revision-major.sh
@@ -162,6 +162,84 @@ echo
 source "${SCRIPT_DIR}/lib/run-claude.sh"
 
 # ---------------------------------------------------------------------------
+# Shared prompt stages (Stages 1-9 + Rules are identical for both paths)
+# ---------------------------------------------------------------------------
+STAGES_1_TO_9=$(cat <<'STAGES_EOF'
+## Stage 1: ASSESS
+Analyze the existing implementation and the proposed changes. Read the relevant code. Understand what currently exists and what needs to change. Identify the scope of changes needed. Briefly describe your assessment before proceeding.
+
+## Stage 2: PLAN
+Create a focused plan for the changes. Reference existing requirements or documentation if available in docs/. Identify what files need to change, what the dependencies are between changes, and what risks exist. Keep the plan specific and actionable.
+
+## Stage 3: IMPLEMENT
+Before writing code, discover the applicable standards:
+- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+- If docs/architecture/ exists, scan for relevant ADRs
+- Read the specific docs/standards/*.md files relevant to your task area
+
+Execute the plan. Make the changes. Produce a brief summary noting:
+- What was changed and why
+- Any deviations from the plan and why they were necessary
+- Files modified
+
+## Stage 4: TEST
+Run tests relevant to the changes.
+- Run existing tests for affected code first
+- If tests fail due to your changes, fix them
+- If new functionality needs tests, add them
+- Report test results clearly: what passed, what failed, what was added
+
+## Stage 5: REVIEW
+Use the code-reviewer agent to review your changes. Analyze the findings:
+- Critical issues: must fix before proceeding
+- Warnings: should fix if scope allows
+- Info: note for future improvement
+
+Fix any Critical issues found. Document which Warning and Info items you chose to address and which you deferred.
+
+## Stage 6: REFACTOR
+Use the refactoring-evaluator agent to evaluate the changed code for structural improvements. Analyze the findings:
+- High priority: implement if scope allows
+- Medium priority: implement if quick and low risk
+- Low priority: defer to future work
+
+Document which suggestions you implemented and which you deferred.
+
+## Stage 7: STANDARDS
+Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
+- Critical violations: must fix before proceeding
+- Warnings: should fix if scope allows
+- Info: note for future improvement
+
+Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
+
+## Stage 8: RESOLVE
+Review all changes made across stages 3-7. Produce a consolidated summary:
+- Original task vs what was actually done
+- Review findings addressed vs deferred
+- Refactoring suggestions implemented vs deferred
+- Standards audit findings addressed vs deferred
+- Any remaining concerns
+
+## Stage 9: VERIFY
+Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 10 with failing tests.
+STAGES_EOF
+)
+
+RULES=$(cat <<'RULES_EOF'
+Rules:
+- Follow each stage in order — do not skip stages
+- Be thorough — this is a major revision, not a quick fix
+- Do not re-read files whose content you already know and haven't modified since you last read them
+- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
+- Fix Critical review findings before submitting
+- Tests must pass before committing
+- Document deviations from the plan
+- If you cannot complete a stage, stop and clearly report why
+RULES_EOF
+)
+
+# ---------------------------------------------------------------------------
 # Workflow execution
 # ---------------------------------------------------------------------------
 if [[ -n "$PR_NUMBER" ]]; then
@@ -183,88 +261,20 @@ if [[ -n "$PR_NUMBER" ]]; then
     echo "→ Creating worktree at ${WORKTREE_PATH}..."
     git worktree add -f "$WORKTREE_PATH" "origin/${PR_BRANCH}"
 
-    PROMPT=$(cat <<EOF
-You are executing the REVISION-MAJOR workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
+    PROMPT="You are executing the REVISION-MAJOR workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
 
 This is a SIGNIFICANT rework — not a minor fix. Follow all 10 stages thoroughly.
 
 Task: ${DESCRIPTION}
 
-## Stage 1: ASSESS
-Analyze the existing implementation and the proposed changes. Read the relevant code. Understand what currently exists and what needs to change. Identify the scope of changes needed. Briefly describe your assessment before proceeding.
-
-## Stage 2: PLAN
-Create a focused plan for the changes. Reference existing requirements or documentation if available in docs/. Identify what files need to change, what the dependencies are between changes, and what risks exist. Keep the plan specific and actionable.
-
-## Stage 3: IMPLEMENT
-Before writing code, discover the applicable standards:
-- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
-- If docs/architecture/ exists, scan for relevant ADRs
-- Read the specific docs/standards/*.md files relevant to your task area
-
-Execute the plan. Make the changes. Produce a brief summary noting:
-- What was changed and why
-- Any deviations from the plan and why they were necessary
-- Files modified
-
-## Stage 4: TEST
-Run tests relevant to the changes.
-- Run existing tests for affected code first
-- If tests fail due to your changes, fix them
-- If new functionality needs tests, add them
-- Report test results clearly: what passed, what failed, what was added
-
-## Stage 5: REVIEW
-Use the code-reviewer agent to review your changes. Analyze the findings:
-- Critical issues: must fix before proceeding
-- Warnings: should fix if scope allows
-- Info: note for future improvement
-
-Fix any Critical issues found. Document which Warning and Info items you chose to address and which you deferred.
-
-## Stage 6: REFACTOR
-Use the refactoring-evaluator agent to evaluate the changed code for structural improvements. Analyze the findings:
-- High priority: implement if scope allows
-- Medium priority: implement if quick and low risk
-- Low priority: defer to future work
-
-Document which suggestions you implemented and which you deferred.
-
-## Stage 7: STANDARDS
-Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
-- Critical violations: must fix before proceeding
-- Warnings: should fix if scope allows
-- Info: note for future improvement
-
-Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
-
-## Stage 8: RESOLVE
-Review all changes made across stages 3-7. Produce a consolidated summary:
-- Original task vs what was actually done
-- Review findings addressed vs deferred
-- Refactoring suggestions implemented vs deferred
-- Standards audit findings addressed vs deferred
-- Any remaining concerns
-
-## Stage 9: VERIFY
-Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 10 with failing tests.
+${STAGES_1_TO_9}
 
 ## Stage 10: SUBMIT
-- Stage and commit all changes with a clear message. Use format: "revision-major: <short description>"
+- Stage and commit all changes with a clear message. Use format: \"revision-major: <short description>\"
 - Push the branch (this updates PR #${PR_NUMBER})
 - Report a summary of the entire workflow
 
-Rules:
-- Follow each stage in order — do not skip stages
-- Be thorough — this is a major revision, not a quick fix
-- Do not re-read files whose content you already know and haven't modified since you last read them
-- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
-- Fix Critical review findings before submitting
-- Tests must pass before committing
-- Document deviations from the plan
-- If you cannot complete a stage, stop and clearly report why
-EOF
-)
+${RULES}"
 
     echo
     echo "→ Launching Claude in revision-major mode (updating PR #${PR_NUMBER})..."
@@ -277,76 +287,18 @@ EOF
 
 else
     # ---- New revision path ------------------------------------------------
-    PROMPT=$(cat <<EOF
-You are executing the REVISION-MAJOR workflow on a new branch.
+    PROMPT="You are executing the REVISION-MAJOR workflow on a new branch.
 
 This is a SIGNIFICANT rework — not a minor fix. Follow all 10 stages thoroughly.
 
 Task: ${DESCRIPTION}
 
-## Stage 1: ASSESS
-Analyze the existing implementation and the proposed changes. Read the relevant code. Understand what currently exists and what needs to change. Identify the scope of changes needed. Briefly describe your assessment before proceeding.
-
-## Stage 2: PLAN
-Create a focused plan for the changes. Reference existing requirements or documentation if available in docs/. Identify what files need to change, what the dependencies are between changes, and what risks exist. Keep the plan specific and actionable.
-
-## Stage 3: IMPLEMENT
-Before writing code, discover the applicable standards:
-- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
-- If docs/architecture/ exists, scan for relevant ADRs
-- Read the specific docs/standards/*.md files relevant to your task area
-
-Execute the plan. Make the changes. Produce a brief summary noting:
-- What was changed and why
-- Any deviations from the plan and why they were necessary
-- Files modified
-
-## Stage 4: TEST
-Run tests relevant to the changes.
-- Run existing tests for affected code first
-- If tests fail due to your changes, fix them
-- If new functionality needs tests, add them
-- Report test results clearly: what passed, what failed, what was added
-
-## Stage 5: REVIEW
-Use the code-reviewer agent to review your changes. Analyze the findings:
-- Critical issues: must fix before proceeding
-- Warnings: should fix if scope allows
-- Info: note for future improvement
-
-Fix any Critical issues found. Document which Warning and Info items you chose to address and which you deferred.
-
-## Stage 6: REFACTOR
-Use the refactoring-evaluator agent to evaluate the changed code for structural improvements. Analyze the findings:
-- High priority: implement if scope allows
-- Medium priority: implement if quick and low risk
-- Low priority: defer to future work
-
-Document which suggestions you implemented and which you deferred.
-
-## Stage 7: STANDARDS
-Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
-- Critical violations: must fix before proceeding
-- Warnings: should fix if scope allows
-- Info: note for future improvement
-
-Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
-
-## Stage 8: RESOLVE
-Review all changes made across stages 3-7. Produce a consolidated summary:
-- Original task vs what was actually done
-- Review findings addressed vs deferred
-- Refactoring suggestions implemented vs deferred
-- Standards audit findings addressed vs deferred
-- Any remaining concerns
-
-## Stage 9: VERIFY
-Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 10 with failing tests.
+${STAGES_1_TO_9}
 
 ## Stage 10: SUBMIT
-- Stage and commit all changes with a clear message. Use format: "revision-major: <short description>"
+- Stage and commit all changes with a clear message. Use format: \"revision-major: <short description>\"
 - Push the branch
-- Create a new PR using 'gh pr create'. Title format: "revision-major: <short description>". In the body, include:
+- Create a new PR using 'gh pr create'. Title format: \"revision-major: <short description>\". In the body, include:
   - Summary of what was changed
   - Deviations from plan (if any)
   - Review findings addressed and deferred
@@ -355,17 +307,7 @@ Run the full relevant test suite one final time to verify everything passes afte
   - Test results
 - Report the PR URL
 
-Rules:
-- Follow each stage in order — do not skip stages
-- Be thorough — this is a major revision, not a quick fix
-- Do not re-read files whose content you already know and haven't modified since you last read them
-- For known-large files (roadmap.md, standards docs, .jsonl logs), use limit:200 on first read or run wc -l to check size first — unbounded reads on large files cause errors
-- Fix Critical review findings before submitting
-- Tests must pass before committing
-- Document deviations from the plan
-- If you cannot complete a stage, stop and clearly report why
-EOF
-)
+${RULES}"
 
     echo "→ Launching Claude in revision-major mode (new branch)..."
     echo

--- a/scripts/workflows/revision-major.sh
+++ b/scripts/workflows/revision-major.sh
@@ -14,9 +14,10 @@
 #   4. TEST — run tests at all levels, report results
 #   5. REVIEW — code review via code-reviewer agent, report findings
 #   6. REFACTOR — refactoring evaluation via refactoring-evaluator agent
-#   7. RESOLVE — engineer decides which review/refactor suggestions to apply
-#   8. VERIFY — final test pass and summary
-#   9. SUBMIT — commit, push, create/update PR with comprehensive summary
+#   7. STANDARDS — standards audit via standards-auditor agent
+#   8. RESOLVE — engineer decides which review/refactor/standards suggestions to apply
+#   9. VERIFY — final test pass and summary
+#  10. SUBMIT — commit, push, create/update PR with comprehensive summary
 #
 # Usage:
 #   ./revision-major.sh "description of changes needed"
@@ -185,7 +186,7 @@ if [[ -n "$PR_NUMBER" ]]; then
     PROMPT=$(cat <<EOF
 You are executing the REVISION-MAJOR workflow on PR #${PR_NUMBER} (branch: ${PR_BRANCH}).
 
-This is a SIGNIFICANT rework — not a minor fix. Follow all 9 stages thoroughly.
+This is a SIGNIFICANT rework — not a minor fix. Follow all 10 stages thoroughly.
 
 Task: ${DESCRIPTION}
 
@@ -196,6 +197,11 @@ Analyze the existing implementation and the proposed changes. Read the relevant 
 Create a focused plan for the changes. Reference existing requirements or documentation if available in docs/. Identify what files need to change, what the dependencies are between changes, and what risks exist. Keep the plan specific and actionable.
 
 ## Stage 3: IMPLEMENT
+Before writing code, discover the applicable standards:
+- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+- If docs/architecture/ exists, scan for relevant ADRs
+- Read the specific docs/standards/*.md files relevant to your task area
+
 Execute the plan. Make the changes. Produce a brief summary noting:
 - What was changed and why
 - Any deviations from the plan and why they were necessary
@@ -224,17 +230,26 @@ Use the refactoring-evaluator agent to evaluate the changed code for structural 
 
 Document which suggestions you implemented and which you deferred.
 
-## Stage 7: RESOLVE
-Review all changes made across stages 3-6. Produce a consolidated summary:
+## Stage 7: STANDARDS
+Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
+- Critical violations: must fix before proceeding
+- Warnings: should fix if scope allows
+- Info: note for future improvement
+
+Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
+
+## Stage 8: RESOLVE
+Review all changes made across stages 3-7. Produce a consolidated summary:
 - Original task vs what was actually done
 - Review findings addressed vs deferred
 - Refactoring suggestions implemented vs deferred
+- Standards audit findings addressed vs deferred
 - Any remaining concerns
 
-## Stage 8: VERIFY
-Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 9 with failing tests.
+## Stage 9: VERIFY
+Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 10 with failing tests.
 
-## Stage 9: SUBMIT
+## Stage 10: SUBMIT
 - Stage and commit all changes with a clear message. Use format: "revision-major: <short description>"
 - Push the branch (this updates PR #${PR_NUMBER})
 - Report a summary of the entire workflow
@@ -265,7 +280,7 @@ else
     PROMPT=$(cat <<EOF
 You are executing the REVISION-MAJOR workflow on a new branch.
 
-This is a SIGNIFICANT rework — not a minor fix. Follow all 9 stages thoroughly.
+This is a SIGNIFICANT rework — not a minor fix. Follow all 10 stages thoroughly.
 
 Task: ${DESCRIPTION}
 
@@ -276,6 +291,11 @@ Analyze the existing implementation and the proposed changes. Read the relevant 
 Create a focused plan for the changes. Reference existing requirements or documentation if available in docs/. Identify what files need to change, what the dependencies are between changes, and what risks exist. Keep the plan specific and actionable.
 
 ## Stage 3: IMPLEMENT
+Before writing code, discover the applicable standards:
+- Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+- If docs/architecture/ exists, scan for relevant ADRs
+- Read the specific docs/standards/*.md files relevant to your task area
+
 Execute the plan. Make the changes. Produce a brief summary noting:
 - What was changed and why
 - Any deviations from the plan and why they were necessary
@@ -304,17 +324,26 @@ Use the refactoring-evaluator agent to evaluate the changed code for structural 
 
 Document which suggestions you implemented and which you deferred.
 
-## Stage 7: RESOLVE
-Review all changes made across stages 3-6. Produce a consolidated summary:
+## Stage 7: STANDARDS
+Use the standards-auditor agent to audit your changes against project standards. Analyze the findings:
+- Critical violations: must fix before proceeding
+- Warnings: should fix if scope allows
+- Info: note for future improvement
+
+Fix any Critical violations found. Document which Warning and Info items you chose to address and which you deferred.
+
+## Stage 8: RESOLVE
+Review all changes made across stages 3-7. Produce a consolidated summary:
 - Original task vs what was actually done
 - Review findings addressed vs deferred
 - Refactoring suggestions implemented vs deferred
+- Standards audit findings addressed vs deferred
 - Any remaining concerns
 
-## Stage 8: VERIFY
-Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 9 with failing tests.
+## Stage 9: VERIFY
+Run the full relevant test suite one final time to verify everything passes after all changes. If anything fails, fix it. Do not proceed to Stage 10 with failing tests.
 
-## Stage 9: SUBMIT
+## Stage 10: SUBMIT
 - Stage and commit all changes with a clear message. Use format: "revision-major: <short description>"
 - Push the branch
 - Create a new PR using 'gh pr create'. Title format: "revision-major: <short description>". In the body, include:
@@ -322,6 +351,7 @@ Run the full relevant test suite one final time to verify everything passes afte
   - Deviations from plan (if any)
   - Review findings addressed and deferred
   - Refactoring suggestions implemented and deferred
+  - Standards audit findings addressed and deferred
   - Test results
 - Report the PR URL
 

--- a/scripts/workflows/revision.sh
+++ b/scripts/workflows/revision.sh
@@ -187,7 +187,12 @@ Follow these stages exactly:
 
 1. ASSESS: Read the relevant files in the current directory to understand what needs to change. Focus only on the scope of the task. Do not explore unrelated code.
 
-2. IMPLEMENT: Apply the fix. Make minimal, focused changes. Do not refactor or improve code outside the scope of the task.
+2. IMPLEMENT: Before writing code, discover the applicable standards:
+   - Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+   - If docs/architecture/ exists, scan for relevant ADRs
+   - Read the specific docs/standards/*.md files relevant to your task area
+
+   Apply the fix. Make minimal, focused changes. Do not refactor or improve code outside the scope of the task.
 
 3. TEST: Run any existing tests for the affected code. If tests fail because of your changes, fix them. If the task requires new tests, add them. Only run tests relevant to the changes — do not run the full test suite unless necessary.
 
@@ -227,7 +232,12 @@ Follow these stages exactly:
 
 1. ASSESS: Read the relevant files in the current directory to understand what needs to change. Focus only on the scope of the task. Do not explore unrelated code.
 
-2. IMPLEMENT: Apply the fix. Make minimal, focused changes. Do not refactor or improve code outside the scope of the task.
+2. IMPLEMENT: Before writing code, discover the applicable standards:
+   - Read root CLAUDE.md plus any nested CLAUDE.md in directories you will touch
+   - If docs/architecture/ exists, scan for relevant ADRs
+   - Read the specific docs/standards/*.md files relevant to your task area
+
+   Apply the fix. Make minimal, focused changes. Do not refactor or improve code outside the scope of the task.
 
 3. TEST: Run any existing tests for the affected code. If tests fail because of your changes, fix them. If the task requires new tests, add them. Only run tests relevant to the changes — do not run the full test suite unless necessary.
 


### PR DESCRIPTION
## Summary

- Created `config/agents/standards-auditor.md` — read-only Sonnet agent following the lean-role-rich-skills pattern of refactoring-evaluator. Preloads `standards-enforcement` and `documentation-structure` skills.
- Created `config/skills/standards-enforcement.md` — methodology for discovering applicable standards (CLAUDE.md chain, docs/standards/, docs/architecture/, existing exemplars), auditing changes with confidence-scored findings, and citing exemplar paths.
- Integrated standards-auditor as Stage 7 (STANDARDS) in `revision-major.sh` and `build-phase.sh` review pipeline, alongside code-reviewer (Stage 5) and refactoring-evaluator (Stage 6). Both workflows now have 10 stages.
- Added inline discovery reminder to the IMPLEMENT stage of all three workflow scripts (`revision.sh`, `revision-major.sh`, `build-phase.sh`) directing Claude to read CLAUDE.md chain, architecture docs, and relevant standards before writing code.
- Updated agents quick reference table in `docs/guide/claude_code_agents.md`.

## Deviations from plan

None.

## Review findings addressed and deferred

**Addressed:**
- Added standards-auditor to agents quick reference table (required by agents standard)
- Added explicit `documentation-structure` skill reference in agent body (was listed in frontmatter but unreferenced)

**Deferred:**
- revision.sh has discovery reminder but no standards audit stage (intentional — lightweight workflow)

## Refactoring suggestions implemented and deferred

**Implemented:**
- Removed duplicate output format from skill (now only in agent, matching refactoring-evaluator exemplar pattern)
- Promoted integration section in skill to proper `## Integration With Workflows` header with workflow-specific details

**Deferred:**
- Extract shared stages variable in revision-major.sh (pre-existing structural issue, not introduced by this change — build-phase.sh already uses this pattern)

## Test results

- All 3 workflow scripts pass `bash -n` syntax check
- Stage numbering verified consistent (1-10 in revision-major.sh and build-phase.sh)
- Cross-references between agent/skill validated
- No test suite exists in the repo