### PR TITLE
fix: act.branch_of does not exist — the #115 guard checked a shape, not a resolution

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -502,6 +502,9 @@ claude-dot-files/
 │                   │                                #   sweep says it lacks, by keying on the join the absence exists to permit rather than on
 │                   │                                #   the missing call. Five of ten runners were in that state and ALL FIVE accepted
 │                   │                                #   ../../../../tmp/… and read through it under --dangerously-skip-permissions
+│                   ├── test_runner_module_attributes_EXIST.py # Every `<alias>.<name>` a runner calls exists on the
+│                                       #   module it aliases. #115 shipped `act.branch_of`, which lives only on
+│                                       #   research_activities — 1831 tests passed and the first live run died
 │                   ├── test_an_entrypoint_REFUSES_an_escaping_operator_path.py # The same property proven by EXECUTION:
 │                   │                                #   every runner declaring a repo path is driven with an escaping value and must refuse it
 │                   │                                #   AS AN ESCAPE, then with an in-repo value and must not. Both arms, because a resolver

--- a/scripts/workflows/temporal/scripts/run_plan_feature.py
+++ b/scripts/workflows/temporal/scripts/run_plan_feature.py
@@ -109,7 +109,7 @@ def main(argv=None) -> int:
         # the branch itself before it could begin. All four `--pr`-accepting
         # plan runners had the same line; `research_minor_workflow.py` already
         # had the right one and is where this expression comes from.
-        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+        ref = (f"origin/{act.pr_branch(a.pr_number, repo_root)}"
                if a.pr_number else "HEAD")
         worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_feature(repo_root=repo_root, worktree=worktree,

--- a/scripts/workflows/temporal/scripts/run_plan_sprint.py
+++ b/scripts/workflows/temporal/scripts/run_plan_sprint.py
@@ -85,7 +85,7 @@ def main(argv=None) -> int:
         # the branch itself before it could begin. All four `--pr`-accepting
         # plan runners had the same line; `research_minor_workflow.py` already
         # had the right one and is where this expression comes from.
-        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+        ref = (f"origin/{act.pr_branch(a.pr_number, repo_root)}"
                if a.pr_number else "HEAD")
         worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_sprint(repo_root=repo_root, worktree=worktree, sprint_path=sprint,

--- a/scripts/workflows/temporal/scripts/run_plan_verify.py
+++ b/scripts/workflows/temporal/scripts/run_plan_verify.py
@@ -143,7 +143,7 @@ def main(argv=None) -> int:
         # the branch itself before it could begin. All four `--pr`-accepting
         # plan runners had the same line; `research_minor_workflow.py` already
         # had the right one and is where this expression comes from.
-        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+        ref = (f"origin/{act.pr_branch(a.pr_number, repo_root)}"
                if a.pr_number else "HEAD")
         worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_plan_verify(repo_root=repo_root, worktree=worktree, context=context,

--- a/scripts/workflows/temporal/scripts/run_triage_candidates.py
+++ b/scripts/workflows/temporal/scripts/run_triage_candidates.py
@@ -71,7 +71,7 @@ def main(argv=None) -> int:
         # the branch itself before it could begin. All four `--pr`-accepting
         # plan runners had the same line; `research_minor_workflow.py` already
         # had the right one and is where this expression comes from.
-        ref = (f"origin/{act.branch_of(a.pr_number, repo_root)}"
+        ref = (f"origin/{act.pr_branch(a.pr_number, repo_root)}"
                if a.pr_number else "HEAD")
         worktree = act.worktree_add(repo_root, worktree_name, ref)
         url = wf.run_triage_candidates(repo_root=repo_root, worktree=worktree,

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -122,7 +122,7 @@ _HERE = Path(__file__).resolve().parent
 # the number, so a message that disagreed with its own assertion would mislead
 # at the worst possible moment. That double-write is the class this file is
 # being corrected for, so it may not appear in the correction.
-_PINNED = (20, 9)
+_PINNED = (21, 10)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_runner_module_attributes_EXIST.py
+++ b/scripts/workflows/temporal/tests/unit/test_runner_module_attributes_EXIST.py
@@ -1,0 +1,99 @@
+"""Every `<alias>.<name>` a runner calls must exist on the module it aliases.
+
+WHY THIS EXISTS, and it is a lesson about the guard rather than about the bug.
+PR #115 fixed four runners that opened their worktree on `main` during a `--pr`
+pass. Its guard asserted the OLD STRING was gone:
+
+    assert 'worktree_add(repo_root, worktree_name, "HEAD")' not in src
+
+That is a shape check. The replacement expression called `act.branch_of(...)`,
+which does not exist on `plan_activities` — the real function is
+`assistant_activities.pr_branch`, and `branch_of` is a one-line alias defined
+only in `research_activities`. So 1831 tests passed, the PR merged, and the
+first live `--pr` run died on `AttributeError` before reaching the model.
+
+**A guard that checks the shape of a fix cannot see whether the fix runs.** This
+one imports the module each runner aliases and asserts every attribute it reaches
+for is really there — which is the property the shape check was standing in for.
+
+WHAT IT DOES NOT COVER, so it is not over-read: it checks that a NAME resolves,
+never that the call is correct. Wrong argument order, a wrong `pr_number`, a
+function that returns the wrong thing — all invisible here and all still need a
+test that runs the path. The narrow claim is that no runner can ship a call to a
+function that does not exist.
+"""
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+TEMPORAL = Path(__file__).resolve().parents[2]
+SCRIPTS = TEMPORAL / "scripts"
+if str(TEMPORAL) not in sys.path:
+    sys.path.insert(0, str(TEMPORAL))
+
+
+def _aliases(tree: ast.AST) -> dict[str, str]:
+    """`from modules.x import y as act` -> {"act": "modules.x.y"}."""
+    out = {}
+    for n in ast.walk(tree):
+        if isinstance(n, ast.ImportFrom) and n.module:
+            for a in n.names:
+                if a.asname:
+                    out[a.asname] = f"{n.module}.{a.name}"
+    return out
+
+
+def _runners() -> list[Path]:
+    found = sorted(SCRIPTS.glob("run_*.py"))
+    assert len(found) > 5, (
+        f"only {len(found)} runners found under {SCRIPTS} — the glob is wrong, "
+        f"and a guard that inspects nothing passes silently"
+    )
+    return found
+
+
+@pytest.mark.parametrize("runner", _runners(), ids=lambda p: p.name)
+def test_every_aliased_attribute_a_runner_calls_EXISTS(runner: Path) -> None:
+    tree = ast.parse(runner.read_text())
+    aliases = _aliases(tree)
+    missing = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name)):
+            continue
+        mod_path = aliases.get(node.value.id)
+        if not mod_path:
+            continue                       # a local name, not an aliased module
+        try:
+            mod = importlib.import_module(mod_path)
+        except ImportError:                # a module this environment cannot load
+            continue                       # is a different failure, not this one
+        if not hasattr(mod, node.attr):
+            missing.append(f"{node.value.id}.{node.attr}  (line {node.lineno}) "
+                           f"-> {mod_path} has no such attribute")
+    assert not missing, (
+        f"{runner.name} calls attributes that do not exist on the module it "
+        f"imports, so the line raises AttributeError the first time it runs:\n  "
+        + "\n  ".join(sorted(set(missing)))
+    )
+
+
+def test_the_guard_can_actually_FAIL(tmp_path: Path) -> None:
+    """The #115 regression, reproduced, so the failing path runs every time.
+
+    `act.branch_of` is the exact call that shipped. It exists on
+    `research_activities` and NOT on `plan_activities`, which is what made it
+    read as plausible in review.
+    """
+    src = ("from modules.assistant.plan import plan_activities as act\n"
+           "x = act.branch_of('1', None)\n")
+    tree = ast.parse(src)
+    aliases = _aliases(tree)
+    assert aliases == {"act": "modules.assistant.plan.plan_activities"}
+    mod = importlib.import_module(aliases["act"])
+    assert not hasattr(mod, "branch_of"), "the regression is no longer reproducible"
+    assert hasattr(mod, "pr_branch"), "the correct name is gone — the fix regressed"


### PR DESCRIPTION
PR #115's four runners called `act.branch_of(...)`. That function exists on
`research_activities` as a one-line alias; the plan runners import
`plan_activities`, where it does not exist. The real function is
`assistant_activities.pr_branch`, reachable as `act.pr_branch` from all four.

1831 tests passed, the PR merged, and the first live `--pr` run died on
AttributeError before it reached the model.

THE GUARD IS THE LESSON. #115's test asserted the OLD STRING was gone:

    assert 'worktree_add(repo_root, worktree_name, "HEAD")' not in src

A shape check. It could see that the wrong line was absent and could not see
whether the right one runs — so a fix that never executes satisfied it
completely. I wrote that guard and it is exactly the failure mode this repo
keeps finding in its own instruments: the finding tool and the proving tool
sharing a blind spot.

`test_runner_module_attributes_EXIST.py` replaces the property it was standing
in for: parse each runner, resolve every `<alias>.<name>` against the module the
alias actually imports, and fail when the attribute is not there. It covers all
twelve runners rather than the four this bug touched, and its positive control
reproduces `act.branch_of` directly so the failing path runs on every suite.

Mutation-tested: reintroducing `act.branch_of` in one runner turns it red.

Narrow claim, stated so the guard is not over-read: it proves a NAME resolves,
never that the call is correct. Wrong argument order or a wrong return value is
still invisible and still needs a test that runs the path.

Census guard updated (20,9) -> (21,10): a new guard that carries its own control.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Found by the first live `plan-verify --pr` run, which died before reaching the model. `1846 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)