### PR TITLE
plan-feature: hand it the six things it plans from, and stop hardcoding where they live

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
@@ -106,7 +106,7 @@ COMPLETION_PATTERN = routing.PR_URL_COMPLETION_ERE
 # components, and `sprint.md` lives in that same directory.
 FORBIDDEN_PATHS = (
     r"^docs/development/",      # "Write or edit ANY file under another component"
-    r"(^|/)sprints?\.md$",      # "Touch `sprint.md` at all" — also caught above,
+    r"(^|/)sprints?\.md$",      # "WRITE or edit `sprint.md`" — also caught above,
                                 #   stated separately because the prohibition is
                                 #   about the FILE and outlives this directory
     r"^docs/standards/",        # "...or anything else under `docs/standards/`"
@@ -241,8 +241,14 @@ MAY_NOT_OBSERVERS: dict[str, str] = {
         "over the new files AGAINST EACH OTHER by own.phase_identity, so two "
         "docs written in the same dispatch cannot both be phase 5 while "
         "`phase5a_` + `phase5b_` planned together stays legal",
-    "**Touch `sprint.md` at all** — you hold no authorization over it":
-        "FORBIDDEN_PATHS, via act.worktree_state / act.boundary_crossings",
+    "**WRITE or edit `sprint.md`** — read it, never touch it":
+        "FORBIDDEN_PATHS, via act.worktree_state / act.boundary_crossings — which "
+        "compares CONTENT either side of the run, so it observes every write and "
+        "is blind to a read BY CONSTRUCTION. That is the right instrument for the "
+        "reworded rule: the run is now told to READ the sprint (Stage 1 item 9) "
+        "because it must name the entry this component needs, and a proposal into "
+        "a sequence nobody has seen is a guess. Reading leaves no artifact, so "
+        "nothing here needs to permit it and nothing can mistake it for a write.",
     "Write or edit anything under ANOTHER component, or under your own `research/`":
         "FORBIDDEN_PATHS `^docs/development/` less permitted_paths, whose first "
         "grant is `<component>/[^/]+\\.md$` and so reaches no subdirectory",

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
@@ -21,7 +21,7 @@ ${RESEARCH_INVENTORY}
 | Create a NEW `phaseN_<name>.md` in `${COMPONENT_PATH}/` | **Rename, renumber or delete an existing phase doc** — the number is IDENTITY |
 | Edit a phase doc **you created in this run** | Give a NEW phase doc a name outside `phaseN_<name>.md` |
 | Re-order phase entries **within `roadmap.md`** | Give a NEW phase a number already used in this component |
-| Append a proposal row to the candidates file | **Touch `sprint.md` at all** — you hold no authorization over it |
+| Append a proposal row to the candidates file | **WRITE or edit `sprint.md`** — read it, never touch it |
 | Name the `component` on a row YOU append | Write or edit anything under ANOTHER component, or under your own `research/` |
 | | **Tick a completion checkbox** — you have built nothing |
 | | Set `decision`, `status`, or another filer's `component` in the candidates file |
@@ -63,7 +63,9 @@ Sizing belongs to `plan-verify`, the fresh-context reviewer that reads what you 
 
 The sprint plan is the operator's cross-domain sequencing surface, and the standing rule is that dispatches never write it. `plan-sprint` carries a specific, bounded override for it; **you do not.**
 
-**This component almost certainly needs a sprint entry, and naming it is your job — writing it is not.** Say in your report what entry it needs and why, in one or two sentences, and stop. It lands by operator edit.
+**READ IT ANYWAY — the prohibition is on writing, and reading is what makes the prohibition workable.** It is the only surface showing what else is being built and in what order, so it is how you avoid planning work another component already owns.
+
+**This component almost certainly needs a sprint entry, and naming it is your job — writing it is not.** Say in your report what entry it needs and why, in one or two sentences, and stop. It lands by operator edit. **Naming a sensible one requires having read the sequence you are proposing into**, which is the whole reason the read grant above exists.
 
 ### Everything else in that column, and exactly what checks it
 
@@ -94,11 +96,18 @@ Read, in this order, and do not skip any:
 
 1. **`${COMPONENT_PATH}/research/synthesis.md`** — your PRIMARY evidence, and the document this step exists to consume. **DO NOT READ THE RAW PAPERS wholesale.** The Research Standard is explicit that downstream consumers take the synthesis and never the pool. Open a paper only when a specific phase cannot be written without it, and say in your report which one and why.
 2. **Everything already in `${COMPONENT_PATH}/`** — the state is counted for you above. If a `roadmap.md` exists you are EXTENDING, not starting.
-3. **`docs/standards/architecture/problem-statement.md`** — the thesis and the differentiators. **You never edit this.** A plan that does not serve the thesis is a well-formed plan for something nobody needed.
-4. **`docs/standards/architecture/architectural_standard.md`** — the binding vocabulary and the seams. A phase that violates a seam is a phase to redesign, and the reason is the seam.
-5. **`docs/standards/architecture/stack_reference.md`** — what we run on and **what we deliberately do not**. Note its "What we do NOT use" section.
-6. **`docs/standards/documentation/documentation_standard.md`** — § *Development Planning Files* for the two artifact shapes, and § *Phase Numbering and Roadmap Ordering* which is **binding** and is where the identity-versus-order rule above comes from.
-7. **Any SIBLING component this one depends on** — read-only. A dependency you cannot name is a dependency that will surface as a blocked phase later.
+3. **`docs/file_structure.txt`** — the annotated map of the repo, and **read it EARLY: it is how you find everything below without guessing a path.** Read the root `CLAUDE.md` beside it; that chain is what names which standards bind in THIS repo.
+4. **The PROJECT-level research pool and its synthesis** — normally `docs/standards/architecture/research/`, confirm against the map. This is what the project as a whole has established: the direction, the settled questions, the problem statement's evidence. **Your component's synthesis is the local evidence; this is the frame it sits in.** Read it so a phase you write does not contradict — or quietly re-derive — something the project already settled at a higher altitude.
+5. **`docs/standards/architecture/problem-statement.md`** — the thesis and the differentiators. **You never edit this.** A plan that does not serve the thesis is a well-formed plan for something nobody needed.
+6. **`docs/standards/architecture/architectural_standard.md`** — the binding vocabulary and the seams. A phase that violates a seam is a phase to redesign, and the reason is the seam.
+7. **`docs/standards/architecture/stack_reference.md`** — what we run on and **what we deliberately do not**. Note its "What we do NOT use" section.
+8. **`docs/standards/documentation/documentation_standard.md`** — § *Development Planning Files* for the two artifact shapes, and § *Phase Numbering and Roadmap Ordering* which is **binding** and is where the identity-versus-order rule above comes from.
+9. **`sprint.md` — READ IT. You may not write it; that is exactly why you must read it.** It is the only place that shows what else is being built and in what order. **Read it to avoid planning work another component already owns, and to see what this component would sit beside** — Stage 4 requires you to name the sprint entry this component needs, and you cannot propose a position in a sequence you have never seen. Its path is in the map above if it is not `docs/development/sprint.md`.
+10. **Any SIBLING component this one depends on** — read-only. A dependency you cannot name is a dependency that will surface as a blocked phase later.
+
+**PATHS 3–9 ARE WHERE THEY USUALLY ARE, NOT WHERE THEY MUST BE.** This workflow runs against whatever repo `--repo` names. Confirm each against `docs/file_structure.txt` and the `CLAUDE.md` chain, and use the repo's equivalent when a path differs. **If one genuinely does not exist here, say so in your report and name what you planned that phase on instead** — do not silently plan from priors, and do not stop unless the missing document is the synthesis itself.
+
+**YOU HAVE `WebSearch` AND `WebFetch`, AND YOU ARE EXPECTED TO USE THEM.** You are designing against real systems. When a phase turns on how a tool, protocol or vendor API actually behaves, **read the official documentation rather than planning from memory** — a plan built on a misremembered API is a plan whose first build phase discovers it. Cite what you looked up in the phase doc. **This does not license fresh research:** the synthesis is your evidence and settles WHAT to build; the web settles mechanical facts about HOW something works. If a phase needs a question researched rather than a fact looked up, that is a finding for your report, not a research cycle you run here.
 
 ${EVIDENCE_BLOCK}
 

--- a/scripts/workflows/temporal/scripts/run_research_minor.py
+++ b/scripts/workflows/temporal/scripts/run_research_minor.py
@@ -1,4 +1,4 @@
-"""Kickoff entrypoint for research-minor — ONE paper, no synthesis.
+"""Kickoff entrypoint for research-minor — ONE topic, ONE paper, plus a synthesis.
 
 A SEPARATE ENTRY RATHER THAN A `--minor` FLAG ON `run_research.py`, for the same
 reason `run_build_minor.py` sits beside `run_build.py`: the two dispatch
@@ -24,7 +24,7 @@ BANNER = "=" * 64
 def main(argv=None) -> int:
     p = RepoPathParser(
         prog="research-minor",
-        description="Research ONE question as ONE paper. No topic list, no synthesis.",
+        description="Research ONE topic as ONE paper, plus the synthesis a planner reads. No topic list, no fan-out.",
     )
     # DECLARED AS A REPO PATH, with `must_exist=False`. See `run_research.py` for
     # both halves: the pool was joined onto `repo_root` unchecked, and this family
@@ -54,7 +54,7 @@ def main(argv=None) -> int:
         if a.dry_run:
             table, due = act.paper_currency(research_dir)
             print(f"{BANNER}\n  DRY RUN — nothing invoked, nothing posted\n{BANNER}")
-            print("  Mode      : research-minor (ONE paper, no synthesis)")
+            print("  Mode      : research-minor (ONE topic -> ONE paper + synthesis)")
             print(f"  Pool      : {research_dir}")
             print(f"  Existing  : {len(due)} of the papers present are past their window")
             for d in due:

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -142,7 +142,19 @@ BUDGETS: dict[str, int] = {
     # prompt forbids, answers the question this run cannot ask of itself — and
     # that changes what the model writes, which is this table's own bar for a
     # raise. Measured with `wc -c`, in BYTES.
-    "plan/plan_feature/prompts/plan_feature.md": 18_051,
+    # 18_051 -> 20820: the six inputs this child was never handed. It already got
+    # the synthesis (PRIMARY) and the raw pool to backtrack into. It did NOT get
+    # docs/file_structure.txt, the CLAUDE.md chain, the PROJECT-level research
+    # pool, or sprint.md — the last one named five times as a prohibition and
+    # never as a read, while Stage 4 requires it to propose the sprint entry this
+    # component needs. A proposal into a sequence nobody has seen is a guess.
+    # Also: WebSearch/WebFetch were granted by --dangerously-skip-permissions and
+    # never mentioned, so a run designing against a real API planned from memory;
+    # and four standards paths were hardcoded in a workflow that takes --repo.
+    # The correction path is what makes these load-bearing rather than nice: a
+    # plan-project loop-back goes to plan-sprint, so a defect in THIS child's
+    # output may not be fixable downstream at all.
+    "plan/plan_feature/prompts/plan_feature.md": 20820,
     # 15_510 -> 13_204: the `research-analyst` re-dispatch is gone. The verify
     # child holds Write/Edit and applies the critic's findings itself, so the
     # rules that existed only to coordinate a second writing agent went with it


### PR DESCRIPTION
TRACED FIRST, because it changes how much these matter. `plan_project`'s
loop-back goes to `plan-sprint` — not to `plan-feature`, not to triage — on the
argument that plan-sprint is the last producer and sees the whole PR. The code
already records that the argument is incomplete: a runway naming a component's
SYNTHESIS is not something plan-sprint can close either, so "the loop spends its
full budget on the one child that is reachable and reports SPENT."

So a defect in THIS child's roadmap or phase docs may not be correctable
downstream at any price. Its inputs are load-bearing in a way BUILD's and
RESEARCH's were not, where a cheap repair child exists. (Routing the loop-back
by what the runway names is already a placed candidate; this commit does not
re-file it.)

WHAT IT ALREADY HAD, and both are right:
  * the component synthesis, named PRIMARY, "the document this step exists to
    consume", with an explicit DO-NOT-READ-THE-RAW-PAPERS-WHOLESALE rule and a
    backtrack route: open one when a phase cannot be written without it, and say
    which and why.
  * PLANNING_STATE and RESEARCH_INVENTORY, computed and injected rather than
    left to be derived.

WHAT IT DID NOT HAVE:
  * `docs/file_structure.txt` and the root `CLAUDE.md` — zero occurrences. The
    map is how it finds everything else; the chain is what names which standards
    bind in THIS repo.
  * The PROJECT-level research pool and its synthesis — zero occurrences. It saw
    only its own component's evidence, so a phase could contradict or quietly
    re-derive something settled at a higher altitude. This is the same rule
    research-minor gained this morning: reference what is there, do not reproduce
    it.
  * `sprint.md` — named five times, EVERY ONE a prohibition, with no path and no
    read instruction, while Stage 4 requires it to name the sprint entry this
    component needs. A proposal into a sequence nobody has seen is a guess. The
    read grant is what makes the write prohibition workable, not a softening of
    it; the authorization row now reads WRITE-or-edit rather than "touch at all".
  * The web. `run-claude.sh` passes --dangerously-skip-permissions so WebSearch
    and WebFetch were always available, and the prompt never mentioned them — so
    a run designing against a real API planned from memory. Bounded deliberately:
    the web settles mechanical facts about HOW something works, the synthesis
    settles WHAT to build, and a phase needing a question RESEARCHED is a finding
    rather than a research cycle run here.

PORTABILITY. Four standards paths were hardcoded in a workflow whose entrypoint
takes --repo. They now carry research-minor's discovery-with-fallback shape:
confirm against the map and the CLAUDE.md chain, use the repo's equivalent, and
if one genuinely does not exist say what you planned that phase on instead —
rather than silently planning from priors.

THE AUTHORIZATION MECHANISM CAUGHT THE REWORDING, which is the best thing in
this family: `test_authorization_is_observed` failed on both halves — a
prohibition with no registered observer, and an observer for a prohibition that
was gone — and told me to re-answer "what observes this?" rather than rename the
key. The answer is better than the old one: content comparison observes every
write and is blind to a read BY CONSTRUCTION, which is exactly the instrument
the reworded rule wants.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

## Scorecard against what was asked for

| # | Input | Before | After |
|---|---|---|---|
| 1 | the synthesis | ✅ already PRIMARY | unchanged |
| 2 | where the feature research lives, to backtrack | ✅ already right | unchanged |
| 3 | web search for official docs | ⚠️ granted, never mentioned | ✅ stated + bounded |
| 4 | project research + synthesis + problem statement | ⚠️ half | ✅ pool added |
| 5 | read the sprint to avoid duplicate work | ❌ 5 prohibitions, no read | ✅ read grant |
| 6 | `file_structure.txt` to find everything | ❌ zero occurrences | ✅ + `CLAUDE.md` |

Plus the portability fix — `--repo` means this runs against repos laid out differently, and four paths were literal.

## Not done here

**Nothing has run.** `plan-feature` has **zero** executions and its turn cap says `NOT MEASURED — an estimate, stated as one`. This is a structural pass, not an efficiency one — there is no cost to optimise yet, and the first run is the measurement.

`1827 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)