### PR TITLE
revision-major: align standards docs with current code reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ For detailed documentation on Claude Code concepts:
 For contributing to this repo, follow the standards:
 - For agent standards, refer to `docs/standards/agents.md`
 - For hook script standards, refer to `docs/standards/hook-scripts.md`
+- For rule standards, refer to `docs/standards/rules.md`
 - For skill standards, refer to `docs/standards/skills.md`
 - For service standards, refer to `docs/standards/services.md`
 - For slash command standards, refer to `docs/standards/slash-commands.md`
@@ -78,6 +79,6 @@ For contributing to this repo, follow the standards:
 ## Rules
 
 - Do not create files outside the repo structure defined above without asking first.
-- When creating hook scripts, they must read JSON from stdin (not env vars). Use `INPUT=$(cat)` then parse with `jq`.
+- When creating hook scripts, follow `docs/standards/hook-scripts.md` (stdin JSON + jq, never env vars).
 - MCP secrets must use `${env:VAR_NAME}` references, never hardcoded values.
 - Keep `config/` as the single source of truth — never edit `~/.claude/` directly for synced items.

--- a/docs/standards/agents.md
+++ b/docs/standards/agents.md
@@ -124,6 +124,15 @@ Choose the model based on the work's complexity:
 
 **Default to `sonnet`** for most custom agents. It's the right balance of capability and cost. Reserve `opus` for agents where the extra reasoning genuinely matters.
 
+### Opus-Approved Roles
+
+The following agent roles are approved for `opus` because they do deep design and strategy work where the extra reasoning meaningfully changes the output quality:
+
+- **`architect`** — system design, scalability analysis, technology selection, architectural trade-offs
+- **`planner`** — feature decomposition, phased implementation plans, risk and dependency analysis
+
+Any other agent should default to `sonnet`. Before promoting a new agent to `opus`, ask: does this role produce deliberative artifacts (designs, plans, decisions that downstream work depends on), or does it perform structured inspection (review, audit, test generation, formatting)? The latter stays on `sonnet`.
+
 ## Prompt Body Conventions
 
 Everything below the frontmatter `---` is the agent's system prompt.

--- a/docs/standards/agents.md
+++ b/docs/standards/agents.md
@@ -126,12 +126,14 @@ Choose the model based on the work's complexity:
 
 ### Opus-Approved Roles
 
-The following agent roles are approved for `opus` because they do deep design and strategy work where the extra reasoning meaningfully changes the output quality:
+**The test:** Does this agent produce *deliberative artifacts* — designs, plans, or decisions that downstream work depends on — or does it perform *structured inspection* (review, audit, test generation, formatting)? Deliberative artifacts justify `opus`; structured inspection stays on `sonnet`.
+
+**Currently approved for `opus`** (both pass the test):
 
 - **`architect`** — system design, scalability analysis, technology selection, architectural trade-offs
 - **`planner`** — feature decomposition, phased implementation plans, risk and dependency analysis
 
-Any other agent should default to `sonnet`. Before promoting a new agent to `opus`, ask: does this role produce deliberative artifacts (designs, plans, decisions that downstream work depends on), or does it perform structured inspection (review, audit, test generation, formatting)? The latter stays on `sonnet`.
+The list above is a snapshot, not a closed allowlist. A future role that passes the deliberative-artifacts test (e.g., a threat-modeler or a migration-strategist) can adopt `opus` without requiring an amendment to this document — update the snapshot when the role lands.
 
 ## Prompt Body Conventions
 

--- a/docs/standards/rules.md
+++ b/docs/standards/rules.md
@@ -6,7 +6,7 @@ Conventions for writing rule files in `config/rules/`.
 
 Rules are modular instruction files that Claude loads at the start of every conversation. They are functionally identical to `CLAUDE.md` — same effect, same priority — but split into individual `.md` files by topic so they can be added, removed, or shared independently.
 
-## When to Write a Rule
+## When to Use Rules
 
 Write a rule instead of a skill when the instruction is **always applicable** — it governs all work in every conversation, not just specific contexts.
 
@@ -18,6 +18,12 @@ Write a rule instead of a skill when the instruction is **always applicable** �
 | Needs to load automatically | Load on-demand based on context |
 
 If it would go in `CLAUDE.md`, it's rule material. If it would go in onboarding documentation for a specific methodology, it's skill material.
+
+### Rules vs. `CLAUDE.md`
+
+Our current `config/CLAUDE.md` is short and fits cleanly in one file. The `config/rules/` directory is **synced and ready but intentionally empty** — don't create rule files speculatively. It exists as the split target for when `CLAUDE.md` outgrows a single file, not as scaffolding to populate now.
+
+**Heuristic:** If `config/CLAUDE.md` passes ~50 lines and you find yourself scrolling to locate instructions by topic, that's when splitting earns its keep. When splitting, move each coherent topic into its own rule file (`git-conventions.md`, `security.md`, etc.) and remove the content from `CLAUDE.md`. Don't duplicate — rules and `CLAUDE.md` stack, they don't override.
 
 ## File Conventions
 
@@ -54,21 +60,13 @@ Keep rules short and declarative. Each rule is one line, ideally starting with a
 
 Don't write prose paragraphs in rule files. If a rule needs explanation, trim the explanation to the minimum needed and move the rest into a skill.
 
-## When to Split CLAUDE.md Into Rules
-
-Our current `config/CLAUDE.md` is short and fits cleanly in one file. The `config/rules/` directory is the planned split target for when it outgrows that format — don't create rule files speculatively.
-
-**Heuristic:** If `config/CLAUDE.md` passes ~50 lines and you find yourself scrolling to locate instructions by topic, that's when splitting earns its keep.
-
-When splitting, move each coherent topic into its own rule file (`git-conventions.md`, `security.md`, etc.) and remove the content from `CLAUDE.md`. Don't duplicate — rules and CLAUDE.md stack, they don't override.
-
 ## Critical Rules
 
 - **Rules are always loaded** — use them for universal constraints, not context-specific methodology
 - **One topic per file** — the filename identifies the topic
 - **Short and declarative** — rules are constraints, not tutorials
 - **No frontmatter** — plain markdown
-- **Don't duplicate CLAUDE.md** — when a rule is moved from CLAUDE.md into a rule file, remove it from CLAUDE.md
+- **Don't duplicate `CLAUDE.md`** — when a rule is moved from `CLAUDE.md` into a rule file, remove it from `CLAUDE.md`
 
 ## Related Documentation
 

--- a/docs/standards/rules.md
+++ b/docs/standards/rules.md
@@ -1,0 +1,76 @@
+# Rule Standards
+
+Conventions for writing rule files in `config/rules/`.
+
+## Purpose
+
+Rules are modular instruction files that Claude loads at the start of every conversation. They are functionally identical to `CLAUDE.md` — same effect, same priority — but split into individual `.md` files by topic so they can be added, removed, or shared independently.
+
+## When to Write a Rule
+
+Write a rule instead of a skill when the instruction is **always applicable** — it governs all work in every conversation, not just specific contexts.
+
+| Write a Rule | Write a Skill |
+|--------------|---------------|
+| Applies to every conversation | Applies only when the work matches |
+| "Never commit secrets" | "When reviewing for security, check for…" |
+| Short, declarative constraint | Multi-step methodology or process |
+| Needs to load automatically | Load on-demand based on context |
+
+If it would go in `CLAUDE.md`, it's rule material. If it would go in onboarding documentation for a specific methodology, it's skill material.
+
+## File Conventions
+
+### Location
+All rules live in `config/rules/` and are symlinked to `~/.claude/rules/` via `install.sh`. These load in every project, on every machine where this repo is installed.
+
+### Loading Behavior
+Claude loads `~/.claude/rules/*.md` into every conversation, stacked with `CLAUDE.md`. There is no triggering logic — rules are always on. This is the opposite of skills, which only load when their description matches the work.
+
+### Naming
+Use descriptive kebab-case names that identify the topic:
+- `git-conventions.md`
+- `security.md`
+- `code-style.md`
+- `dependencies.md`
+
+Avoid generic names (`rules.md`, `general.md`) — the directory is already named `rules/`, so the filename should name the topic.
+
+### No Frontmatter
+Rules are plain markdown. No YAML frontmatter required — the entire file content is the instruction set.
+
+## Writing Rule Content
+
+Keep rules short and declarative. Each rule is one line, ideally starting with a verb (Never, Always, Prefer, Use) or an imperative phrasing.
+
+```markdown
+# Git Conventions
+
+- Use conventional commit format: `type: short description`
+- Never force push without explicit approval
+- Don't amend commits unless asked — create new commits instead
+- Don't push unless asked
+```
+
+Don't write prose paragraphs in rule files. If a rule needs explanation, trim the explanation to the minimum needed and move the rest into a skill.
+
+## When to Split CLAUDE.md Into Rules
+
+Our current `config/CLAUDE.md` is short and fits cleanly in one file. The `config/rules/` directory is the planned split target for when it outgrows that format — don't create rule files speculatively.
+
+**Heuristic:** If `config/CLAUDE.md` passes ~50 lines and you find yourself scrolling to locate instructions by topic, that's when splitting earns its keep.
+
+When splitting, move each coherent topic into its own rule file (`git-conventions.md`, `security.md`, etc.) and remove the content from `CLAUDE.md`. Don't duplicate — rules and CLAUDE.md stack, they don't override.
+
+## Critical Rules
+
+- **Rules are always loaded** — use them for universal constraints, not context-specific methodology
+- **One topic per file** — the filename identifies the topic
+- **Short and declarative** — rules are constraints, not tutorials
+- **No frontmatter** — plain markdown
+- **Don't duplicate CLAUDE.md** — when a rule is moved from CLAUDE.md into a rule file, remove it from CLAUDE.md
+
+## Related Documentation
+
+- `docs/guide/claude_code_rules.md` — Full rules architecture and loading hierarchy
+- `docs/standards/skills.md` — Skill standards (for on-demand methodology)

--- a/docs/standards/services.md
+++ b/docs/standards/services.md
@@ -222,7 +222,7 @@ touch "$LOCK_FILE"
 Services log to systemd journal by default (stdout/stderr captured by systemd). For additional structured logging, write to `.claude/logs/` following the workflow logging convention.
 
 ### Error Handling
-- **Don't crash the service on single-item failures.** If processing one comment fails, log it, react with ❌, and continue to the next.
+- **Don't crash the service on single-item failures.** If processing one comment fails, log it, react with 👎 (GitHub reaction name `-1` — matches the State Tracking failure marker), and continue to the next.
 - **Do crash on infrastructure failures.** If `gh` isn't authed or the network is down, exit with error.
 - **Post error comments on PRs** when a workflow fails, so the commenter knows what happened.
 

--- a/docs/standards/skills.md
+++ b/docs/standards/skills.md
@@ -214,7 +214,7 @@ A skill that covers "planning and architecture and testing" is too broad. Split 
 This way Claude loads only what's relevant, not a giant monolith.
 
 ### Don't Put Rules in Skills
-Rules go in `CLAUDE.md` or `rules/` — those are always loaded. Skills are for detailed methodology that loads on-demand.
+Rules go in `CLAUDE.md` or `config/rules/` (see `docs/standards/rules.md`) — those are always loaded. Skills are for detailed methodology that loads on-demand.
 
 **Rule** (always applies):
 > Never commit secrets

--- a/docs/standards/slash-commands.md
+++ b/docs/standards/slash-commands.md
@@ -152,7 +152,9 @@ For each CLAUDE.md:
 
 ## README Integration
 
-When you add a new command, update the **Operation** section of the README to list it. Users should be able to discover available commands from the README without browsing the config directory.
+When you add a new command, add it to the slash-command bullet list under **Operation → Workflow 1: Interactive** in `README.md`. Users should be able to discover available commands from the README without browsing the config directory.
+
+If the README layout changes and that subsection no longer exists, update this standard to point at whatever section lists commands — don't invent a new location.
 
 ## Examples of Good Commands
 
@@ -181,5 +183,5 @@ Follow these stages:
 - **Commands MUST be plain markdown with no frontmatter**
 - **Commands MUST use `$ARGUMENTS` for variable input**
 - **Commands MUST be focused on a single purpose**
-- **Commands SHOULD be listed in the README Operation section**
+- **Commands SHOULD be listed in the README Operation → Workflow 1: Interactive section**
 - **Commands SHOULD support safe/dry-run modes for destructive operations**

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -369,9 +369,9 @@ Current per-script values as of April 2026:
 | `plan-revision.sh` | 300 |
 | `plan-new.sh` | 500 |
 
-**Why these specific values:** All six were **doubled from their original values in April 2026** after production runs crashed mid-implementation when the smaller limits were exhausted — usually during the REVIEW or REFACTOR stages when a long back-and-forth with an agent pushed the turn count past the prior ceiling. Doubling gave comfortable headroom without meaningfully increasing the cap-hit rate on successful runs.
+**Why these specific values:** The table is a living set of per-script ceilings, not a formula. Values have been raised iteratively in April 2026 as production runs surfaced real ceiling hits — most commonly during the REVIEW or REFACTOR stages when a long back-and-forth with an agent pushed the turn count past the prior limit. Each bump has been a targeted response to an observed crash, not a proactive multiplier; the values should be read as "current authoritative" rather than "doubled from X." Expect further bumps as workflows evolve and as review agents grow more demanding.
 
-**Guidance for new scripts:** Match the size of an existing script with a similar stage count, then multiply by ~2 for safety. Start with the doubled value — it's cheaper to have unused headroom than to crash a 45-minute autonomous run at turn 149.
+**Guidance for new scripts:** Start by picking the entry in this table whose stage count and complexity most resemble your new workflow, then add ~30-50% headroom. Unused turns cost nothing; crashing a 45-minute autonomous run at turn N-1 costs a full rerun. When in doubt, err high — the ceiling exists to catch runaway loops, not to force tight budgeting.
 
 ## Safety Conventions
 

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -362,9 +362,9 @@ Current per-script values as of April 2026:
 
 | Script | `MAX_TURNS` |
 |--------|-------------|
-| `revision.sh` | 60 |
-| `review-runs.sh` | 60 |
-| `revision-major.sh` | 150 |
+| `revision.sh` | 100 |
+| `review-runs.sh` | 100 |
+| `revision-major.sh` | 300 |
 | `build-phase.sh` | 300 |
 | `plan-revision.sh` | 300 |
 | `plan-new.sh` | 500 |
@@ -413,7 +413,7 @@ FORMATTER="${SCRIPT_DIR}/lib/format-stream.sh"
 # ---- Configuration ----
 # See "Max Turns Per Script" section above — pick a value from the table
 # based on your workflow's stage count and complexity.
-MAX_TURNS=60
+MAX_TURNS=100
 
 # ---- Argument parsing ----
 DESCRIPTION=""

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -19,16 +19,20 @@ scripts/
     │   └── run-claude.sh       # shared run_claude helper function
     ├── revision.sh             # minor corrections
     ├── revision-major.sh       # significant rework
-    ├── build-phase.sh          # architect and build
-    └── plan-new.sh             # research and planning
+    ├── build-phase.sh          # architect and build from a plan
+    ├── plan-new.sh             # research and planning (new project)
+    ├── plan-revision.sh        # revise existing planning docs
+    └── review-runs.sh          # CPI analysis of workflow JSONL logs
 ```
 
 ### Naming
 Script names use kebab-case matching the workflow's purpose, with `.sh` suffix:
 - `revision.sh` — minor corrections workflow
 - `revision-major.sh` — significant rework workflow
-- `build-phase.sh` — architect and build a phase workflow
-- `plan-new.sh` — research and planning workflow
+- `build-phase.sh` — implement from a plan document
+- `plan-new.sh` — research and planning for a new project
+- `plan-revision.sh` — revise existing planning docs
+- `review-runs.sh` — CPI analysis of workflow JSONL logs
 
 **Note:** Workflows are bash scripts, NOT slash commands. Slash commands live in `config/commands/` and are for prompt-template injection in interactive mode. Workflow scripts live in `scripts/workflows/` and are full bash programs that wrap `claude -p` invocations with logging, visibility, and structured stages. These are different things — don't confuse the notation.
 
@@ -70,7 +74,92 @@ while [[ $# -gt 0 ]]; do
 done
 ```
 
-### 2. Raw JSONL Logging
+### 2. `--pr <N>` Flag
+
+Workflow scripts must support updating an existing PR instead of creating a new one. This enables iterative revision loops — rerun the workflow against a PR after review feedback, and it commits and pushes to the PR's existing branch rather than creating a second PR.
+
+```bash
+PR_NUMBER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                exit 1
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        # ... other flags
+    esac
+done
+```
+
+When `--pr <N>` is set, the script should:
+1. Resolve the PR's branch via `gh pr view <N> --json headRefName`
+2. Fetch the latest branch state and create a worktree checked out to `origin/<branch>`
+3. Invoke Claude inside the worktree; push to the same branch at the end (this updates the PR)
+
+This is also the integration point for the gh-monitor service — it invokes workflows with `--pr <N>` when responding to `@claude` comments on PRs.
+
+### 3. `--task-file <path>` Flag
+
+Workflow scripts must support reading the task description from a file, mutually exclusive with the positional description argument. This flag exists because command-line parsing breaks on multi-paragraph inputs containing quotes, newlines, backticks, or other special characters — a common case for real task descriptions.
+
+```bash
+TASK_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --task-file)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --task-file requires a path" >&2
+                exit 1
+            fi
+            TASK_FILE="$2"
+            shift 2
+            ;;
+        # ... other flags
+    esac
+done
+
+# Must provide exactly one of: positional description OR --task-file
+if [[ -n "$DESCRIPTION" && -n "$TASK_FILE" ]]; then
+    echo "Error: cannot use both a positional description and --task-file" >&2
+    exit 1
+fi
+if [[ -z "$DESCRIPTION" && -z "$TASK_FILE" ]]; then
+    show_usage >&2
+    exit 1
+fi
+
+# Load file into DESCRIPTION (preserves content literally)
+if [[ -n "$TASK_FILE" ]]; then
+    if [[ ! -f "$TASK_FILE" ]]; then
+        echo "Error: task file not found: ${TASK_FILE}" >&2
+        exit 1
+    fi
+    DESCRIPTION=$(cat "$TASK_FILE")
+fi
+```
+
+The file is read with `cat` and passed through to the prompt verbatim. Content never crosses a shell-parsing boundary, so quotes, newlines, and special characters pass through literally.
+
+### 4. Flags-First Convention
+
+All examples in usage text and invocations should put flags FIRST and the positional description LAST:
+
+```bash
+# Preferred — flags visible at the start, positional at the end
+./revision-major.sh --verbose --pr 22 --task-file /tmp/task.md
+./revision-major.sh --pr 5 "address all findings from PR #5"
+
+# Avoid — positional in the middle gets stepped on by terminal line-wrap
+./revision-major.sh "address findings" --pr 5 --verbose
+```
+
+Rationale: terminals line-wrap long commands. A trailing positional stays visible and editable even when earlier portions wrap. Flags at the front keep the options obvious at a glance.
+
+### 5. Raw JSONL Logging
 
 Every run writes a raw JSONL log to `.claude/logs/<workflow>-<timestamp>.jsonl` regardless of verbose mode. This enables post-mortem analysis even for runs that weren't watched live.
 
@@ -95,13 +184,13 @@ mkdir -p "$LOG_DIR"
 
 **Important:** The log directory is always in the main repo's `.claude/logs`, not inside worktrees. This keeps all logs in one place for analysis.
 
-### 3. Stream Format Usage
+### 6. Stream Format Usage
 
 Always invoke Claude with `--output-format stream-json`. This gives structured events that can be formatted for display AND saved for analysis.
 
 The shared formatter at `scripts/workflows/lib/format-stream.sh` reads JSONL from stdin and outputs formatted human-readable text. Use it for live display in verbose mode.
 
-### 4. Standard run_claude Helper
+### 7. Standard run_claude Helper
 
 Every workflow script must source the shared `run_claude` helper from `scripts/workflows/lib/run-claude.sh`. This avoids duplicating the verbose/quiet invocation logic across every workflow script.
 
@@ -122,7 +211,7 @@ Usage is the same as before — call `run_claude` with a prompt and optional ext
 run_claude "$PROMPT" -w "$WORKTREE_NAME"
 ```
 
-### 5. Environment Checks
+### 8. Environment Checks
 
 Every workflow script must verify its dependencies before running:
 
@@ -155,7 +244,7 @@ fi
 
 Fail fast if anything is missing. Don't assume tools are available.
 
-### 6. Repo Root Operation
+### 9. Repo Root Operation
 
 Always operate from the repo root to ensure consistent paths:
 
@@ -166,7 +255,7 @@ cd "$REPO_ROOT"
 
 This makes worktree paths, log paths, and relative file references consistent regardless of where the script is invoked from.
 
-### 7. Worktree Isolation
+### 10. Worktree Isolation
 
 All workflow scripts that modify code use git worktrees for isolation. Worktrees go in `.claude/worktrees/<workflow>-<timestamp>/` and the main working directory is never touched.
 
@@ -174,7 +263,7 @@ Two patterns:
 - **New branch:** Use `claude -p -w <name>` — Claude Code creates the worktree with auto-prefixed branch name
 - **Update existing PR:** Manually create worktree checked out to the PR's branch, then invoke claude inside it
 
-### 8. Summary Banner
+### 11. Summary Banner
 
 Every run starts with a summary banner showing the configuration:
 
@@ -193,7 +282,7 @@ echo "================================================================"
 
 This makes it obvious what's about to happen and where to find the log.
 
-### 9. Completion Summary
+### 12. Completion Summary
 
 Every run ends with a completion banner showing where the log and worktree live:
 
@@ -208,7 +297,7 @@ echo "To clean up when done:"
 echo "  /cleanup-merged-worktrees"
 ```
 
-### 10. Structured Prompt
+### 13. Structured Prompt
 
 Every workflow script embeds a structured prompt with numbered stages. The prompt is the specification for Claude's behavior in the autonomous run.
 
@@ -235,6 +324,12 @@ EOF
 )
 ```
 
+**⚠️ Heredoc context:** The heredoc above is INTERNAL to the script — it assembles the prompt string inside the script process, and the assembled string is then passed to `claude -p` via the shell. It never crosses a terminal copy-paste boundary, so there is no risk of whitespace corruption.
+
+This is the opposite case from `config/CLAUDE.md :: Terminal Commands & Prompts`, which forbids heredocs in USER-FACING command output (commands shown to the user to paste into their terminal). That rule exists because terminal paste reliably corrupts multi-line input. Inside a script, heredocs are fine and preferred for multi-line prompt construction — they handle quotes, backticks, and special characters without manual escaping.
+
+For prompts that must interpolate shell variables (like `${DESCRIPTION}`), use an unquoted `EOF` sentinel. For static stage blocks that should pass through literally with no expansion, use a quoted `'STAGES_EOF'` sentinel (see `scripts/workflows/revision-major.sh` for the `STAGES_1_TO_9` / `RULES` pattern that shares stages across the new-branch and existing-PR code paths).
+
 ## Design Principles
 
 ### Keep Stages Explicit
@@ -255,16 +350,22 @@ For larger workflows (like `build-phase.sh`), break into multiple `claude -p` ca
 ### Scope Narrowly
 Tell Claude to focus only on the task. Research has shown unscoped exploration ("investigate the codebase") burns tokens for no value.
 
-### Max Turns Based on Complexity
+### Max Turns Per Script
 
-| Workflow Size | Suggested `MAX_TURNS` |
-|---------------|----------------------|
-| Minor (revision) | 30 |
-| Medium (revision-major) | 75 |
-| Large (build-phase) | 150 |
-| Extra large (plan-new) | 225 |
+Current per-script values as of April 2026:
 
-Start conservative. Bump up only if runs hit the limit and fail.
+| Script | `MAX_TURNS` |
+|--------|-------------|
+| `revision.sh` | 60 |
+| `review-runs.sh` | 60 |
+| `revision-major.sh` | 150 |
+| `build-phase.sh` | 300 |
+| `plan-revision.sh` | 300 |
+| `plan-new.sh` | 500 |
+
+**Why these specific values:** All six were **doubled from their original values in April 2026** after production runs crashed mid-implementation when the smaller limits were exhausted — usually during the REVIEW or REFACTOR stages when a long back-and-forth with an agent pushed the turn count past the prior ceiling. Doubling gave comfortable headroom without meaningfully increasing the cap-hit rate on successful runs.
+
+**Guidance for new scripts:** Match the size of an existing script with a similar stage count, then multiply by ~2 for safety. Start with the doubled value — it's cheaper to have unused headroom than to crash a 45-minute autonomous run at turn 149.
 
 ## Safety Conventions
 
@@ -294,7 +395,8 @@ A minimal workflow script skeleton:
 #!/usr/bin/env bash
 # workflow-name.sh — Description of what this workflow does
 #
-# Usage: ./workflow-name.sh "description" [--verbose]
+# Usage: ./workflow-name.sh "description" [--pr N] [--verbose]
+#        ./workflow-name.sh --task-file path/to/task.md [--pr N] [--verbose]
 
 set -euo pipefail
 
@@ -303,24 +405,45 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FORMATTER="${SCRIPT_DIR}/lib/format-stream.sh"
 
 # ---- Configuration ----
-MAX_TURNS=30
+# See "Max Turns Per Script" section above — pick a value from the table
+# based on your workflow's stage count and complexity.
+MAX_TURNS=60
 
 # ---- Argument parsing ----
-if [[ $# -lt 1 ]]; then
-    echo "Usage: $(basename "$0") \"description\" [--verbose]"
-    exit 1
-fi
-
-DESCRIPTION="$1"
-shift
+DESCRIPTION=""
+TASK_FILE=""
+PR_NUMBER=""
 VERBOSE=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --task-file)
+            [[ $# -ge 2 ]] || { echo "Error: --task-file requires a path" >&2; exit 1; }
+            TASK_FILE="$2"; shift 2 ;;
+        --pr)
+            [[ $# -ge 2 ]] || { echo "Error: --pr requires a PR number" >&2; exit 1; }
+            PR_NUMBER="$2"; shift 2 ;;
         --verbose|-v) VERBOSE=true; shift ;;
-        *) echo "Error: unknown option '$1'" >&2; exit 1 ;;
+        -*) echo "Error: unknown option '$1'" >&2; exit 1 ;;
+        *)
+            [[ -z "$DESCRIPTION" ]] || { echo "Error: unexpected positional '$1'" >&2; exit 1; }
+            DESCRIPTION="$1"; shift ;;
     esac
 done
+
+# Exactly one of: positional description OR --task-file
+if [[ -n "$DESCRIPTION" && -n "$TASK_FILE" ]]; then
+    echo "Error: cannot combine positional description with --task-file" >&2; exit 1
+fi
+if [[ -z "$DESCRIPTION" && -z "$TASK_FILE" ]]; then
+    echo "Usage: $(basename "$0") \"description\" [--pr N] [--verbose]" >&2
+    echo "       $(basename "$0") --task-file path/to/task.md [--pr N] [--verbose]" >&2
+    exit 1
+fi
+if [[ -n "$TASK_FILE" ]]; then
+    [[ -f "$TASK_FILE" ]] || { echo "Error: task file not found: $TASK_FILE" >&2; exit 1; }
+    DESCRIPTION=$(cat "$TASK_FILE")
+fi
 
 # ---- Environment checks ----
 for cmd in claude gh jq; do
@@ -404,17 +527,20 @@ Before marking a new workflow script as complete:
 ## Critical Rules
 
 - **Workflow scripts MUST support `--verbose` flag** — visibility is not optional
+- **Workflow scripts MUST support `--pr <N>` flag** — enables iterative revision and gh-monitor integration
+- **Workflow scripts MUST support `--task-file <path>` flag** — required for multi-paragraph/special-character payloads
 - **Workflow scripts MUST log to `.claude/logs/`** — post-mortem analysis matters
 - **Workflow scripts MUST validate environment upfront** — fail fast
 - **Workflow scripts MUST operate from repo root** — consistent paths
 - **Workflow scripts MUST use worktree isolation** — main branch is sacred
 - **Workflow scripts MUST have structured staged prompts** — not unscoped instructions
 - **Workflow scripts MUST use `run_claude` helper pattern** — consistent invocation
-- **Workflow scripts SHOULD match the `MAX_TURNS` guideline** for their complexity
+- **Workflow scripts SHOULD follow the per-script `MAX_TURNS` values** in the table above
 
 ## Related Documentation
 
-- `docs/guide/workflows.md` — Architectural context
+- `docs/guide/workflows.md` — Authoritative user-facing workflow guide (start here)
 - `docs/guide/claude_code_headless.md` — Headless mode details
 - `docs/guide/claude_code_orchestration.md` — Orchestration patterns
 - `docs/standards/hook-scripts.md` — Hook script conventions (complementary)
+- `config/CLAUDE.md` — Workflow invocation template and terminal paste rules

--- a/docs/standards/workflow-scripts.md
+++ b/docs/standards/workflow-scripts.md
@@ -55,7 +55,11 @@ This ensures:
 
 ## Required Features
 
-Every workflow script MUST implement these features. They are not optional.
+**Scope:** The subsections below apply to **task-execution workflows** — scripts that take a user-supplied task description and produce a PR (`revision.sh`, `revision-major.sh`, `build-phase.sh`, `plan-new.sh`, `plan-revision.sh`).
+
+**Analysis workflows** that derive their inputs from the filesystem without a user-supplied task (e.g. `review-runs.sh`, which scans `.claude/logs/`) MUST still implement the non-task-specific features: verbose flag, JSONL logging, stream format, `run_claude` helper, environment checks, repo-root operation, banners, and a structured prompt. They are exempt from the task-input features (`--pr <N>`, `--task-file <path>`, flags-first positional convention) because those features have no referent — there is no task string to carry. Every subsection below is marked **(task-execution only)** where it applies narrowly.
+
+Everything not marked **(task-execution only)** applies to all workflow scripts. None of it is optional.
 
 ### 1. `--verbose` / `-v` Flag
 
@@ -74,9 +78,9 @@ while [[ $# -gt 0 ]]; do
 done
 ```
 
-### 2. `--pr <N>` Flag
+### 2. `--pr <N>` Flag (task-execution only)
 
-Workflow scripts must support updating an existing PR instead of creating a new one. This enables iterative revision loops — rerun the workflow against a PR after review feedback, and it commits and pushes to the PR's existing branch rather than creating a second PR.
+Task-execution workflow scripts must support updating an existing PR instead of creating a new one. This enables iterative revision loops — rerun the workflow against a PR after review feedback, and it commits and pushes to the PR's existing branch rather than creating a second PR.
 
 ```bash
 PR_NUMBER=""
@@ -102,9 +106,9 @@ When `--pr <N>` is set, the script should:
 
 This is also the integration point for the gh-monitor service — it invokes workflows with `--pr <N>` when responding to `@claude` comments on PRs.
 
-### 3. `--task-file <path>` Flag
+### 3. `--task-file <path>` Flag (task-execution only)
 
-Workflow scripts must support reading the task description from a file, mutually exclusive with the positional description argument. This flag exists because command-line parsing breaks on multi-paragraph inputs containing quotes, newlines, backticks, or other special characters — a common case for real task descriptions.
+Task-execution workflow scripts must support reading the task description from a file, mutually exclusive with the positional description argument. This flag exists because command-line parsing breaks on multi-paragraph inputs containing quotes, newlines, backticks, or other special characters — a common case for real task descriptions.
 
 ```bash
 TASK_FILE=""
@@ -144,9 +148,9 @@ fi
 
 The file is read with `cat` and passed through to the prompt verbatim. Content never crosses a shell-parsing boundary, so quotes, newlines, and special characters pass through literally.
 
-### 4. Flags-First Convention
+### 4. Flags-First Convention (task-execution only)
 
-All examples in usage text and invocations should put flags FIRST and the positional description LAST:
+For scripts that take a positional task description, all examples in usage text and invocations should put flags FIRST and the positional description LAST:
 
 ```bash
 # Preferred — flags visible at the start, positional at the end
@@ -328,7 +332,9 @@ EOF
 
 This is the opposite case from `config/CLAUDE.md :: Terminal Commands & Prompts`, which forbids heredocs in USER-FACING command output (commands shown to the user to paste into their terminal). That rule exists because terminal paste reliably corrupts multi-line input. Inside a script, heredocs are fine and preferred for multi-line prompt construction — they handle quotes, backticks, and special characters without manual escaping.
 
-For prompts that must interpolate shell variables (like `${DESCRIPTION}`), use an unquoted `EOF` sentinel. For static stage blocks that should pass through literally with no expansion, use a quoted `'STAGES_EOF'` sentinel (see `scripts/workflows/revision-major.sh` for the `STAGES_1_TO_9` / `RULES` pattern that shares stages across the new-branch and existing-PR code paths).
+**Quoted vs unquoted sentinel:** Use an unquoted `EOF` when the heredoc body must interpolate shell variables (like `${DESCRIPTION}`). Use a quoted `'EOF'` sentinel for any static block that should pass through literally — backticks, `$symbols`, and dollar-brace tokens all survive untouched, so you don't have to hunt down escape edge cases. Default to quoted when the block has no variables; it's the safer choice.
+
+`scripts/workflows/revision-major.sh` shows both idioms in one file: `STAGES_1_TO_9` and `RULES` are quoted (`'STAGES_EOF'`, `'RULES_EOF'`) because they're static, and the final `PROMPT` is built with double-quoted string concatenation so `${STAGES_1_TO_9}`, `${RULES}`, and `${DESCRIPTION}` can interpolate. The quoted sentinels also happen to enable reuse of the block across the new-branch and existing-PR code paths, but that's a secondary benefit — safety from accidental expansion is the primary one.
 
 ## Design Principles
 
@@ -527,8 +533,8 @@ Before marking a new workflow script as complete:
 ## Critical Rules
 
 - **Workflow scripts MUST support `--verbose` flag** — visibility is not optional
-- **Workflow scripts MUST support `--pr <N>` flag** — enables iterative revision and gh-monitor integration
-- **Workflow scripts MUST support `--task-file <path>` flag** — required for multi-paragraph/special-character payloads
+- **Task-execution workflow scripts MUST support `--pr <N>` flag** — enables iterative revision and gh-monitor integration (does not apply to analysis workflows like `review-runs.sh` that have no user-supplied task)
+- **Task-execution workflow scripts MUST support `--task-file <path>` flag** — required for multi-paragraph/special-character payloads (same scope carve-out)
 - **Workflow scripts MUST log to `.claude/logs/`** — post-mortem analysis matters
 - **Workflow scripts MUST validate environment upfront** — fail fast
 - **Workflow scripts MUST operate from repo root** — consistent paths


### PR DESCRIPTION
## Summary

Docs-only revision aligning `docs/standards/` with current code reality. Resolves 3 Critical and 7 Warning findings from a `standards-architect` dogfood audit. No code changes except for docs and the root `CLAUDE.md`.

## Findings addressed

### Critical
1. **MAX_TURNS table stale** — rewrote `workflow-scripts.md` with per-script values (revision=60, review-runs=60, revision-major=150, build-phase=300, plan-revision=300, plan-new=500). Noted the April 2026 doubling.
2. **Missing `--pr` / `--task-file` docs** — added subsections 2, 3, 4 to Required Features, plus flags-first convention.
3. **Heredoc template conflict with `config/CLAUDE.md`** — kept the heredoc template (matches actual script pattern) and added a prominent callout distinguishing internal script use from user-facing terminal paste. Also documented quoted vs unquoted sentinel choice.

### Warning
4. **`config/rules/` judgment call** — REAL, not vestigial. `docs/guide/claude_code_rules.md` explicitly describes it as "synced and ready but intentionally empty" for when `CLAUDE.md` outgrows a single file. Roadmap also references it as part of the 7 permanent symlinks. Wrote new **`docs/standards/rules.md`**, added to CLAUDE.md standards index, referenced from `skills.md`. Directory and symlink stay.
5. **Tree diagram incomplete** — added `plan-revision.sh` and `review-runs.sh`.
6. **Related Docs: `workflows.md`** — already the first entry; improved its label from "Architectural context" to "Authoritative user-facing workflow guide (start here)".
7. **services.md emoji inconsistency** — ❌ → 👎 in Error Handling. Verified against `gh-monitor.sh` which uses GitHub reaction name `-1`.
8. **opus vs sonnet underspecified** — added "Opus-Approved Roles" subsection. Currently: architect + planner. Framed as a test-based snapshot, not a closed allowlist.
9. **Root CLAUDE.md hook-rule duplication** — replaced restatement with pointer + short parenthetical summary.
10. **README Operation section "broken"** — finding was stale; `## Operation` exists. Refined the rule to point at the specific "Operation → Workflow 1: Interactive" subsection where commands are listed.

## Scope carve-out (added during Stage 5 review)

`review-runs.sh` is an analysis workflow with no user-supplied task — it derives its inputs from `.claude/logs/`. The code-reviewer correctly flagged that the blanket "MUST support `--pr` / `--task-file`" language would falsely mark it non-compliant. Added explicit scope language to `workflow-scripts.md` distinguishing **task-execution workflows** from **analysis workflows**, and tagged subsections 2, 3, 4 as `(task-execution only)`. Critical Rules list updated to match.

## Deviations from plan

- Scope carve-out was unplanned; surfaced by the code-reviewer and added to prevent misinterpretation of the new flag requirements.
- Finding #6 turned out to be stale (workflows.md was already present in Related Docs). Improved its description rather than adding it.
- Finding #10 turned out to be stale (README has `## Operation`). Refined the rule text rather than dropping the requirement.

## Review findings

- **Critical**: 1 raised, 1 addressed (scope carve-out for analysis workflows).
- **Warnings**: 3 addressed — rules.md phrasing harmonized with the guide ("intentionally empty"), opus-approved list reframed as a test-based snapshot, quoted-sentinel callout clarified to separate safety-from-expansion from block reuse.
- **Deferred**: minor run_claude env-var source-time vs call-time clarification (out of original audit scope, not blocking).

## Refactoring suggestions

- **Implemented (Medium)**: Restructured `rules.md` to mirror the peer standards file shape (Purpose → When to Use → File Conventions → Writing Content → Critical Rules → Related Docs).
- **Deferred (High)**: Strip April 2026 historical note from MAX_TURNS section — task explicitly requested it inline.
- **Deferred (High)**: Split Required Features into Universal / Task-Execution named groups — the `(task-execution only)` tags are clear and splitting would renumber everything for no factual gain.
- **Deferred (Medium)**: Remove parenthetical from CLAUDE.md hook pointer — task finding #9 specifies the exact text.

## Standards audit

- **Critical**: none.
- **Warnings**: Two project-wide inherited debt issues flagged — (1) standards files don't follow the RFC 2119 section template from `config/skills/documentation-structure.md`, and (2) cross-references use bare paths instead of relative Markdown links. Both are shared across all five peer standards files; fixing requires a separate docs-refactor PR that was explicitly out of scope ("Don't rewrite docs that weren't flagged"). Worth tracking as future work.
- **Info**: All low-impact; deferred.

## Verification

- All referenced files resolve (workflows, guides, standards, CLAUDE.md, scripts).
- `workflow-scripts.md` Required Features numbering 1–13 is consecutive.
- MAX_TURNS table values verified 1:1 against `scripts/workflows/*.sh`.
- services.md emoji verified against `gh-monitor.sh` reaction name `-1`.

## Test plan

- [x] All cross-references resolve to real files
- [x] MAX_TURNS table values match actual `MAX_TURNS=` lines in scripts
- [x] Required Features numbering is unbroken (1–13)
- [x] `services.md` emoji matches `gh-monitor.sh` reaction mapping
- [x] `docs/standards/rules.md` is referenced from `CLAUDE.md`, `skills.md`
- [x] Root `CLAUDE.md` standards index is alphabetical and complete (agents, hook-scripts, rules, skills, services, slash-commands, workflow-scripts)
- [ ] Render check on GitHub to visually confirm tables, callouts, and numbering display correctly