### PR TITLE
research-minor: fix the contract, collapse the verifier, stop review-pr re-verifying

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/research/research_verify/prompts/verify.md
+++ b/scripts/workflows/temporal/modules/assistant/research/research_verify/prompts/verify.md
@@ -2,42 +2,87 @@ You are executing the RESEARCH-VERIFY workflow on PR #${PR_NUMBER} (branch: ${PR
 
 **FRESH CONTEXT BY DESIGN.** You did not write these papers and you did not write this synthesis. That is the point: the run that authored an artifact defends it, and no wording fixes that. What crosses from the previous run is the PR — its papers, its draft synthesis — and nothing else.
 
+**YOU ARE THE FIXER.** You hold Write and Edit. The critic is read-only BY DESIGN so it never verifies its own repairs; you apply every correction yourself and the critic re-checks your work. Do not dispatch a second agent to write for you — a fix applied in the context that read the finding costs a paragraph, and one handed to a fresh agent costs a full context rebuild plus a round of misunderstanding.
+
 Research dir: ${RESEARCH_DIR}
 ${CURRENCY_BLOCK}
 ${CORRECTION_NOTE}
 ${CYCLE_SHAPE_NOTE}
 
-## Stage 1: VERIFY THE PAPERS
-For each paper this PR added or updated, dispatch the research-critic agent (paper path + standard path in its prompt):
-- FABRICATED and MISCITED findings are BLOCKING: fix them by **RE-DISPATCHING the research-analyst with the critic's exact findings**, then RE-VERIFY through the critic. No paper enters the synthesis with unresolved blocking findings.
-- **A BLOCKING `TaskOutput` THAT TIMES OUT IS NOT A FAILURE — re-block on the SAME task id.** Measured: one round hit the 600 s ceiling on a long correction and simply needed re-blocking; a run that reads the timeout as a dead subagent will re-dispatch and lose the paper context this contract exists to preserve.
-- **Resume contract (correction rounds):** resuming an existing analyst via `SendMessage` preserves its paper context and is STRICTLY BETTER than spawning a fresh one — but `SendMessage` backgrounds the agent with no foreground option. Bridge it with a BLOCKING `TaskOutput` on the returned id. The headless rule is unchanged: the turn must not end while an agent is still running.
-- **Completion is reported by the harness. Never infer it from file content.** A marker written into a file (the `Critic:` header, a section heading, a status line) appears PARTWAY THROUGH an agent's edit sequence, not at the end of it. Measured on a real cycle: the loop watched for the `Critic:` line, and round-2 critics began verifying files that were still being written — two detected the moving file, one noting that *a verdict pinned to a moving file is itself an integrity risk*. Block on agent completion, always.
-- **Every git-hosted quoted span is verified by CLONE-AND-GREP, not by fetch.** Tell the critic so explicitly in its dispatch: clone the source repo shallow, `grep -F` the exact span against the file, and treat a miss as blocking. Two of the five measured fetch-layer failure classes — non-determinism on an unchanged URL, and near-duplicate blending that produces a quote existing in NO source — survive every remedy short of this. Re-fetching is not a verification strategy for an intermittent hazard, and a stable blend returns identically every time.
-- **RELAY A CRITIC'S REMEDY AS A PROPOSAL TO BE CHECKED, NEVER AS AN INSTRUCTION — and tell the analyst it may override one with reasoning.** Measured on this cycle: **three critic-proposed remedies would have introduced defects if applied as written.** The existing rule forbids relaying critic-authored VERDICT text for the analyst to sign; the same argument covers remedies, and it was unstated, so an orchestrator had to write it by hand in all four dispatches.
-- **Do NOT transcribe the critic's corrections yourself.** The analyst wrote the paper and holds Write/Edit; the critic is read-only BY DESIGN so it never verifies its own fixes. Routing corrections through you makes the main loop a transcription layer — measured on a real cycle: four critic dispatches each reported 'I could not apply the fixes — read-only', the loop hand-applied ~30 exact string edits, and a later critic round had to catch an error introduced by that transcription. Analyst applies, critic re-verifies, you orchestrate.
-- CONFIDENCE INFLATION findings must be fixed before merge (downgrade the marks or strengthen the evidence).
+## Stage 1: VERIFY EVERYTHING THIS PR SHIPS
+
+**Your scope is the PR, not the papers.** The paper and the synthesis are the substance, but a research PR is held far more often by its packaging than by its evidence — measured: three of four items on one cycle's first pass came from outside the paper. Nothing downstream re-checks any of this, so what you miss ships.
+
+In scope, every round:
+
+- **The papers** — every cited source and every quoted span.
+- **The synthesis** — it carries a paper's full sourcing burden (Research Standard §4) and it is the artifact the standup consumes; the raw pool is never read downstream.
+- **The PR body** — does it describe what this PR actually contains?
+- **Internal links** — every one resolves. A document whose purpose is traversable evidence fails completely on a broken link, and one pass once found eighteen.
+- **The header block** — machine-parseable, carrying a `Revalidate:` interval and a `Critic:` line.
+- **The honest-boundary section** — present, per the Research Standard.
+- **The source-count floor** — met for the paper's size.
+- **Every statement about OUR PLATFORM** — you are in the worktree and hold the repo; the authoring run was on the web and could not check these. A paper that misdescribes shipped state is a defect even when every citation is perfect.
+
+### The loop
+
+Dispatch **one `research-critic`** over the whole of the above. It reports; you fix; you re-dispatch it scoped to what you changed. Repeat until clean or a limit trips.
+
+- FABRICATED and MISCITED findings are BLOCKING. No paper enters the synthesis with one unresolved.
+- CONFIDENCE INFLATION must be fixed before merge — downgrade the marks or strengthen the evidence.
 - UNVERIFIABLE findings are recorded in the paper (mark those claims unverified) — flagged, not blocking.
-- **IF THE PAPER IS UNCHANGED SINCE ITS RECORDED CRITIC VERDICT: record that verdict, state the check that proved it unchanged, and DO NOT RE-DISPATCH.** A correction pass whose runway says *do not touch the paper* otherwise has no defined first stage — and that is the common case, because a HOLD usually lands on the non-research half of a diff (three of four items on this cycle's first pass came from outside the paper).
-- **UNCHANGED MEANS THE FILE, NOT THE BODY — NEW TEXT IS NEW CLAIM SURFACE.** A paper whose body is byte-identical but which GAINED text (a supersession header, a status banner, a scope note) is NOT unchanged: the added block carries an original's full sourcing burden. Read literally the rule above points at skipping it; that reading is wrong. **Measured on this cycle: an added supersession header carried a blocking defect that had also propagated into a second paper.** Verify the ADDED SPANS and say so; skip only what is genuinely untouched.
-- **COMMIT AFTER EVERY CORRECTION ROUND, before the next critic dispatch.** A round boundary that exists in git is the only way a later actor can attribute an edit to the round that made it. **Measured: with no intermediate commits the round-3 critic read a cumulative diff, found no boundary in it, and mis-attributed an edit's round** — caught only because the analyst still held its own round-by-round spans in context, which a fresh actor would not.
-- **ROUND 1 VERIFIES THE CORPUS. EVERY LATER ROUND VERIFIES ONLY WHAT CHANGED. This is a REQUIREMENT, not an optimisation you may take if you think of it.**
-  - **Round 1: the full pass.** Every cited source, every quoted span, clone-and-`grep -F` as specified above. This is the anti-hallucination gate and nothing below reduces it.
-  - **Rounds 2+: scope the critic's dispatch to the spans the analyst actually touched**, named explicitly in the dispatch, and tell it so: *the sources verified in round 1 and not edited since are settled — do not re-clone, re-fetch or re-read them.* **A REPAIRED SPAN IS A NEW CLAIM AND CARRIES AN ORIGINAL'S FULL SOURCING BURDEN** — scoping narrows WHAT is judged, never how hard.
-  - **What counts as changed is the analyst's own diff, not its summary of it.** Derive the span list from `git diff` against the previous round's commit — which is why the per-round commit above is a hard requirement and not bookkeeping. If the analyst rewrote the paper wholesale rather than repairing spans, that is a full pass again; say so and take it.
-  - **WHY THIS IS WRITTEN DOWN, measured 2026-08-12.** The prior cycle re-verified the whole corpus every round: 28 sources re-fetched from scratch five times, **33 `git clone`s, $58.62 and 135 minutes — 6.4x the $9.14 the paper cost to write.** The next cycle scoped rounds 2 and 3 to repaired spans and re-cloned nothing: **4 clones, $20.05, 44 minutes.** That run invented the scoping itself and filed `C-075` asking for it to be made a rule — **so the single largest saving in the measured pair was luck, and this paragraph is what converts it into a guarantee.**
-  - **`author != judge` needs a fresh JUDGMENT, not a fresh DOWNLOAD.** The critic is fresh every round regardless; re-downloading a source it already cleared buys nothing and is what the 3-round ceiling was bounding the damage of.
-- **Correction-round budget.** A round is analyst-fix → critic re-verify. Expect at least one round on most papers — that is the gate working, not a failure. Two limits, and they measure different things:
-  - **Non-convergence: the SAME blocking finding survives 3 rounds.** Two attempts at one defect that does not yield is a defect that will not yield.
-  - **Hard ceiling: 3 rounds total per paper, whatever the findings are.** This is a runaway guard, not a budget — it cannot be spent, only tripped.
-  - **WHY 3 AND NOT 6, measured 2026-08-12.** The ceiling was 6, set by assertion and never earned. **A single minor cycle then cost $58.62 and 135 minutes in this stage alone — six times the $9.14 the paper itself cost to write** — because five critic passes each re-verified the WHOLE paper: 28 sources, re-fetched from scratch every round, 441 Bash calls against 1 WebFetch. At roughly $7-10 a round, a ceiling of 6 is not a guard. It is a budget that permits a $60 run and calls itself a guard.
-  - **THIS IS A RAMP STEP, NOT THE ANSWER.** The same discipline the fleet applies to loop-backs: a bound starts low, the workflow earns more with evidence. **The real defect is that a correction round re-verifies everything rather than what changed** — `author != judge` needs a fresh JUDGMENT, not a fresh DOWNLOAD, and this stage conflates them. Until that is rebuilt, 3 bounds the damage.
-  - **AND 3 IS A DIAGNOSTIC WINDOW, not just a cap.** The operator's framing: understand WHY this stage needs so many rounds before buying it more. **The target is 90% of papers passing inside 3 rounds** — measured, not assumed. Raise the ceiling only after that holds, and never from taste.
-- **A DEFECT CLASS RECURRING IN NEW INSTANCES IS CONVERGENCE. THE SAME INSTANCE SURVIVING IS NOT.** This run had to derive that distinction and said so; deriving it WRONG is how a cycle spends every round it has. If each flagged instance closes and the same *kind* of defect turns up somewhere new, the paper is converging — bank the closures and move on. If a specific flagged instance is still standing after a fix aimed at it, that is the non-convergence this budget exists to stop.
-- **Why the test is per-finding.** A round that fixes the flagged defect and introduces a *different* one is converging; a round that leaves the same defect standing is not. The old rule ("any blocking finding exists at round 3") could not tell them apart and dropped a paper that was still closing. The ceiling exists because the per-finding test alone would never trip on a paper generating a fresh defect every round.
+- **Write the verdict line in your own words.** Never paste critic-authored text into the artifact: text the critic wrote and you signed is the critic's text wearing your name, and it puts the critic in the position of verifying itself. Measured twice in one cycle — a mandated line claimed three sources where the body had four, and another asserted a directory total a re-fetch contradicted.
+- **RELAY A CRITIC'S REMEDY AS A PROPOSAL TO BE CHECKED, NEVER AS AN INSTRUCTION.** Measured on one cycle: **three critic-proposed remedies would have introduced defects if applied as written.** You may override one with reasoning.
+- **Completion is reported by the harness. Never infer it from file content.** A marker written into a file appears PARTWAY THROUGH an edit sequence, not at the end of it. Measured: a loop watched for the `Critic:` line and round-2 critics began verifying files still being written — *a verdict pinned to a moving file is itself an integrity risk*. Block on agent completion. **A blocking `TaskOutput` that times out is not a failure — re-block on the SAME task id.**
+- Record the final critic verdict for the PR body, and write it into the paper's own header (`Critic:` line) so a paper read on its own carries its verification evidence.
+
+### How a quoted span is verified
+
+**Byte-exact HTTP GET, then `grep -F`. Not `WebFetch`, and not a clone.**
+
+```
+curl -s https://raw.githubusercontent.com/<org>/<repo>/<sha>/<path> | grep -F "<the exact span>"
+```
+
+Tell the critic this explicitly in its dispatch, and require it to **record the resolved SHA per source in the paper**.
+
+- **`WebFetch` cannot establish a verbatim quote.** It is model-mediated, non-deterministic on an unchanged URL, and blends near-duplicates into a span existing in NO source. Two of the five measured fetch-layer failure classes survive every remedy short of byte-exact retrieval.
+- **A raw GET has neither failure mode** — no model touches the bytes. The old rule mandated `git clone` for this reason and the reason does not reach that far: it conflated *a summarizing fetch* with *an HTTP request*, and bought 33 clones, $58.62 and 135 minutes for the confusion.
+- **Pinning to a SHA makes the check stronger, not just cheaper** — a re-check hits identical bytes instead of whatever `HEAD` has moved to, and the paper carries its own reproducibility.
+- **Clone only when a raw GET genuinely cannot serve** — a non-public host, or a claim about repository structure rather than file content. Then `--depth 1 --filter=blob:none --sparse` with a sparse-checkout of the one path, and **deduplicate by repository before touching the network**: eleven sources are rarely eleven repos.
+
+### Round scoping — a requirement, not an optimisation
+
+- **Round 1: the full pass.** Every source, every span, every item in the scope list above. This is the anti-hallucination gate and nothing below reduces it.
+- **Rounds 2+: scope the critic's dispatch to what you actually changed**, named explicitly, and tell it so: *everything verified in round 1 and not edited since is settled — do not re-fetch or re-read it.* **A REPAIRED SPAN IS A NEW CLAIM AND CARRIES AN ORIGINAL'S FULL SOURCING BURDEN** — scoping narrows WHAT is judged, never how hard.
+- **What counts as changed is the diff, not your summary of it.** Derive the span list from `git diff` against the previous round's commit — which is why the per-round commit below is a hard requirement and not bookkeeping.
+- **COMMIT AFTER EVERY CORRECTION ROUND, before the next critic dispatch.** A round boundary that exists in git is the only way a later actor can attribute an edit to the round that made it. Measured: with no intermediate commits a round-3 critic read a cumulative diff, found no boundary, and mis-attributed an edit's round.
+- **`author != judge` needs a fresh JUDGMENT, not a fresh DOWNLOAD.** The critic is fresh every round regardless; re-downloading a source it already cleared buys nothing.
+- **WHY THIS IS WRITTEN DOWN, measured 2026-08-12.** The prior cycle re-verified the whole corpus every round: **33 `git clone`s, $58.62 and 135 minutes — 6.4x the $9.14 the paper cost to write.** The next cycle scoped rounds 2 and 3 to repaired spans: **4 clones, $20.05, 44 minutes.** That run invented the scoping itself and filed `C-075` asking for it to be made a rule — so the single largest saving in the measured pair was luck, and this paragraph converts it into a guarantee.
+
+### Skipping what is genuinely untouched
+
+- **IF A PAPER IS UNCHANGED SINCE ITS RECORDED CRITIC VERDICT: record that verdict, state the check that proved it unchanged, and DO NOT RE-DISPATCH.** A correction pass whose runway says *do not touch the paper* otherwise has no defined first stage — and that is the common case.
+- **UNCHANGED MEANS THE FILE, NOT THE BODY — NEW TEXT IS NEW CLAIM SURFACE.** A paper whose body is byte-identical but which GAINED text (a supersession header, a status banner, a scope note) is NOT unchanged: the added block carries an original's full sourcing burden. **Measured: an added supersession header carried a blocking defect that had also propagated into a second paper.** Verify the ADDED SPANS and say so; skip only what is genuinely untouched.
+
+### Correction-round budget
+
+A round is your fix → critic re-verify. Expect at least one on most papers — that is the gate working, not a failure. Two limits, measuring different things:
+
+- **Non-convergence: the SAME blocking finding survives 3 rounds.** Two attempts at one defect that does not yield is a defect that will not yield.
+- **Hard ceiling: 3 rounds total per paper, whatever the findings are.** A runaway guard, not a budget — it cannot be spent, only tripped.
+- **A DEFECT CLASS RECURRING IN NEW INSTANCES IS CONVERGENCE. THE SAME INSTANCE SURVIVING IS NOT.** If each flagged instance closes and the same *kind* of defect turns up somewhere new, the paper is converging — bank the closures and move on. The ceiling exists because the per-finding test alone would never trip on a paper generating a fresh defect every round.
+- **3 IS ALSO A DIAGNOSTIC WINDOW.** The target is **90% of papers passing inside 3 rounds** — measured, not assumed. Raise the ceiling only after that holds, and never from taste.
 - **Non-convergence path:** when either limit is reached, do NOT keep looping. DROP that paper from this cycle: exclude it from `synthesis.md`, leave it in `raw/` with a prominent header line `STATUS: NOT VERIFIED — excluded from synthesis (N correction rounds, unresolved: <what>)`, and report it in the PR body as a non-convergent topic needing human attention. An unverifiable paper that is honestly excluded is a finding; one that silently rides into the synthesis is a contamination.
-- **The critic supplies the verdict's CONTENT; the ANALYST renders the header line.** Never route verbatim header text from critic to analyst for transcription — text the critic authors and the analyst signs is the critic's text wearing the analyst's name, and it bypasses the read-only boundary that keeps a critic from verifying its own words. Measured twice in one cycle: a mandated line claimed three sources where the paper's body had four, and another asserted a directory total the analyst's re-fetch contradicted (the analyst correctly refused to write it). Both defects were in critic-authored text.
-- Record each paper's final critic verdict for the PR body, and write it into the paper's own header (`Critic:` line) so a paper read on its own carries its verification evidence.
+
+### Tracing a correction
+
+**Binding, from the Research Standard §4:** *a corrected fact traces to ALL its dependents.* When you correct a claim, enumerate EVERY place the synthesis depends on it — a cited figure, a count, an action candidate resting on it, a homeless finding — and correct each one in the same round. You hold the full picture exactly once; this is the cheapest moment it will ever be done.
+
+Two rules the synthesis inherits from a paper and fails most often:
+
+- Every quote is **verbatim** — established by the byte-exact GET above, never by a summarizing fetch.
+- **Every count was enumerated, not asked for.** Ask a layer to list, then count the list yourself.
 
 ## YOUR OWN DISPOSITIONS — you may not decline on the grounds you would reject from someone else
 
@@ -50,25 +95,7 @@ You are told above to treat another run's **"pre-existing"**, **"out of scope"**
 
 **Rejecting is legitimate — with reasoning that holds.** Declining because the label sounds like it grants permission is not a disposition, it is a deferral wearing one.
 
-## Stage 2: TRACE CORRECTIONS INTO THE SYNTHESIS
-
-**Binding, from the Research Standard §4:** *a corrected fact traces to ALL its dependents.* When Stage 1 corrected a claim, enumerate EVERY place the draft synthesis depends on it — a cited figure, a count, an action candidate resting on it, a homeless finding — and correct each one.
-
-This is the stage that exists because the trace is cheapest here: you have the full picture exactly once.
-
-## Stage 3: VERIFY THE SYNTHESIS ITSELF
-
-The synthesis carries **a paper's full sourcing burden** (§4), and it is the artifact the standup consumes — the raw pool is never read downstream. Until now nothing checked it, and a wrong count in one cycle's synthesis propagated into the next cycle's dispatch prompts.
-
-Verify, with the same rules that govern a paper:
-- Every quote is **verbatim** — the exact character sequence was returned by a fetch. A summarizing fetch cannot establish that.
-- **Every count was enumerated, not asked for.** Ask a layer to list, then count the list yourself.
-- Every cited paper exists, carries the stated `Last validated` date and critic verdict, and says what it is claimed to say.
-- No retired paper is cited.
-
-A defect you find here you FIX — you are not decide-only. Dispatch the analyst for anything requiring authorship; a repaired span is a new claim and carries a fresh claim's full sourcing burden.
-
-## Stage 4: SUBMIT
+## Stage 2: SUBMIT
 ${SUBMIT_PROMPT}
 
 ${DECISION_LOG_AND_REFLECTION}

--- a/scripts/workflows/temporal/modules/assistant/research/research_verify/research_verify_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/research/research_verify/research_verify_workflow.py
@@ -1,8 +1,9 @@
-"""research-verify — FRESH context: verify the papers, fix, trace, verify the synthesis.
+"""research-verify — FRESH context: verify everything the PR ships, and fix it.
 
 Folder holds only this file (§10.1 rule 6).
 
-Three jobs the monolith never separated:
+Three jobs the monolith never separated, all still done, now in ONE critic loop
+rather than three stages:
   1. verify each paper (this existed, as stage 4)
   2. trace every correction through to the synthesis (§4 binding rule, never executed)
   3. verify the SYNTHESIS itself (never existed at all)
@@ -11,6 +12,18 @@ Job 3 is why this child exists. The synthesis carries a paper's full sourcing
 burden per §4 and is the only artifact the standup consumes — and nothing
 checked it. A wrong count in one cycle's synthesis propagated into the next
 cycle's dispatch prompts and mis-instructed two analysts.
+
+WHY THEY COLLAPSED INTO ONE PASS. They were separate stages because a separate
+`research-analyst` did the writing, so each artifact needed its own hand-off.
+The child now holds Write/Edit and applies the critic's findings itself, which
+makes tracing a correction into the synthesis simply part of fixing it.
+
+AND THE SCOPE WIDENED WITH IT: the papers, the synthesis, the PR body, internal
+links, the header block, and every claim the paper makes about OUR platform —
+which the authoring run could not check, having been on the web while this child
+holds the repo. Measured: three of four items on one cycle's first review pass
+came from outside the paper, so a verifier scoped to "the papers" leaves the
+common defect for a downstream reviewer that cannot fix it.
 """
 
 from __future__ import annotations

--- a/scripts/workflows/temporal/modules/assistant/research/research_write_minor/prompts/write_minor.md
+++ b/scripts/workflows/temporal/modules/assistant/research/research_write_minor/prompts/write_minor.md
@@ -1,22 +1,24 @@
 You are executing the RESEARCH-MINOR workflow on a new branch.
 
-This workflow produces ONE research mini-paper. It is the scaled-down member of the research family: no topic list, no sizing assessment, and no fan-out — but it DOES write a synthesis, because that is the document every downstream consumer reads. The target repo's Research Standard owns the artifact contract — it is your binding input, and every per-paper obligation in it applies to your one paper in full.
+**WHAT THIS WORKFLOW IS FOR.** You are given a TOPIC — a candidate feature or direction, big enough to warrant multi-phase planning, too small to need several papers on separate subjects. You produce the basis a PLANNER plans from: best practices, what the industry does, where the evidence points. **The synthesis is the deliverable; the paper is the durable repository it draws on and the pool keeps.**
+
+**A TOPIC IS NOT A QUESTION.** A topic legitimately spans several concerns — that is what makes it a topic. **Do not decompose it and answer one slice:** a narrowed paper is the same size as a complete one and covers a quarter of the ground. The 20-source ceiling below is what bounds scope, not the number of concerns.
+
+The target repo's Research Standard owns the artifact contract — your binding input, and every per-paper obligation in it applies to your one paper in full.
 
 Research dir: ${RESEARCH_DIR}
 ${CONTEXT_BLOCK}
 ${HEADLESS_EXECUTION_GUARD}
 
-**WHY THIS SHAPE EXISTS, so you do not try to restore the parts that are missing.** A single question — the kind a person could ask over coffee — was once answered with five papers and a synthesis, at roughly 3.5 hours. That was not a sizing error to be corrected by choosing fewer topics: even a correctly-sized Small cycle still emits a topic list, a fan-out and a roll-up. **The absent machinery is absent on purpose.** Do not create `topics.md`. Do not write a sizing assessment. Do not dispatch more than one analyst. **You DO write `synthesis.md`, and the earlier version of this prompt was wrong to forbid it.** The argument was that with one paper the roll-up IS the paper. That holds on the first run and breaks on the second: papers ACCUMULATE and the synthesis is REPLACED (Research Standard §4), so a pool with two minor papers and no synthesis has nothing rolling them up. It also strands the evidence — a planner is told not to read raw papers wholesale, so it reports "no synthesis" and plans from priors while your paper sits unread. Keep it SHORT: one input, no fan-out, a roll-up and its candidates.
+**THE ABSENT MACHINERY IS ABSENT ON PURPOSE — do not restore it.** Do not create `topics.md`. Do not write a sizing assessment. Do not dispatch more than one analyst. **You DO write `synthesis.md`:** papers ACCUMULATE and the synthesis is REPLACED (Research Standard §4), so a pool with two minor papers and no synthesis has nothing rolling them up — and a planner told not to read raw papers wholesale reports "no synthesis" and plans from priors while your paper sits unread.
 
-**A CEILING, AND IT IS BINDING: 20 CITED SOURCES. If answering the question honestly needs more, STOP — you have the wrong instrument.**
+**A CEILING, AND IT IS BINDING: 20 CITED SOURCES. If covering the topic honestly needs more, STOP — you have the wrong instrument.**
 
-Say so, name the question, and stop: this is a FULL cycle, not a minor one. Do not write a bigger paper and do not silently narrow the question to fit.
+Say so, name the topic, and stop: this is a FULL cycle, not a minor one. **Do not write a bigger paper, and do not silently narrow the topic to fit** — a narrowed topic delivered as if it were the whole one is the worse of the two failures, because nothing downstream can tell.
 
-**WHY, MEASURED 2026-08-12.** A minor cycle was pointed at four questions at once. It produced ONE conforming paper — 1,103 lines, 28 sources — and the paper itself was fine at **$9.14 and 21 minutes**. Then verification cost **$58.62 and 135 minutes**, because that stage's cost tracks SOURCES, not papers: 28 sources, re-verified from scratch on every correction round. **The whole saving of a minor cycle evaporates the moment its one paper is large**, and nothing here was watching the variable that decides it. The Research Standard sets a source FLOOR — 10-20 for medium-and-up, proportionally fewer for small — and no ceiling anywhere. This is the ceiling.
+**WHY A CEILING AT ALL.** Verification cost tracks SOURCES, not papers — every source is re-checked as the paper converges. The Research Standard sets a source FLOOR (10-20 for medium-and-up, proportionally fewer for small) and no ceiling anywhere; this is the ceiling. **20 is the top of that same band** — generous for one topic, well under what a full cycle produces, and measured against this repo's corpus rather than chosen by taste.
 
-**WHERE 20 COMES FROM — the corpus, not taste.** All 32 papers in this repo were measured: **median 34 sources, mean 33, max 54; median 872 lines.** The 28-source paper that triggered this was *below* the median — it was a NORMAL paper, and an earlier draft of this rule set the cap at 12, which would have rejected almost every paper ever written here. **20 is the top of the Research Standard's own 10-20 band for medium-and-up topics**, which is generous for a cycle answering ONE question and still well under what a full cycle produces.
-
-**AND BE CLEAR WHAT THIS CAP DOES: it bounds SCOPE CREEP, not cost.** The $58.62 verification came from re-verifying the same sources across five rounds, not from there being 28 of them. A cap on the paper is the smaller of the two levers and is here to stop one cycle quietly becoming four.
+**BE CLEAR WHAT IT DOES: it bounds SCOPE CREEP, not cost.** It is here to stop one cycle quietly becoming four.
 
 **What is NOT reduced: the paper itself.** Source discipline and the count rule, per-claim confidence marking, the honest-boundary analysis, the currency header with its machine-parseable revalidation interval — all binding, all unchanged. Those are per-PAPER rigor and have nothing to do with how many papers a cycle produces. A thin paper is not what "minor" means.
 
@@ -31,12 +33,20 @@ FIRST: verify the task targets THIS repo. If ${RESEARCH_DIR} or the context refe
 
 Then:
 - Locate and READ the repo's research standard (expected at `docs/standards/research/research_standard.md` or the repo's equivalent — check CLAUDE.md / the docs index). If NO research standard exists in this repo, STOP and report it — the artifact contract is a required input, not something to improvise.
-- Read ${RESEARCH_DIR} if it already exists — the papers in `raw/`. A re-run corrects or extends what is there; it does not blindly duplicate it. **If a current paper already answers the question you were given, say so and stop rather than writing a second one** — that is a finding, not a failed run.
+- Read ${RESEARCH_DIR} if it already exists — the papers in `raw/`. A re-run corrects or extends what is there; it does not blindly duplicate it. **If a current paper already covers the topic you were given, say so and stop rather than writing a second one** — that is a finding, not a failed run.
+- **IF A PAPER EXISTS BUT THE TOPIC HAS MOVED — extend it in place.** Papers accumulate and the pool is read by subject, so two papers on one subject means a reader finds whichever they hit first. Widen its `Topic:` line, add the new ground, note the shift in the PR body. **A new paper only when the topic is genuinely a DIFFERENT subject** — say why. Retire the old one (`Revalidate: retired`) only if it is now WRONG, never merely narrower.
 - **VERIFY the context against your branch before reasoning from it.** If the dispatch quotes or names a document section, confirm that section EXISTS on your branch. When it does not, do NOT conclude the dispatch is wrong about its own repo and do NOT research against a frame you cannot see — the likely cause is a commit that was not pushed when you were dispatched. Locate it (check the default branch tip and recent local refs), work from the version the dispatch describes, and **report the discrepancy as a low-confidence call in your PR body**.
 - **Your worktree is checked out from the branch under work.** If this run is updating an existing PR, the papers you read ARE that PR's — not main's. Extend and correct what the PR already produced; never conclude the directory is empty because main does not have it yet.
-- Read the planning doc or decision this paper feeds — **the DESTINATION is what makes the question answerable.** A paper with no destination is not in scope for this workflow.
+**YOUR INPUTS — read all of them before you scope anything:**
+- **The dispatch prompt** — the topic.
+- **The feature's own location** — its roadmap entry and any feature/phase docs. This is what is already decided; re-opening a settled decision is waste.
+- **The project's scope and top-level synthesis** — so recommendations fit the system being built, not a generic one.
+- **The PROJECT-level research pool**, located in the context above. **REFERENCE what is there rather than reproducing it** — re-deriving a project-level finding pays full price for something already bought.
+- **The destination** — the planning doc or decision this feeds. **The DESTINATION is what makes the topic tractable**; a paper without one is not in scope.
 
-**State the question and its destination in one line before you go further**, in the shape the standard's header block uses: `Topic: <the question this paper answers>` / `Feeds: <the decision or doc it validates>`. If the dispatch handed you something broader than one question — several concerns bundled together, or a subject with real competing alternatives to weigh — **say so and stop.** That is a Medium-or-larger component by the standard's own sizing rubric, and it belongs in the full `research` workflow, not here. Reporting the mis-fit costs one paragraph; researching a five-topic subject one topic at a time produces a paper that reads complete and is not.
+**State the topic and its destination in one line before you go further**, in the shape the standard's header block uses: `Topic: <the subject this paper covers>` / `Feeds: <the decision or doc it validates>`.
+
+**A topic with several concerns in it is NORMAL and is not a mis-fit — cover them.** Stop and report a mis-fit only when the subject genuinely needs MORE THAN ONE PAPER: separate subjects that would each carry their own sources, their own destination and their own honest-boundary case. That is a Medium-or-larger component by the standard's sizing rubric and belongs in the full `research` workflow. Reporting a real mis-fit costs one paragraph; **treating a normal multi-concern topic as a mis-fit, or quietly answering one slice of it, produces a paper that reads complete and is not.**
 
 ## Stage 2: RESEARCH — ONE PAPER
 Dispatch the **research-analyst** agent, ONCE, to write `${RESEARCH_DIR}/raw/<topic>.md`.
@@ -53,7 +63,9 @@ The analyst's prompt must include: the question, its `Feeds:` destination, **the
   - **a count is a claim** — enumerate the population and count the enumeration, or state the count as a gap
   - **gaps are findings**, and a negative finding states its search method
   - **the honest-boundary analysis** (content arc item 5) — when this is NOT needed, and where it fails. A paper with no case against its own thesis is advocacy, not research. This section is not optional because the cycle is small; a one-paper answer with no counter-case is the single most dangerous artifact this workflow can produce, because there is no second paper to disagree with it.
-- **You run NO critic rounds.** The analyst sets `Critic: not-yet-verified — <date>` in the header, which §3 names as a legal and honest value. **A separate fresh-context run verifies the paper** — that seam is why your own verdict would be worthless: an actor that writes a paper and then certifies it has verified its own work.
+  - **EVERY QUOTED SPAN IS CHECKED AGAINST THE BYTES AT WRITE TIME, and the resolved SHA recorded beside it.** `curl -s https://raw.githubusercontent.com/<org>/<repo>/<sha>/<path> | grep -F "<the exact span>"`. Never establish a quote with `WebFetch` — it is model-mediated, non-deterministic on an unchanged URL, and blends near-duplicates into a span existing in NO source. **A quote checked here costs one HTTP request; the same quote caught downstream costs a critic round, a fix and a re-verify.**
+  - **Every internal link resolves.** `ls` the path before you write the link. A document whose purpose is traversable evidence fails completely on a broken one, and one verification pass once found eighteen.
+- **You run NO critic rounds.** The analyst sets `Critic: not-yet-verified — <date>` in the header, which §3 names as a legal and honest value. **A separate fresh-context run verifies the paper** — that seam is why your own verdict would be worthless: an actor that writes a paper and then certifies it has verified its own work. **Self-checking at write time does NOT replace it**: it lowers the defect rate the verifier finds so the run converges in one round instead of three.
 - **Currency claims passed to the analyst MUST come from the computed table in the context above**, never from prose. Where the two disagree, the table wins.
 - After the analyst returns, checkpoint-commit the paper.
 
@@ -69,7 +81,7 @@ Write (or fully rewrite) `${RESEARCH_DIR}/synthesis.md` per the Research Standar
 
 - **Cites your paper** with its `Last validated` date and its critic verdict — the same citation burden a full cycle carries
 - **Cites any paper already in the pool**, because a second minor cycle rewrites this file over BOTH papers. Read `raw/` before writing; you may not be the first run here
-- **Rolls up what it means for us**, so a human can act without opening the paper
+- **Rolls up what it means for us — written for the PLANNER who reads it next.** Best practices, what the industry does, and which direction the evidence points, at the altitude someone decomposing this feature into phases can act on without opening the paper
 - **Ends in action candidates** — adopt / change direction / new concept / no change, sized for a standup. **A candidate with no home is named as homeless HERE**; you surface it, you do not file it
 - **EXCLUDES retired papers** — a paper marked `Revalidate: retired` is provenance, not input
 

--- a/scripts/workflows/temporal/modules/assistant/review_pr/prompts/criteria_research.md
+++ b/scripts/workflows/temporal/modules/assistant/review_pr/prompts/criteria_research.md
@@ -17,21 +17,19 @@ Research also has a staleness cost nothing else carries: a high-volatility paper
 
 **Candidates are cargo. They ride through the review untouched.** You do not rule on them, rank them, or convert them into findings. Enumerate them so the operator can see them; that is all.
 
-### Axis 2 — the blocking-defect checklist (exactly six; nothing else blocks)
+### Axis 2 — what the run tells on itself about, and where each routes
 
-1. **Every citation resolves and the claim matches the source.**
-2. **Internal links resolve.**
-3. **Header block present and machine-parseable** — `Revalidate:` interval, `Critic:` line.
-4. **Honest-boundary section present.**
-5. **No statement about our platform that is factually false.**
-6. **Source-count floor met for the paper's size.**
+**There is no checklist here, and that is deliberate. You do not verify papers, citations, quotes, links, headers or counts** — `research-critic` does that inside the run and `research-verify` checks everything the PR ships. Repeating it is the most expensive thing this review can do and it establishes nothing they have not.
 
-That is the whole review. These artifacts already passed `research-critic` **inside** the run; this is a **fresh-context integrity pass**, not a second opinion on the research itself.
+| The run reports | Exit |
+|---|---|
+| **Non-convergent paper** — `STATUS: NOT VERIFIED — excluded from synthesis` | **needs_ruling.** Verify spent its rounds; redispatch asks the same actor to fail again |
+| **Unverifiable claims**, marked as such | **Not blocking.** Enumerate — an honestly recorded gap is a finding by design |
+| **Candidates / standards amendments** | **Cargo**, per Axis 1. Enumerate, never rule |
+| **A defect verify should have caught** — wrong PR body, dead link, missing header | **redispatch** — the exception path, not the design |
 
-Worth knowing why it is kept rather than skipped: one pass found **18 broken links** in a document whose entire purpose is traversable evidence, plus a false statement about shipped state. `research-critic` verifies that sources exist and claims match them — it does **not** check internal link integrity or platform accuracy. That gap is real, and fresh-context review is what closes it.
+**If that last row fires routinely, the defect is `research-verify`'s scope, not this review's diligence.** Say so rather than compensating by looking harder here.
 
-### The volume expectation — state it to yourself before you begin
+### The volume expectation
 
-**A clean research PR returns `MERGE` with ZERO findings. That is the expected outcome, not a failure of diligence.**
-
-A reviewer instructed to enumerate *will* find things. Resist it. If the six checks pass, say so and merge — a manufactured finding costs the operator real attention and teaches them to distrust the next one.
+**A clean research PR returns `MERGE` with ZERO findings. That is the expected outcome, not a failure of diligence.** A reviewer instructed to enumerate *will* find things — resist it. A manufactured finding costs the operator real attention and teaches them to distrust the next one.

--- a/scripts/workflows/temporal/tests/unit/test_research_minor.py
+++ b/scripts/workflows/temporal/tests/unit/test_research_minor.py
@@ -586,13 +586,22 @@ def test_the_ternary_predicate_actually_detects_a_branch() -> None:
 
 
 def test_verify_has_no_minor_specific_stage() -> None:
-    """The reused child's own stages are untouched.
+    """The reused child's stages do not branch by tier.
 
-    The block states a fact about the cycle; it must not have grown a fourth
-    stage or a conditional stage heading in the prompt itself.
+    `research_verify` is shared by the full cycle and the minor one. The context
+    block states a fact about which cycle is running; it must never become a
+    conditional stage heading, because a prompt that branches on tier is two
+    prompts sharing a file and they drift.
+
+    THE COUNT WENT 4 -> 2, and that is the change it was frozen to catch. The
+    `research-analyst` re-dispatch is gone — the child holds Write/Edit and
+    applies the critic's findings itself — so TRACE and VERIFY-THE-SYNTHESIS
+    stopped being separate passes over the artifact and became part of the one
+    critic loop. Tracing a correction into the synthesis IS fixing what the
+    critic found; it was a stage only because a different agent did the writing.
     """
     titles = _stage_titles(VERIFY_PROMPT.read_text())
-    assert len(titles) == 4, f"research_verify's stage count changed: {titles}"
+    assert len(titles) == 2, f"research_verify's stage count changed: {titles}"
     assert not any("MINOR" in t.upper() for t in titles), (
         "verify.md grew a minor-specific stage. The reuse is the design: one set "
         "of stages, one of them told what the cycle produced."

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -143,7 +143,12 @@ BUDGETS: dict[str, int] = {
     # that changes what the model writes, which is this table's own bar for a
     # raise. Measured with `wc -c`, in BYTES.
     "plan/plan_feature/prompts/plan_feature.md": 18_051,
-    "research/research_verify/prompts/verify.md": 15_510,
+    # 15_510 -> 13_204: the `research-analyst` re-dispatch is gone. The verify
+    # child holds Write/Edit and applies the critic's findings itself, so the
+    # rules that existed only to coordinate a second writing agent went with it
+    # — the resume contract, "do not transcribe", and the critic-authors /
+    # analyst-signs split. Stages 2 and 3 also folded into the one critic pass.
+    "research/research_verify/prompts/verify.md": 13_204,
     # SET AT ITS SIZE ON THE DAY IT LANDED, like `plan_feature.md` above and for
     # the same reason: this prompt is new, so it MEETS this gate rather than
     # being measured into it. Measured in BYTES with `wc -c`, never eyeballed —
@@ -189,7 +194,18 @@ BUDGETS: dict[str, int] = {
     # true on run 1, false on run 2, since papers accumulate and the synthesis is
     # replaced. Without it a planner reports "no synthesis" and plans from priors
     # while the paper sits unread, which wastes the whole cycle.
-    "research/research_write_minor/prompts/write_minor.md": 13_941,
+    # 13_941 -> 15_131: the CONTRACT was wrong, and the prompt is where it was
+    # wrong. This workflow takes a TOPIC and produces the basis a planner plans
+    # from; the prompt said "one question" and told a run to STOP if handed
+    # several concerns. A run followed it, narrowed a four-concern brief to one
+    # question, and produced 1,055 lines covering a quarter of the ground at the
+    # same cost. Also gained: the inputs it is expected to read (feature docs,
+    # project synthesis, the project research pool it must not re-derive),
+    # write-time quote verification by byte-exact GET, and the topic-has-moved
+    # case that was previously undefined. ~2,300 bytes of measurement narration
+    # were cut to pay for it, per `workflow-scripts.md` § Prompt economy — the
+    # figures belong in a commit, not on every turn of every run.
+    "research/research_write_minor/prompts/write_minor.md": 15_131,
     "research/research_write/prompts/write.md": 11_669,
     "build/build_draft_minor/prompts/update_pr.md": 10_675,
     # SHARED FRAGMENTS ARE THE EXPENSIVE ONES — every workflow that includes one


### PR DESCRIPTION
The family cost 200,277 output tokens and 139.8M cache-read on one paper.
Writing was 11% of it. Three defects, one per child.

CHILD 1 — the contract was wrong. This workflow takes a TOPIC and produces
the basis a planner plans from. The prompt said "one question" and told a run
to STOP if handed several concerns bundled together. A run obeyed it: it
narrowed a four-concern brief to a single fork-vs-parameterize question and
produced 1,055 lines covering a quarter of the ground, for the same cost as
covering all of it. Also added: the inputs it is expected to read (feature
docs, project synthesis, the project research pool it must REFERENCE rather
than re-derive), write-time quote verification, and the topic-has-moved case
that was previously undefined — the prompt handled "already covered" and "not
covered" and was silent on "the topic changed".

CHILD 2 — too many cooks. The child dispatched `research-analyst` to apply the
critic's findings, so six rules existed only to coordinate two writing agents
that cannot see each other: the SendMessage resume contract, "do not
transcribe", "relay a remedy as a proposal", the critic-authors/analyst-signs
split. The child now holds Write/Edit and fixes what the critic finds itself.
`author != judge` is unaffected — child 1 authored the paper, this is a fresh
dispatch, and the critic still re-checks work it did not write.

Stages TRACE and VERIFY-THE-SYNTHESIS folded into the one critic loop; they
were separate stages only because a different agent did the writing. Scope
widened from "the papers" to everything the PR ships, because three of four
items on one cycle's first review pass came from outside the paper.

CLONE-AND-GREP -> BYTE-EXACT GET. The rule mandating `git clone` for every
quoted span reasoned that fetch is non-deterministic and blends near-duplicates
into a span existing in no source. That is true of WebFetch, which is
model-mediated. It is not true of an HTTP GET, where no model touches the
bytes. The conflation bought 33 clones, $58.62 and 135 minutes. Now:
curl raw.githubusercontent.com | grep -F, pinned to a SHA recorded in the
paper — cheaper AND stronger, since a re-check hits identical bytes.

CHILD 3 — review-pr was doing other children's jobs. `criteria_research.md`
carried a six-item checklist that re-resolved every citation and re-matched
every claim, on a corpus `research-critic` had just cleared. Its own text says
"these artifacts already passed research-critic INSIDE the run; this is not a
second opinion on the research itself" two lines below the check that is
exactly that — and check 3 already proves the critic ran, making check 1 the
same question answered the expensive way. It also contradicted the universal
core it is appended to, which states "You are NOT re-reviewing the code".

The core is right and is untouched. review-pr reads what the run told on
itself and routes to merge / redispatch / needs_ruling. Axis 2 is now that
routing table and carries no checks. The five real ones moved to the children
that already hold the file open — including platform accuracy, which child 2
can do better anyway: it runs in the worktree and holds the repo, while the
authoring run was on the web.

Research is the only review type that had grown this; build and planning both
judge without re-deriving, and both criteria files are ~1,390 bytes to
research's 3,112.

Net across the family: -1,066 bytes of prompt, and no new children, agents or
test files. `research_minor_workflow.py`'s single loop-back stays as a safety
net and becomes a calibration signal — if it fires routinely, that is child 2's
scope, not a reason to strengthen the loop.

---

## What changed, per child

| Child | Change |
|---|---|
| `research_write_minor` | Contract: a **topic**, not a question. Explicit inputs incl. the project research pool. Write-time quote verification (`curl` + `grep -F` + SHA). Topic-has-moved case defined. |
| `research_verify` | `research-analyst` dispatch deleted — the child fixes what the critic finds. Stages 4→2. Scope widened to everything the PR ships. Clone-and-grep → byte-exact GET. |
| `review_pr` (`criteria_research.md`) | Six-item checklist → routing table with **zero checks**. The five real checks moved into the two children that already hold the artifact open. |

## Verification

`1825 passed, 3 skipped` — full suite. Two guards fired and were updated with reasons rather than numbers: `test_verify_has_no_minor_specific_stage` (frozen at 4 stages, now 2) and the two prompt budgets.

## Not done here

Nothing has yet **run** through the new shape. The estimates behind this — ~65 min and ~60–70k output tokens against #102's 5.6 h and 200,277 — are derived from the measured cost of what was removed, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)