### PR TITLE
plan family: a --pr pass must start from the PR, not from main

### DIFF
--- a/scripts/workflows/temporal/scripts/run_plan_feature.py
+++ b/scripts/workflows/temporal/scripts/run_plan_feature.py
@@ -100,7 +100,18 @@ def main(argv=None) -> int:
                              workflow_key="plan-feature",
                              worktree_name=worktree_name)
 
-        worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
+        # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
+        # "HEAD" put the run on `main`, so a correction pass opened a worktree
+        # with none of the PR's files in it. Measured on plan-feature's first
+        # correction pass: the counted-in-code block reported "0 phase doc(s)"
+        # — true of the worktree it was handed, false of the four docs it was
+        # told to correct — and the run spent turns fetching and checking out
+        # the branch itself before it could begin. All four `--pr`-accepting
+        # plan runners had the same line; `research_minor_workflow.py` already
+        # had the right one and is where this expression comes from.
+        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+               if a.pr_number else "HEAD")
+        worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_feature(repo_root=repo_root, worktree=worktree,
                                   component=component, candidates_path=cands,
                                   pr_number=a.pr_number, context=context,

--- a/scripts/workflows/temporal/scripts/run_plan_sprint.py
+++ b/scripts/workflows/temporal/scripts/run_plan_sprint.py
@@ -76,7 +76,18 @@ def main(argv=None) -> int:
                              workflow_key="plan-sprint",
                              worktree_name=worktree_name)
 
-        worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
+        # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
+        # "HEAD" put the run on `main`, so a correction pass opened a worktree
+        # with none of the PR's files in it. Measured on plan-feature's first
+        # correction pass: the counted-in-code block reported "0 phase doc(s)"
+        # — true of the worktree it was handed, false of the four docs it was
+        # told to correct — and the run spent turns fetching and checking out
+        # the branch itself before it could begin. All four `--pr`-accepting
+        # plan runners had the same line; `research_minor_workflow.py` already
+        # had the right one and is where this expression comes from.
+        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+               if a.pr_number else "HEAD")
+        worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_sprint(repo_root=repo_root, worktree=worktree, sprint_path=sprint,
                                  candidates_path=cands, research_dir=research,
                                  pr_number=a.pr_number, verbose=a.verbose)

--- a/scripts/workflows/temporal/scripts/run_plan_verify.py
+++ b/scripts/workflows/temporal/scripts/run_plan_verify.py
@@ -126,7 +126,18 @@ def main(argv=None) -> int:
                              workflow_key="plan-verify",
                              worktree_name=worktree_name)
 
-        worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
+        # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
+        # "HEAD" put the run on `main`, so a correction pass opened a worktree
+        # with none of the PR's files in it. Measured on plan-feature's first
+        # correction pass: the counted-in-code block reported "0 phase doc(s)"
+        # — true of the worktree it was handed, false of the four docs it was
+        # told to correct — and the run spent turns fetching and checking out
+        # the branch itself before it could begin. All four `--pr`-accepting
+        # plan runners had the same line; `research_minor_workflow.py` already
+        # had the right one and is where this expression comes from.
+        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+               if a.pr_number else "HEAD")
+        worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_verify(repo_root=repo_root, worktree=worktree,
                                  component=component, candidates_path=cands,
                                  pr_number=a.pr_number, verbose=a.verbose)

--- a/scripts/workflows/temporal/scripts/run_triage_candidates.py
+++ b/scripts/workflows/temporal/scripts/run_triage_candidates.py
@@ -62,7 +62,18 @@ def main(argv=None) -> int:
                              workflow_key="triage-candidates",
                              worktree_name=worktree_name)
 
-        worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
+        # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
+        # "HEAD" put the run on `main`, so a correction pass opened a worktree
+        # with none of the PR's files in it. Measured on plan-feature's first
+        # correction pass: the counted-in-code block reported "0 phase doc(s)"
+        # — true of the worktree it was handed, false of the four docs it was
+        # told to correct — and the run spent turns fetching and checking out
+        # the branch itself before it could begin. All four `--pr`-accepting
+        # plan runners had the same line; `research_minor_workflow.py` already
+        # had the right one and is where this expression comes from.
+        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+               if a.pr_number else "HEAD")
+        worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_triage_candidates(repo_root=repo_root, worktree=worktree,
                                        candidates_path=cands, research_dir=research,
                                        pr_number=a.pr_number, verbose=a.verbose)

--- a/scripts/workflows/temporal/tests/unit/test_plan_feature.py
+++ b/scripts/workflows/temporal/tests/unit/test_plan_feature.py
@@ -827,3 +827,36 @@ def test_the_first_time_path_is_UNCHANGED(tmp_path) -> None:
     c.mkdir()
     assert own.taken_phase_numbers(c) == set()
     assert "Numbering starts at `phase1_`" in own.planning_state(c, tmp_path)
+
+
+def test_every_pr_accepting_plan_runner_bases_its_worktree_ON_THE_PR() -> None:
+    """A `--pr` pass must open its worktree on the PR's branch, not on `main`.
+
+    ALL FOUR HAD THE SAME LINE. `worktree_add(..., "HEAD")` is correct for a
+    fresh run and wrong for a correction pass, and nothing distinguished them —
+    so `--pr` changed where the run PUSHED and never where it STARTED.
+
+    Measured on plan-feature's first correction pass: the counted-in-code block
+    reported "0 phase doc(s)", true of the worktree it was handed and false of
+    the four documents it was told to correct. The run detected the mismatch,
+    fetched the branch and checked it out itself, and said so in its reflection.
+    A run rescuing itself from its own harness is not a control.
+
+    Asserted over a DISCOVERED set rather than a list, so a fifth runner that
+    gains `--pr` is covered on the day it does.
+    """
+    scripts = Path(__file__).resolve().parents[2] / "scripts"
+    offenders = []
+    for p in sorted(scripts.glob("run_*.py")):
+        src = p.read_text()
+        if '"--pr"' not in src:
+            continue                      # a runner with no --pr cannot have the bug
+        if 'worktree_add(repo_root, worktree_name, "HEAD")' in src:
+            offenders.append(p.name)
+    assert not offenders, (
+        "these runners accept --pr and still base the worktree on HEAD, so a "
+        "correction pass starts from the default branch with none of the PR's "
+        "work in it:\n  " + "\n  ".join(offenders)
+        + "\n\nDerive the ref instead:\n"
+        '    ref = f"origin/{act.branch_of(a.pr_number, repo_root)}" if a.pr_number else "HEAD"'
+    )


### PR DESCRIPTION
ALL FOUR --pr-ACCEPTING PLAN RUNNERS HAD THE SAME LINE:

    worktree = act.worktree_add(repo_root, worktree_name, "HEAD")

Correct for a fresh run, wrong for a correction pass, and nothing distinguished
them — so `--pr` changed where a run PUSHED and never where it STARTED.

MEASURED on plan-feature's first correction pass. The worktree was opened on
`main`, so the counted-in-code block reported "0 phase doc(s)" — true of the
worktree it was handed, false of the four documents it was told to correct. The
operator context and the injected count contradicted each other, and each was
right about a different tree. The run detected it, fetched the branch and
checked it out itself before starting, and reported the friction. A run
rescuing itself from its own harness is not a control, and the next run might
not notice.

`research_minor_workflow.py` already had the right expression; this is that
line, applied to the four that did not.

The guard asserts over a DISCOVERED set — any `run_*.py` carrying `--pr` — so a
fifth runner that gains the flag is covered the day it does. Mutation-tested:
reintroducing "HEAD" in one runner turns it red.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Mined from the plan-feature correction pass. `1831 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)