### PR TITLE
plan-feature: give it a --task-file, because it could not be TOLD anything

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
@@ -166,7 +166,7 @@ def permitted_paths(component_rel: Path, candidates_rel: Path) -> tuple[str, ...
 
 
 def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
-                  pr_number: str | None) -> dict[str, str]:
+                  pr_number: str | None, context: str = "") -> dict[str, str]:
     """Every placeholder the prompt takes, assembled ONCE for both callers.
 
     THE DRY RUN AND THE REAL RUN MUST RENDER THE SAME PROMPT, and this exists so
@@ -194,6 +194,19 @@ def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
         "EVIDENCE_BLOCK": act.evidence_block(tree),
         "SUBMIT_PROMPT": act.submit_prompt(
             pr_number, f"plan-feature: plan {rel_component.name}"),
+        # OPAQUE, and rendered verbatim. Before this existed `--pr` could push to
+        # a branch and could not be TOLD why it was re-running, so this child had
+        # no correction path at all: `plan_project`'s loop-back goes to
+        # `plan-sprint`, which cannot edit a roadmap or a phase doc. A producer
+        # nothing can instruct is a producer whose only repair is a full re-plan.
+        "TASK_CONTEXT": (
+            "## OPERATOR CONTEXT FOR THIS RUN\n\n"
+            "**This is authoritative and overrides your own reading where they "
+            "disagree** — it is the operator speaking, not another run's account. "
+            "Verify any FACT it asserts about the tree before building on it, the "
+            "same as any other claim.\n\n" + context
+            if context.strip() else ""
+        ),
         "DECISION_LOG_AND_REFLECTION": act.shared_prompt("decision_log_and_reflection"),
         "HEADLESS_EXECUTION_GUARD": act.shared_prompt("headless_execution_guard"),
     }
@@ -335,7 +348,7 @@ DISAPPEARANCE_OBSERVERS: dict[str, str] = {
 
 def run_plan_feature(*, repo_root: Path, worktree: Path, component: Path,
                      candidates_path: Path, pr_number: str | None = None,
-                     verbose: bool = False) -> str:
+                     context: str = "", verbose: bool = False) -> str:
     """Plan ONE component: its roadmap and its phase docs. Returns the PR URL."""
     # Paths arrive rooted at the REPO because that is where they are configured,
     # but the run reads and writes inside the WORKTREE. Resolve once, count what
@@ -358,10 +371,12 @@ def run_plan_feature(*, repo_root: Path, worktree: Path, component: Path,
     before_hours = own.hour_hits(wt_component)
     before_tree = act.worktree_state(worktree)
 
-    values = prompt_values(rel_component, rel_candidates, worktree, pr_number)
+    values = prompt_values(rel_component, rel_candidates, worktree, pr_number,
+                           context)
 
     output = act.run_claude(
-        act.render(act.load_prompt(PROMPTS / "plan_feature.md"), values),
+        act.render(act.load_prompt(PROMPTS / "plan_feature.md"), values,
+                   opaque=frozenset({"TASK_CONTEXT"})),
         model_key=MODEL_KEY, workflow_key=WORKFLOW_KEY,
         completion_pattern=COMPLETION_PATTERN,
         repo_root=repo_root, worktree=worktree,

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
@@ -5,6 +5,8 @@ Your job is to **write ONE component's `roadmap.md` and its phase docs, from tha
 Component:  ${COMPONENT_PATH}
 Candidates: ${CANDIDATES_PATH}
 
+${TASK_CONTEXT}
+
 ${PLANNING_STATE}
 
 ${RESEARCH_INVENTORY}

--- a/scripts/workflows/temporal/scripts/run_plan_feature.py
+++ b/scripts/workflows/temporal/scripts/run_plan_feature.py
@@ -48,6 +48,11 @@ def main(argv=None) -> int:
     p.add_argument("--repo", dest="repo_target", help="target repo — a FILESYSTEM PATH, never a gh slug")
     p.add_repo_path("--candidates", default=DEFAULT_CANDIDATES)
     p.add_argument("--pr", dest="pr_number", help="update an existing plan-feature PR")
+    # NOT a repo path, deliberately — operator context from wherever they wrote it,
+    # the same contract `run_research_minor.py` uses. Without this the `--pr` path
+    # could push to a branch and could not be TOLD why it was re-running.
+    p.add_argument("--task-file", dest="task_file",
+                   help="operator context or a correction runway, from a file")
     p.add_argument("--verbose", "-v", action="store_true")
     p.add_argument("--dry-run", action="store_true", help="count and render; no model, no spend")
 
@@ -58,6 +63,7 @@ def main(argv=None) -> int:
         print(f"\n✗ {exc}", file=sys.stderr)
         return 1
     component, cands = resolved["component"], resolved["candidates"]
+    context = Path(a.task_file).read_text() if a.task_file else ""
 
     try:
         if a.dry_run:
@@ -68,6 +74,8 @@ def main(argv=None) -> int:
                   f"roadmap.md {'present' if (component / 'roadmap.md').is_file() else 'ABSENT'}")
             print(f"  Max turns  : {wf.MAX_TURNS} (estimate — nothing has measured this workflow)")
             print(f"  Grants     : {', '.join(wf.permitted_paths(rel, cands.relative_to(repo_root)))}")
+            print(f"  Context    : {len(context.encode())} bytes from --task-file"
+                  if context else "  Context    : none (--task-file not given)")
             # THE SAME ASSEMBLY THE LIVE RUN USES, called rather than copied. A
             # dry run that builds its own values dict previews a prompt that is
             # not the one dispatched — the family has shipped that bug once
@@ -75,7 +83,9 @@ def main(argv=None) -> int:
             # checking the wrong artifact is worse than checking none.
             rendered = act.render(
                 act.load_prompt(wf.PROMPTS / "plan_feature.md"),
-                wf.prompt_values(rel, cands.relative_to(repo_root), repo_root, None))
+                wf.prompt_values(rel, cands.relative_to(repo_root), repo_root,
+                                 a.pr_number, context),
+                opaque=frozenset({"TASK_CONTEXT"}))
             print(f"  Prompt     : {len(rendered.encode())} bytes rendered, 0 placeholders remaining")
             return 0
 
@@ -93,7 +103,8 @@ def main(argv=None) -> int:
         worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
         url = wf.run_plan_feature(repo_root=repo_root, worktree=worktree,
                                   component=component, candidates_path=cands,
-                                  pr_number=a.pr_number, verbose=a.verbose)
+                                  pr_number=a.pr_number, context=context,
+                                  verbose=a.verbose)
     except (RuntimeError, FileNotFoundError, ValueError) as exc:
         # These carry operator-facing recovery instructions from the layer that
         # knew what failed. Do not wrap or reformat them.

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -159,7 +159,7 @@ BUDGETS: dict[str, int] = {
     # first run produced six for a component with small remaining work, said in
     # its own report that two should probably be one, named which two, and shipped
     # six anyway — the verb did not exist.
-    "plan/plan_feature/prompts/plan_feature.md": 21_828,
+    "plan/plan_feature/prompts/plan_feature.md": 21845,  # +${TASK_CONTEXT} placeholder
     # 15_510 -> 13_204: the `research-analyst` re-dispatch is gone. The verify
     # child holds Write/Edit and applies the critic's findings itself, so the
     # rules that existed only to coordinate a second writing agent went with it


### PR DESCRIPTION
`--pr` changed where the run PUSHED and nothing else. There was no way to hand
this child a correction runway, operator context, or a ruling — no --task-file
on the runner, no placeholder in the prompt.

That is why this child has no correction path. plan_project's loop-back goes to
plan-sprint, which cannot edit a roadmap or a phase doc, and the code already
says so: 'the loop spends its full budget on the one child that is reachable and
reports SPENT.' A producer nothing can instruct is a producer whose only repair
is a full re-plan at full price.

Found by trying to run the correction pass the operator's four rulings called
for, and discovering there was no argument to pass them in.

Same contract run_research_minor.py already uses: --task-file is NOT a repo path
(operator context from wherever they wrote it), rendered through the opaque set
so ${...} inside it is never treated as a placeholder, and stated in the prompt
as authoritative-but-still-checkable — the operator speaking, not another run's
account, with asserted FACTS still verified against the tree.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Found while trying to execute the correction pass for PR #111 — there was no argument to pass the operator's rulings in.

`1828 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)