### PR TITLE
plan family: promote the candidate-filing procedure, and say what a COMPLETE phase gets sized at

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_workflow.py
@@ -192,6 +192,7 @@ def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
         # teaches the pool convention and names the thesis; `RESEARCH_INVENTORY`
         # says which pool is THIS run's, which the shared block cannot know.
         "EVIDENCE_BLOCK": act.evidence_block(tree),
+        "FILING_A_CANDIDATE_ROW": act.shared_prompt("filing_a_candidate_row"),
         "SUBMIT_PROMPT": act.submit_prompt(
             pr_number, f"plan-feature: plan {rel_component.name}"),
         # OPAQUE, and rendered verbatim. Before this existed `--pr` could push to

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/prompts/plan_feature.md
@@ -31,6 +31,8 @@ ${RESEARCH_INVENTORY}
 | | **Delete anything** — a candidate row, a phase doc, or a planning file |
 | | Decide WHEN this component gets built, or where it sits against other work |
 
+${FILING_A_CANDIDATE_ROW}
+
 ### The phase number is IDENTITY, and reading it as ORDER is the expensive mistake
 
 **A phase number names the phase for life, the way a ticket number does.** It is not the rollout order, and it never becomes the rollout order.

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
@@ -224,6 +224,7 @@ def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
             "Verify any FACT it asserts about the tree before building on it.\n\n"
             + context if context.strip() else ""
         ),
+        "FILING_A_CANDIDATE_ROW": act.shared_prompt("filing_a_candidate_row"),
         "SUBMIT_PROMPT": act.submit_prompt(
             pr_number, f"plan-verify: size and judge {rel_component.name}"),
         "DECISION_LOG_AND_REFLECTION": act.shared_prompt("decision_log_and_reflection"),

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
@@ -35,6 +35,8 @@ ${PLAN_INVENTORY}
 | | **Delete anything** — a candidate row, a phase doc, or the roadmap |
 | | Decide WHEN this component gets built, or where it sits against other work |
 
+${FILING_A_CANDIDATE_ROW}
+
 ### You judge the decomposition; you do not rewrite it
 
 **A phase boundary you think is wrong is a FINDING, not an edit.** Say so in your report, name what the second verifiable outcome is, and stop. `plan-feature` closes that runway — the phase docs are its output and you hold no grant over them.
@@ -141,7 +143,7 @@ Open questions, operator calls, and anything the plan assumes without saying so.
 
 For each phase, decide from: the number of distinct artifacts it creates, how much of it is new mechanism versus applying an existing one, how much is verification work, and what it is gated on. **Say the basis in one clause** — an estimate whose basis is unstated cannot be argued with, and being argued with is what it is for.
 
-- **Every phase gets one**, gated phases included.
+- **Every phase gets one**, gated phases included — **except a phase that is already COMPLETE, which gets none and gets a sentence saying why.** An estimate is a forecast of work; a shipped phase has no work left to forecast, and a number beside it invites a reader to add it into a total that would then describe nothing. **The unsized check compares a TOTAL against a TOTAL and a complete phase is outside both**, so sizing four planned phases when the roadmap lists five is the correct outcome and not a gap to explain away.
 - **Estimate the work, not the calendar.** Hours of focused development, not elapsed time.
 - **A phase you sized very large is a finding about the phase, not just a number** — say so, and name where you would split it.
 - **Do not adjust an estimate to make a total look reasonable.** The total is an input to a decision somebody else makes.

--- a/scripts/workflows/temporal/modules/assistant/prompts/filing_a_candidate_row.md
+++ b/scripts/workflows/temporal/modules/assistant/prompts/filing_a_candidate_row.md
@@ -1,0 +1,6 @@
+**FILING A CANDIDATE ROW — the two steps, and the second one is why runs push red.**
+
+1. **Append the row inside the table block**, with no blank line before it. A row separated from the table by a newline is not part of the table — it renders as a paragraph and two guards fire on it.
+2. **THEN UPDATE THE DERIVED DECLARATIONS THAT COUNT IT.** `candidates.md` § *Where things stand* states the untriaged total and the id range, and a test DERIVES both from the table and fails when the prose disagrees. Appending a row changes both. **A run that files a correct row and stops here has pushed a red suite**, which reads as a broken change rather than a finished one.
+
+**Run the suite before you commit.** These two guards are cheap to trip and their messages name the exact remedy; neither is discoverable by reading the file you are editing.

--- a/scripts/workflows/temporal/tests/unit/test_promoted_fragments_render_for_every_consumer.py
+++ b/scripts/workflows/temporal/tests/unit/test_promoted_fragments_render_for_every_consumer.py
@@ -35,6 +35,8 @@ from modules.assistant.build.build_draft import build_draft_workflow as draft
 from modules.assistant.build.build_draft_minor import build_draft_minor_workflow as draft_minor
 from modules.assistant.build.build_refine import build_refine_workflow as refine
 from modules.assistant.build.build_refine_minor import build_refine_minor_workflow as refine_minor
+from modules.assistant.plan.plan_feature import plan_feature_workflow as pfeat
+from modules.assistant.plan.plan_verify import plan_verify_workflow as pverify
 from modules.assistant.research import research_activities as ract
 from modules.assistant.research.research_refresh import research_refresh_workflow as refresh
 from modules.assistant.research.research_write import research_write_workflow as write
@@ -415,6 +417,7 @@ def test_an_UNSUPPLIED_fragment_placeholder_stops_the_dispatch(monkeypatch, tmp_
 # gate — it catches deletion and says nothing about a line being rewritten into
 # something else, which is the half no guard here reaches.
 _FRAGMENT_FLOOR = {
+    "filing_a_candidate_row": 4,
     "build_from_plan": 9,
     "stages_1_to_4_from_plan": 46,
     "fidelity_premise": 2,
@@ -503,7 +506,12 @@ _NOT_RENDER_CHECKED: dict[str, str] = {}
 
 # Every consumer this module DRIVES. The tests above expect each one to render
 # what its own source loads, so this union is exactly the render-checked set.
-_DRIVEN = (draft, draft_minor, refine, refine_minor, write, refresh)
+# `pfeat`/`pverify` joined 2026-08-19 with the first fragment promoted for the
+# PLANNING family. The docstring below already named that family as the
+# consumer set this module did not drive, and adding them is the remedy it
+# names — a static AST scan needs no fixture, only the module.
+_DRIVEN = (draft, draft_minor, refine, refine_minor, write, refresh,
+           pfeat, pverify)
 
 
 def test_every_POOL_fragment_is_render_checked_by_some_consumer() -> None:

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -165,7 +165,7 @@ BUDGETS: dict[str, int] = {
     # the immutability rule reads unconditionally, so it applied to a plan
     # nothing had cited yet. Operator ruling — the rule protects PUBLISHED
     # addresses, and before publication a tidy plan is strictly better.
-    "plan/plan_feature/prompts/plan_feature.md": 23422,
+    "plan/plan_feature/prompts/plan_feature.md": 23449,  # +${FILING_A_CANDIDATE_ROW}
     # 15_510 -> 13_204: the `research-analyst` re-dispatch is gone. The verify
     # child holds Write/Edit and applies the critic's findings itself, so the
     # rules that existed only to coordinate a second writing agent went with it
@@ -202,7 +202,12 @@ BUDGETS: dict[str, int] = {
     # seen one), and the web (sizing "build X against vendor Y's API" is answerable
     # by reading Y's docs, and the grant was live but unmentioned). Plus
     # ${TASK_CONTEXT}, so a --pr pass can be told why it is re-running.
-    "plan/plan_verify/prompts/plan_verify.md": 15577,
+    # + the complete-phase sizing rule and ${FILING_A_CANDIDATE_ROW}. Both came
+    # from the first plan-verify run: it hit the "every phase gets one" vs
+    # "a TOTAL against a TOTAL" ambiguity on a COMPLETE phase with no doc, and
+    # it found the derived-prose guard by reading it before writing rather than
+    # by pushing red — which the next run would not.
+    "plan/plan_verify/prompts/plan_verify.md": 16083,
     # RATCHETED DOWN 14_437 -> 9_896, the other side of the same move. It stays
     # above the FLOOR, so it keeps its line rather than dropping off the table.
     # Then 9_896 -> 9_908, the same twelve substituted-away bytes as above.


### PR DESCRIPTION
Both mined from the first plan-verify execution (63/150 turns, $6.80, 12 min).

1. FILING A CANDIDATE ROW HAS A SECOND STEP NOBODY IS TOLD ABOUT. `candidates.md`
§ Where things stand states the untriaged total and the id range, and a test
derives both from the table. Appending a row changes both — so a run that files
a correct row and stops has pushed a RED suite, which reads as a broken change
rather than a finished one.

The run found this by reading the guard before writing rather than by pushing
red, and said so: "a run that appended without reading it would have pushed a
red suite having done everything else right." Two consumers (plan-feature,
plan-verify), so §10.1 makes it a promotion rather than a copy.

The fragment also carries the leading-newline trap the same run hit: a row
separated from the table by a blank line is not in the table, and two guards
fire on it.

THE PROMOTION GUARD CAUGHT ITS OWN GAP, which is worth recording. This is the
first fragment promoted for the PLANNING family, and
`test_promoted_fragments_render_for_every_consumer` drives only build and
research — so the fragment went under the deletion floor and under no render
check. Its docstring already anticipated exactly this: "the pool has consumers
outside these — the planning family among them — and a fragment reaching only
those is genuinely unverified by this module. The remedy is a fixture for that
consumer." `plan_feature` and `plan_verify` are now in `_DRIVEN`; the scan is
static so no fixture was needed, only the modules.

2. A COMPLETE PHASE IS NOT SIZED. The prompt said "every phase gets one, gated
phases included" and separately that the check compares "a TOTAL against a
TOTAL" — and said nothing about a phase that has already shipped. The run hit
it live: four phase docs, five phases, one complete. It resolved it correctly
and had to reason its way there. Now stated: a complete phase gets no estimate
and a sentence saying why, because an estimate is a forecast and a shipped
phase has no work left to forecast — and a number beside it invites a reader to
add it into a total that would then describe nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

`1850 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)