### PR TITLE
plan-verify: give the reviewer what the planner reads, and a way to be told things

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
@@ -136,7 +136,7 @@ COMPLETION_PATTERN = routing.PR_URL_COMPLETION_ERE
 # coupling worth having, and it is per-workflow by construction.
 FORBIDDEN_PATHS = (
     r"^docs/development/",      # "Edit a phase doc, or anything under another component"
-    r"(^|/)sprints?\.md$",      # "Touch `sprint.md` at all" — also caught above,
+    r"(^|/)sprints?\.md$",      # "WRITE or edit `sprint.md`" — also caught above,
                                 #   stated separately because the prohibition is
                                 #   about the FILE and outlives this directory
     r"^docs/standards/",        # "...or anything else under `docs/standards/`"
@@ -191,7 +191,7 @@ def permitted_paths(component_rel: Path, candidates_rel: Path) -> tuple[str, ...
 
 
 def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
-                  pr_number: str | None) -> dict[str, str]:
+                  pr_number: str | None, context: str = "") -> dict[str, str]:
     """Every placeholder the prompt takes, assembled ONCE for both callers.
 
     THE DRY RUN AND THE REAL RUN MUST RENDER THE SAME PROMPT, and this exists so
@@ -214,6 +214,16 @@ def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
         # teaches the pool convention and names the thesis; `PLAN_INVENTORY` says
         # which plan is THIS run's, which the shared block cannot know.
         "EVIDENCE_BLOCK": act.evidence_block(tree),
+        # OPAQUE, rendered verbatim. Before this existed `--pr` changed where a
+        # run PUSHED and nothing else, so a correction pass could not be told why
+        # it was re-running — the same gap `plan-feature` had until 2026-08-19.
+        "TASK_CONTEXT": (
+            "## OPERATOR CONTEXT FOR THIS RUN\n\n"
+            "**This is authoritative and overrides your own reading where they "
+            "disagree** — it is the operator speaking, not another run's account. "
+            "Verify any FACT it asserts about the tree before building on it.\n\n"
+            + context if context.strip() else ""
+        ),
         "SUBMIT_PROMPT": act.submit_prompt(
             pr_number, f"plan-verify: size and judge {rel_component.name}"),
         "DECISION_LOG_AND_REFLECTION": act.shared_prompt("decision_log_and_reflection"),
@@ -260,7 +270,7 @@ MAY_NOT_OBSERVERS: dict[str, str] = {
         "own.roadmap_phase_links counted either side of the run and compared in "
         "BOTH directions — the one prohibition here that happens INSIDE the "
         "granted file, where act.boundary_crossings is blind by construction",
-    "**Touch `sprint.md` at all** — you hold no authorization over it":
+    "**WRITE or edit `sprint.md`** — read it (Stage 1), never touch it":
         "FORBIDDEN_PATHS, via act.worktree_state / act.boundary_crossings",
     "Write or edit anything under ANOTHER component, or under this one's `research/`":
         "FORBIDDEN_PATHS `^docs/development/` less permitted_paths, which grants "
@@ -343,7 +353,7 @@ DISAPPEARANCE_OBSERVERS: dict[str, str] = {
 
 def run_plan_verify(*, repo_root: Path, worktree: Path, component: Path,
                     candidates_path: Path, pr_number: str | None = None,
-                    verbose: bool = False) -> str:
+                    context: str = "", verbose: bool = False) -> str:
     """Read ONE component's plan cold, size it, judge it. Returns the PR URL."""
     # Paths arrive rooted at the REPO because that is where they are configured,
     # but the run reads and writes inside the WORKTREE. Resolve once, read what
@@ -375,10 +385,12 @@ def run_plan_verify(*, repo_root: Path, worktree: Path, component: Path,
     before_boxes = act.checked_boxes(wt_component / own.ROADMAP)
     before_tree = act.worktree_state(worktree)
 
-    values = prompt_values(rel_component, rel_candidates, worktree, pr_number)
+    values = prompt_values(rel_component, rel_candidates, worktree, pr_number,
+                           context)
 
     output = act.run_claude(
-        act.render(act.load_prompt(PROMPTS / "plan_verify.md"), values),
+        act.render(act.load_prompt(PROMPTS / "plan_verify.md"), values,
+                   opaque=frozenset({"TASK_CONTEXT"})),
         model_key=MODEL_KEY, workflow_key=WORKFLOW_KEY,
         completion_pattern=COMPLETION_PATTERN,
         repo_root=repo_root, worktree=worktree,

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
@@ -5,6 +5,8 @@ Your job is to **read ONE component's plan COLD, size every phase in hours, and 
 Component:  ${COMPONENT_PATH}
 Candidates: ${CANDIDATES_PATH}
 
+${TASK_CONTEXT}
+
 ${PLAN_INVENTORY}
 
 ---
@@ -25,7 +27,7 @@ ${PLAN_INVENTORY}
 | Add a short sizing note beside an estimate | **Write an hour estimate anywhere but `roadmap.md`** — one figure, one home |
 | Report a phase boundary you believe is wrong | **Rename, renumber or delete a phase doc** — the number is IDENTITY |
 | Report a phase resting on evidence that does not support it | **Re-plan the component** — add, merge, split or drop a phase |
-| Append a proposal row to the candidates file | **Touch `sprint.md` at all** — you hold no authorization over it |
+| Append a proposal row to the candidates file | **WRITE or edit `sprint.md`** — read it (Stage 1), never touch it |
 | Name the `component` on a row YOU append | Write or edit anything under ANOTHER component, or under this one's `research/` |
 | | **Tick a completion checkbox** — nothing has been built |
 | | Set `decision`, `status`, or another filer's `component` in the candidates file |
@@ -89,6 +91,15 @@ Read, in this order, and do not skip any:
 3. **`docs/standards/architecture/problem-statement.md`** — the thesis. A plan that does not serve it is a well-formed plan for something nobody needed.
 4. **`docs/standards/architecture/architectural_standard.md`** — the binding seams. A phase that violates one is a finding with a named reason.
 5. **`docs/standards/documentation/documentation_standard.md`** — § *Development Planning Files* and § *Phase Numbering and Roadmap Ordering*, which is binding.
+6. **`docs/standards/architecture/stack_reference.md`** — what we run on and, in its *"What we do NOT use"* section, what we have deliberately ruled out. **A phase planned on something in that list is a finding no other reader is positioned to catch**, and sizing a phase built on the wrong stack produces a confident number for work that will not happen.
+7. **`docs/file_structure.txt`** — the annotated map, and the root `CLAUDE.md` beside it. The map is how you find everything above without guessing a path, and it is also direct sizing evidence: how many files a subsystem already holds tells you more about the cost of changing it than the phase's prose does.
+8. **The PROJECT-level research pool and its synthesis** — normally `docs/standards/architecture/research/`, confirm against the map. Question 4 asks whether a phase's evidence supports it; a phase can also rest on something the project settled differently at a higher altitude, and only this shows you that.
+9. **`docs/development/sprint.md` — READ IT, and it is READ-ONLY.** You are producing the numbers that feed it, against a sprint calibration, and you cannot judge whether a phase is sized like the work around it without seeing that work. **You may never write it** — see the authorization table.
+10. **Any SIBLING component this plan depends on** — read-only. A dependency the plan names and cannot deliver against is a gate, not a phase.
+
+**PATHS 3–9 ARE WHERE THEY USUALLY ARE, NOT WHERE THEY MUST BE.** This workflow runs against whatever repo `--repo` names. Confirm each against `docs/file_structure.txt` and the `CLAUDE.md` chain, and use the repo's equivalent where a path differs. **If one does not exist here, say so in your report and say what you judged that phase against instead** — never judge silently against a document you could not open.
+
+**YOU HAVE `WebSearch` AND `WebFetch`, AND SIZING IS WHERE THEY EARN THEIR KEEP.** *"How long does it take to build this against that vendor's API"* is usually answerable by reading the vendor's own documentation, and an estimate built on a misremembered API is confidently wrong in the direction nobody checks. Look it up, and say in your sizing note when a number rests on something you read rather than on something you know. **This does not license re-planning:** you are sizing and judging what is written, never researching what should have been written instead.
 
 ${EVIDENCE_BLOCK}
 

--- a/scripts/workflows/temporal/scripts/run_plan_verify.py
+++ b/scripts/workflows/temporal/scripts/run_plan_verify.py
@@ -44,6 +44,11 @@ def main(argv=None) -> int:
     p.add_argument("--repo", dest="repo_target", help="target repo — a FILESYSTEM PATH, never a gh slug")
     p.add_repo_path("--candidates", default=DEFAULT_CANDIDATES)
     p.add_argument("--pr", dest="pr_number", help="update an existing plan-verify PR")
+    # NOT a repo path, deliberately — operator context from wherever they wrote it,
+    # the same contract run_research_minor.py and run_plan_feature.py use. Without
+    # it a `--pr` pass can push and cannot be TOLD why it is re-running.
+    p.add_argument("--task-file", dest="task_file",
+                   help="operator context or a correction runway, from a file")
     p.add_argument("--verbose", "-v", action="store_true")
     p.add_argument("--dry-run", action="store_true", help="count and render; no model, no spend")
 
@@ -54,6 +59,7 @@ def main(argv=None) -> int:
         print(f"\n✗ {exc}", file=sys.stderr)
         return 1
     component, cands = resolved["component"], resolved["candidates"]
+    context = Path(a.task_file).read_text() if a.task_file else ""
 
     # REFUSED BEFORE ANYTHING IS CREATED, not diagnosed after a dispatch. There
     # is nothing here to verify without a plan, and the failure a run would
@@ -102,7 +108,9 @@ def main(argv=None) -> int:
             # checking the wrong artifact is worse than checking none.
             rendered = act.render(
                 act.load_prompt(wf.PROMPTS / "plan_verify.md"),
-                wf.prompt_values(rel, cands.relative_to(repo_root), repo_root, None))
+                wf.prompt_values(rel, cands.relative_to(repo_root), repo_root,
+                                 a.pr_number, context),
+                opaque=frozenset({"TASK_CONTEXT"}))
             # BYTES, VIA `.encode()`, AND NOT `len(str)`. The prompt-budget gate
             # measures with `path.stat().st_size`, so an operator comparing this
             # line against a budget is comparing two different units — and this
@@ -127,7 +135,7 @@ def main(argv=None) -> int:
                              worktree_name=worktree_name)
 
         worktree = act.worktree_add(repo_root, worktree_name, "HEAD")
-        url = wf.run_plan_verify(repo_root=repo_root, worktree=worktree,
+        url = wf.run_plan_verify(repo_root=repo_root, worktree=worktree, context=context,
                                  component=component, candidates_path=cands,
                                  pr_number=a.pr_number, verbose=a.verbose)
     except (RuntimeError, FileNotFoundError, ValueError) as exc:

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -188,7 +188,15 @@ BUDGETS: dict[str, int] = {
     # model is the only thing that can close it, and it could not while the
     # prompt told it the machine was already checking. This clears the gate's
     # own bar: it changes what the model DOES, and the harness cannot enforce it.
-    "plan/plan_verify/prompts/plan_verify.md": 13_142,
+    # 13_142 -> 15577: the reviewer was reading FIVE documents where the planner it
+    # judges reads ten. Three of the five it lacked bear directly on its own job:
+    # stack_reference's "what we do NOT use" (a phase planned on ruled-out tech is
+    # the finding no other reader is positioned to catch), sprint.md (it produces
+    # the numbers that feed the sprint, against a sprint calibration, having never
+    # seen one), and the web (sizing "build X against vendor Y's API" is answerable
+    # by reading Y's docs, and the grant was live but unmentioned). Plus
+    # ${TASK_CONTEXT}, so a --pr pass can be told why it is re-running.
+    "plan/plan_verify/prompts/plan_verify.md": 15577,
     # RATCHETED DOWN 14_437 -> 9_896, the other side of the same move. It stays
     # above the FLOOR, so it keeps its line rather than dropping off the table.
     # Then 9_896 -> 9_908, the same twelve substituted-away bytes as above.


### PR DESCRIPTION
THE REVIEWER READ FIVE DOCUMENTS WHERE THE PLANNER IT JUDGES READS TEN. That
asymmetry is backwards: this child exists to answer the question the author
structurally cannot, and it was doing so with less context than the author had.

Three of the five it lacked bear directly on its own two jobs — size the phases,
say where the plan is weakest:

  * `stack_reference.md` and its "What we do NOT use" section. A phase planned
    on something we have ruled out is a finding NO OTHER READER is positioned to
    catch, and sizing such a phase produces a confident number for work that
    will not happen.
  * `sprint.md`, read-only. It produces the numbers that feed the sprint, judged
    against a sprint calibration, and had never seen a sprint. The authorization
    row now reads WRITE-or-edit rather than "touch at all" — reading is what
    makes the write prohibition workable, and the observer was re-answered
    rather than renamed: content comparison sees every write and is blind to a
    read by construction.
  * WebSearch/WebFetch. "How long to build this against that vendor's API" is
    usually answerable from the vendor's own docs, and an estimate resting on a
    misremembered API is confidently wrong in the direction nobody checks. The
    grant was already live via --dangerously-skip-permissions and unmentioned.

Also added: `docs/file_structure.txt` + the CLAUDE.md chain (how it finds the
rest, and direct sizing evidence — how many files a subsystem holds says more
about the cost of changing it than the phase's prose does), the PROJECT-level
research pool (a phase can rest on something settled differently at a higher
altitude, and only this shows it), and sibling components.

Paths carry the same discovery-with-fallback shape `plan-feature` gained: this
runs against whatever `--repo` names, and a missing document is reported rather
than silently judged around.

AND `--task-file`, the same gap plan-feature had until today: `--pr` changed
where a run PUSHED and nothing else, so a correction pass could not be told why
it was re-running.

Not touched: the estimate's consumer. `plan-verify` writes per-phase estimates
into roadmap.md and deliberately writes no total; `plan-sprint` is meant to sum
them into the sprint header and is never handed the roadmap nor told to. That is
a real break in the chain and it belongs to plan-sprint, which is the next child
to look at.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

`1831 passed, 3 skipped`. Renders at 30,021 bytes, 0 placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)