### PR TITLE
plan-verify: a DETERMINED defect it FIXES; a design choice it REPORTS

### DIFF
--- a/scripts/workflows/temporal/modules/assistant/plan/plan_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_activities.py
@@ -960,3 +960,62 @@ def submit_prompt(pr_number: str | None, label: str) -> str:
                 f"- Push to the PR branch and report PR #{pr_number}'s URL as your FINAL line")
     return (f"- Stage and commit your changes with message `{label}`\n"
             f"- Push the branch and open a PR; report its URL as your FINAL line")
+
+def plan_docs(component: Path) -> dict[str, str]:
+    """EVERY top-level markdown file in the component — the write grant's own scope.
+
+    THE SCOPE OF THE GUARDS MUST BE THE SCOPE OF THE GRANT, and this reader is
+    what makes those two the same set. The grant is `<component>/[^/]+\\.md$` —
+    any markdown file sitting directly in the component — while `phase_docs`
+    above answers a narrower question (*which files are phase docs*) by matching
+    `^phase`. Three guards were built on the narrow reader and inherited its
+    scope, which left the grant wider than anything that inspected it:
+
+      * a NEW `the_run_bag.md` — a phase doc with the number dropped, which is
+        the FIRST failure mode the standard names and the likeliest one — does
+        not start with `phase`, so it was invisible to `malformed_phase_docs`
+        while the row it violates claims that function observes it;
+      * an hour estimate or a pre-ticked checkbox written into any top-level file
+        other than `roadmap.md` or a `phase*` one was scanned by nothing.
+
+    Both are closed by asking the grant's question instead of the phase reader's.
+    `roadmap.md` is the one legitimate non-phase name and the callers below say
+    so explicitly rather than this reader excluding it — the deletion and
+    checkbox guards want it in, and only the naming guard wants it out.
+
+    A MISSING COMPONENT DIRECTORY IS AN EMPTY MAP, for the same reason
+    `phase_docs` gives: `plan-candidates` creates the folder and the seed and
+    nothing else, so a first-time plan legitimately starts from nothing.
+    """
+    if not component.is_dir():
+        return {}
+    return {p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sorted(component.iterdir())
+            if p.is_file() and p.suffix == ".md"}
+
+def plan_boxes(component: Path) -> Counter:
+    """Every completion checkbox in the component's PLAN, as one Counter.
+
+    THE ROADMAP AND EVERY OTHER TOP-LEVEL DOC TOGETHER, because the prohibition
+    is about the plan and not about a file. `checked_boxes` reads one path;
+    this workflow's output is one roadmap plus N phase docs, and a guard scoped
+    to `roadmap.md` alone would be blind to a phase doc shipping with its steps
+    pre-ticked — which is the likelier mistake, since a phase doc is where the
+    implementation checklist lives.
+
+    SCOPED BY `plan_docs`, i.e. by the write grant, so it cannot be narrower than
+    what the run may write. It sat in the workflow module keyed on a hand-written
+    `name == "roadmap.md" or name.lower().startswith("phase")`, which was a
+    second spelling of `_LOOKS_LIKE_A_PHASE` in a second file with nothing
+    forcing the two to move together — and it carried the same scope gap
+    `plan_docs` exists to close.
+
+    `research/` is deliberately outside the sweep, for the same reason it is
+    outside the write grant: a synthesis' own checkboxes are not this plan's.
+    """
+    boxes: Counter = Counter()
+    for name in plan_docs(component):
+        boxes += checked_boxes(component / name)
+    return boxes
+
+

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_feature/plan_feature_activities.py
@@ -61,6 +61,10 @@ from collections import Counter
 from pathlib import Path
 
 from .. import plan_activities as act
+# PROMOTED 2026-08-19: `plan_verify` gained a phase-doc write grant and needs the
+# same two, so §10.1 moved them to the family layer. Re-exported here rather
+# than rewritten at ~20 call sites and in the observer strings that name them.
+from ..plan_activities import plan_boxes, plan_docs  # noqa: F401
 
 # The binding filename grammar, verbatim from the Documentation Standard's
 # "Filename pattern (binding)" block: `phase{N}_{descriptor}.md` canonical, with
@@ -83,64 +87,6 @@ _HOURS = act.HOUR_ESTIMATE
 # The other half of the output, and the only top-level name that is not a phase
 # doc. Named rather than spelled inline because three readers below test for it.
 ROADMAP = "roadmap.md"
-
-def plan_docs(component: Path) -> dict[str, str]:
-    """EVERY top-level markdown file in the component — the write grant's own scope.
-
-    THE SCOPE OF THE GUARDS MUST BE THE SCOPE OF THE GRANT, and this reader is
-    what makes those two the same set. The grant is `<component>/[^/]+\\.md$` —
-    any markdown file sitting directly in the component — while `phase_docs`
-    above answers a narrower question (*which files are phase docs*) by matching
-    `^phase`. Three guards were built on the narrow reader and inherited its
-    scope, which left the grant wider than anything that inspected it:
-
-      * a NEW `the_run_bag.md` — a phase doc with the number dropped, which is
-        the FIRST failure mode the standard names and the likeliest one — does
-        not start with `phase`, so it was invisible to `malformed_phase_docs`
-        while the row it violates claims that function observes it;
-      * an hour estimate or a pre-ticked checkbox written into any top-level file
-        other than `roadmap.md` or a `phase*` one was scanned by nothing.
-
-    Both are closed by asking the grant's question instead of the phase reader's.
-    `roadmap.md` is the one legitimate non-phase name and the callers below say
-    so explicitly rather than this reader excluding it — the deletion and
-    checkbox guards want it in, and only the naming guard wants it out.
-
-    A MISSING COMPONENT DIRECTORY IS AN EMPTY MAP, for the same reason
-    `phase_docs` gives: `plan-candidates` creates the folder and the seed and
-    nothing else, so a first-time plan legitimately starts from nothing.
-    """
-    if not component.is_dir():
-        return {}
-    return {p.name: hashlib.sha256(p.read_bytes()).hexdigest()
-            for p in sorted(component.iterdir())
-            if p.is_file() and p.suffix == ".md"}
-
-
-def plan_boxes(component: Path) -> Counter:
-    """Every completion checkbox in the component's PLAN, as one Counter.
-
-    THE ROADMAP AND EVERY OTHER TOP-LEVEL DOC TOGETHER, because the prohibition
-    is about the plan and not about a file. `act.checked_boxes` reads one path;
-    this workflow's output is one roadmap plus N phase docs, and a guard scoped
-    to `roadmap.md` alone would be blind to a phase doc shipping with its steps
-    pre-ticked — which is the likelier mistake, since a phase doc is where the
-    implementation checklist lives.
-
-    SCOPED BY `plan_docs`, i.e. by the write grant, so it cannot be narrower than
-    what the run may write. It sat in the workflow module keyed on a hand-written
-    `name == "roadmap.md" or name.lower().startswith("phase")`, which was a
-    second spelling of `_LOOKS_LIKE_A_PHASE` in a second file with nothing
-    forcing the two to move together — and it carried the same scope gap
-    `plan_docs` exists to close.
-
-    `research/` is deliberately outside the sweep, for the same reason it is
-    outside the write grant: a synthesis' own checkboxes are not this plan's.
-    """
-    boxes: Counter = Counter()
-    for name in plan_docs(component):
-        boxes += act.checked_boxes(component / name)
-    return boxes
 
 
 # `Phase 4`, `**Phase 4**`, `### Phase 4 — name`. Case-insensitive because a

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/plan_verify_workflow.py
@@ -185,7 +185,18 @@ def permitted_paths(component_rel: Path, candidates_rel: Path) -> tuple[str, ...
     to die at merge. It comes with the column guards below.
     """
     return (
-        rf"^{re.escape(component_rel.as_posix())}/{re.escape(own.ROADMAP)}$",
+        # WIDENED 2026-08-19 from `roadmap.md` alone to every top-level markdown
+        # file in the component — the same grant `plan_feature.permitted_paths`
+        # holds, and for a reason the two now share. This run may CORRECT a
+        # determined defect in a phase doc; it may not RE-PLAN. Those were one
+        # prohibition enforced by this grant, and separating them moves the
+        # enforcement to the observers that were always the real check:
+        # `roadmap_phase_links` for add/merge/split/drop, `ids_deleted` over
+        # `phase_docs_of` for a disappearance, and `plan_boxes` below for a
+        # ticked or reworded checkbox. The grant was never what stopped a
+        # re-plan; it stopped ALL editing, which is what parked a one-sentence
+        # fix as a fifteen-hundred-byte candidate row.
+        rf"^{re.escape(component_rel.as_posix())}/[^/]+\.md$",
         rf"^{re.escape(candidates_rel.as_posix())}$",
     )
 
@@ -249,10 +260,6 @@ def prompt_values(rel_component: Path, rel_candidates: Path, tree: Path,
 # construction. `own.roadmap_phase_links` exists because the row would not
 # otherwise have been allowed to say anything true.
 MAY_NOT_OBSERVERS: dict[str, str] = {
-    "**Edit a phase doc** — you are the plan's READER, not a second author":
-        "FORBIDDEN_PATHS `^docs/development/` less permitted_paths, whose only "
-        "component grant is `<component>/roadmap.md` — so every phase doc is a "
-        "forbidden path, via act.worktree_state / act.boundary_crossings",
     "**Write an hour estimate anywhere but `roadmap.md`** — one figure, one home":
         "the same mechanism, and the grant IS the enforcement rather than a "
         "scanner beside it: `roadmap.md` is the only file in the component this "
@@ -266,18 +273,28 @@ MAY_NOT_OBSERVERS: dict[str, str] = {
         "that is the LAST guard, and a run that also under-sized reached the "
         "sizing message first — a true failure naming the wrong cause, which is "
         "the defect this file already reorders one guard to avoid",
-    "**Re-plan the component** — add, merge, split or drop a phase":
-        "own.roadmap_phase_links counted either side of the run and compared in "
-        "BOTH directions — the one prohibition here that happens INSIDE the "
-        "granted file, where act.boundary_crossings is blind by construction",
     "**WRITE or edit `sprint.md`** — read it (Stage 1), never touch it":
         "FORBIDDEN_PATHS, via act.worktree_state / act.boundary_crossings",
     "Write or edit anything under ANOTHER component, or under this one's `research/`":
         "FORBIDDEN_PATHS `^docs/development/` less permitted_paths, which grants "
         "one named file and so reaches no sibling and no subdirectory",
     "**Tick a completion checkbox** — nothing has been built":
-        "act.checked_boxes over the roadmap — the only file this run may write — "
-        "counted either side and compared in BOTH directions",
+        "act.plan_boxes — act.checked_boxes over EVERY top-level doc the grant "
+        "permits, not the roadmap alone — counted either side and compared in "
+        "BOTH directions. Widened with the grant: a phase doc shipping with its "
+        "steps pre-ticked is the likelier mistake now that phase docs are "
+        "writable, since that is where the implementation checklist lives",
+    "**Reword a completion criterion** — a checkbox is the author's sentence":
+        "act.plan_boxes is a Counter keyed by the box's TEXT, so a reworded "
+        "criterion presents as one text gone and one text arrived — caught by "
+        "the same both-directions comparison, without a second mechanism",
+    "**RE-PLAN the component** — add, merge, split or drop a phase, or change what one delivers":
+        "own.roadmap_phase_links counted either side and compared in BOTH "
+        "directions for add/merge/split/drop, plus act.ids_deleted over "
+        "own.phase_docs_of for a phase that vanished. JUDGEMENT for the last "
+        "clause: prose inside a granted file cannot be told from a correction "
+        "by any comparator, and it is held by the report's integrity clause — "
+        "every correction named, with whether it moved an estimate",
     "Set `decision`, `status`, or another filer's `component` in the candidates file":
         "act.candidate_decisions, act.candidate_statuses and "
         "act.candidate_components snapshotted either side of the run, compared by "
@@ -339,7 +356,10 @@ DISAPPEARANCE_OBSERVERS: dict[str, str] = {
         "act.ids_deleted on the SAME id set, by the same coupling registered "
         "against before_status — one parse, one id set, three columns"),
     "before_boxes": (
-        "act.checked_boxes over the roadmap, counted either side and compared in "
+        "act.plan_boxes over EVERY top-level doc the grant permits — widened with "
+        "the grant on 2026-08-19, since a phase doc shipping with its steps "
+        "pre-ticked is the likelier mistake once phase docs are writable — "
+        "counted either side and compared in "
         "BOTH directions — so an ERASED tick is an offence exactly as an added "
         "one is. A plan reporting work nobody built is bad; a plan that has "
         "forgotten work somebody did is worse, because nothing downstream will "
@@ -382,7 +402,7 @@ def run_plan_verify(*, repo_root: Path, worktree: Path, component: Path,
     before_decision = act.candidate_decisions(wt_candidates)
     before_status = act.candidate_statuses(wt_candidates)
     before_component = act.candidate_components(wt_candidates)
-    before_boxes = act.checked_boxes(wt_component / own.ROADMAP)
+    before_boxes = act.plan_boxes(wt_component)
     before_tree = act.worktree_state(worktree)
 
     values = prompt_values(rel_component, rel_candidates, worktree, pr_number,
@@ -619,7 +639,7 @@ def run_plan_verify(*, repo_root: Path, worktree: Path, component: Path,
     # the roadmap because that is the only file it may write; a tick anywhere
     # else in the component is already a boundary crossing. Compared in BOTH
     # directions: erasing a tick is the same prohibition and the worse half.
-    after_boxes = act.checked_boxes(wt_component / own.ROADMAP)
+    after_boxes = act.plan_boxes(wt_component)
     ticked = sorted((after_boxes - before_boxes).elements())
     erased = sorted((before_boxes - after_boxes).elements())
     if ticked or erased:

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_verify/prompts/plan_verify.md
@@ -23,12 +23,13 @@ ${PLAN_INVENTORY}
 
 | You MAY | You MAY NOT |
 |---|---|
-| Write an hour estimate per phase into `${COMPONENT_PATH}/roadmap.md` | **Edit a phase doc** — you are the plan's READER, not a second author |
+| Write an hour estimate per phase into `${COMPONENT_PATH}/roadmap.md` | **RE-PLAN the component** — add, merge, split or drop a phase, or change what one delivers |
 | Add a short sizing note beside an estimate | **Write an hour estimate anywhere but `roadmap.md`** — one figure, one home |
-| Report a phase boundary you believe is wrong | **Rename, renumber or delete a phase doc** — the number is IDENTITY |
-| Report a phase resting on evidence that does not support it | **Re-plan the component** — add, merge, split or drop a phase |
+| **Correct a DETERMINED defect in a phase doc** — see below | **Rename, renumber or delete a phase doc** — the number is IDENTITY |
+| Report a phase boundary you believe is wrong | **Reword a completion criterion** — a checkbox is the author's sentence |
+| Report a phase resting on evidence that does not support it | Write or edit anything under ANOTHER component, or under this one's `research/` |
 | Append a proposal row to the candidates file | **WRITE or edit `sprint.md`** — read it (Stage 1), never touch it |
-| Name the `component` on a row YOU append | Write or edit anything under ANOTHER component, or under this one's `research/` |
+| Name the `component` on a row YOU append | |
 | | **Tick a completion checkbox** — nothing has been built |
 | | Set `decision`, `status`, or another filer's `component` in the candidates file |
 | | Edit `problem-statement.md`, `architectural_standard.md`, or anything else under `docs/standards/` |
@@ -81,6 +82,26 @@ Any one of these **fails the whole run** — including the work you did correctl
 **One row in that column is NOT mechanically checked, and you are told which** so the list is not read as covering everything: *deciding when this component gets built* cannot be separated in code from reporting what it costs, because both are prose about the same hours. The FILE that would carry a sequencing decision is `sprint.md`, and that one IS checked.
 
 ---
+
+### A DETERMINED defect you FIX. A design choice you REPORT. The line is whether the answer is already decided.
+
+**This used to read "edit no phase doc, you are the READER not a second author", and that bundled two rules with one reason.** *Do not re-plan* protects the seam and is unchanged. *Do not edit at all* is far broader than that reason, and it is what made a reviewer spend fifteen hundred bytes describing a fix that was one sentence — the exact shape [`engineering-quality.md`](../../../../../../../../config/rules/engineering-quality.md) names: *"The process of recording it taking longer than the fix is the smell."*
+
+**FIX IT when the remedy is DETERMINED — one right answer, no design choice:**
+- a statement that contradicts the phase's own argument, or another phase doc, or the roadmap
+- a stale cross-reference, a dangling section link, a number that a rename made false
+- a claim about the tree you checked and found false
+- a requirement whose remedy the plan ALREADY contains somewhere else — the answer is written, it is just written in the wrong place
+
+**REPORT IT when the answer is a JUDGEMENT somebody has to make:**
+- a phase boundary you would have drawn elsewhere
+- a phase you believe should not exist, or should be two
+- what a phase delivers, or a completion criterion's wording — **a checkbox is the author's sentence and you never rewrite one**
+- anything where two competent readers could land differently
+
+**INTEGRITY CLAUSE, and it is not optional: every correction you make is named in your report, with whether it changed your own estimate.** You are grading a document you just touched, and a reader must be able to see exactly where. **If a correction is large enough to move an estimate, say the old number and the new one.**
+
+**When in doubt, REPORT.** A reported defect costs a paragraph; a wrong fix inside a phase doc is the reviewer becoming a second author with nobody left to check it.
 
 ## Stage 1: ASSESS — read the plan cold
 

--- a/scripts/workflows/temporal/tests/unit/test_plan_verify.py
+++ b/scripts/workflows/temporal/tests/unit/test_plan_verify.py
@@ -444,13 +444,20 @@ def _state(paths: dict[str, str]) -> dict[str, str]:
 
 def test_the_grant_reaches_the_ROADMAP_and_NOT_the_phase_doc_beside_it(
         tree: Path) -> None:
-    """THE DISCRIMINATING FIXTURE, and it is not the write half's.
+    """The grant reaches every TOP-LEVEL doc, and stops at the subdirectory.
 
-    `plan-feature`'s grant is a SHAPE over the component, so its boundary tests
-    need two components to be asymmetric. This grant is ONE NAMED FILE, so the
-    case that separates a reader from a second author is a phase doc in the SAME
-    directory as the granted roadmap — a fixture that only denies a sibling
-    component reads correct either way.
+    WIDENED 2026-08-19, and the old assertion is worth recording because it was
+    right for the design it guarded and wrong for this one. It read *"expected
+    everything in the component except its roadmap to be a crossing — a phase
+    doc most of all, since a judge that may edit one can quietly become its
+    author"*. The bundled prohibition it enforced has since been split: this run
+    may CORRECT a determined defect in a phase doc and may not RE-PLAN, and the
+    re-plan half moved to the observers that always did that work —
+    `roadmap_phase_links`, `phase_docs_of`, and `plan_boxes` keyed on box TEXT.
+
+    What still discriminates is the SUBDIRECTORY: `research/` is this run's
+    evidence and must stay read-only, and a grant shaped `[^/]+\.md$` reaches no
+    subdirectory by construction. That is what this fixture now proves.
     """
     permitted = wf.permitted_paths(Path("docs/development/alpha"), _CANDS)
     before = _state({
@@ -465,16 +472,14 @@ def test_the_grant_reaches_the_ROADMAP_and_NOT_the_phase_doc_beside_it(
     })
     after = {k: "CHANGED" for k in before}
     assert act.boundary_crossings(before, after, wf.FORBIDDEN_PATHS, permitted) == [
-        "docs/development/alpha/notes.md",
-        "docs/development/alpha/phase1_a.md",
         "docs/development/alpha/research/synthesis.md",
         "docs/development/beta/roadmap.md",
         "docs/development/sprint.md",
         "docs/standards/architecture/problem-statement.md",
     ], (
-        "expected everything in the component except its roadmap to be a "
-        "crossing — a phase doc most of all, since a judge that may edit one can "
-        "quietly rewrite the plan it was sent to judge"
+        "expected every TOP-LEVEL doc in this component to be inside the grant "
+        "and `research/` to be outside it — the evidence a run plans against "
+        "must not be editable by the run that judges the plan"
     )
 
 
@@ -675,8 +680,15 @@ def _harness(monkeypatch: pytest.MonkeyPatch, tree: Path, writes):
     comp, seen = _component(tree), set()
 
     def snapshot(*_a: object, **_k: object) -> dict[str, str]:
-        seen.update(p.name for p in comp.iterdir()
-                    if p.is_file() and p.suffix == ".md")
+        # RECURSIVE since 2026-08-19, and the widened grant is why. When this run
+        # could write only `roadmap.md`, every top-level sibling of it was a
+        # crossing and a non-recursive walk could prove the boundary fires. Now
+        # every top-level `.md` is INSIDE the grant, so the only crossing left
+        # inside this component is `research/` — invisible to a walk that stops
+        # at the directory. A stub that cannot see the one remaining offence
+        # makes every assertion about that boundary vacuous.
+        seen.update(str(p.relative_to(comp)) for p in comp.rglob("*.md")
+                    if p.is_file())
         return {f"docs/development/alpha/{n}":
                 (hashlib.sha256((comp / n).read_bytes()).hexdigest()
                  if (comp / n).is_file() else act.ABSENT) for n in seen}
@@ -956,7 +968,7 @@ def test_DELETING_a_PHASE_DOC_raises_its_OWN_message_not_the_unsized_one(
         "erased a document — the remedy it suggests leaves the doc deleted")
 
 
-def test_a_phase_doc_merely_EDITED_is_left_to_the_BOUNDARY_check(
+def test_an_EDIT_OUTSIDE_THE_GRANT_is_left_to_the_BOUNDARY_check(
         tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """THE DISCRIMINATOR for the guard above, and it is a scope assertion.
 
@@ -965,12 +977,22 @@ def test_a_phase_doc_merely_EDITED_is_left_to_the_BOUNDARY_check(
     `boundary_crossings`, which is the guard that says the right thing about an
     EDIT. Only DISAPPEARANCE needs its own message, because only disappearance
     is what the generic message gets wrong.
+
+    THE FIXTURE MOVED 2026-08-19 and the reason matters. It used to EDIT a phase
+    doc, which was a crossing when this run could write only `roadmap.md`. It no
+    longer is: the grant reaches every top-level doc so a determined correction
+    can be applied where the defect is. `research/synthesis.md` is the file that
+    still separates the two guards — outside the grant by the SUBDIRECTORY, and
+    the evidence this run judges a plan against, so a run editing it has made
+    the evidence agree with the verdict it is about to write.
     """
     c = _planned(tree)
-    message = _drive(monkeypatch, tree, lambda: (
-        c / "phase2_the_gated_one.md").write_text("# Phase 2 — rewritten\n"))
+    evidence = c / "research" / "synthesis.md"
+    evidence.write_text("# evidence\n")
+    message = _drive(monkeypatch, tree,
+                     lambda: evidence.write_text("# rewritten evidence\n"))
     assert "outside its authorization" in message, (
-        f"an edited phase doc should reach the boundary check: {message}")
+        f"an edited research file should reach the boundary check: {message}")
     assert "cease to exist" not in message
 
 

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -202,7 +202,13 @@ BUDGETS: dict[str, int] = {
     # seen one), and the web (sizing "build X against vendor Y's API" is answerable
     # by reading Y's docs, and the grant was live but unmentioned). Plus
     # ${TASK_CONTEXT}, so a --pr pass can be told why it is re-running.
-    "plan/plan_verify/prompts/plan_verify.md": 15577,
+    # + the DETERMINED-vs-JUDGEMENT split. The old prohibition bundled two rules
+    # under one reason: "do not re-plan" (right, and unchanged) and "edit no
+    # phase doc" (far broader than the reason given). The second is what made a
+    # reviewer spend 1,500 bytes describing a one-sentence fix — the exact smell
+    # engineering-quality.md names. Fixing a determined defect is now in scope;
+    # re-planning is not, and the observers that always enforced that half do it.
+    "plan/plan_verify/prompts/plan_verify.md": 17621,
     # RATCHETED DOWN 14_437 -> 9_896, the other side of the same move. It stays
     # above the FLOOR, so it keeps its line rather than dropping off the table.
     # Then 9_896 -> 9_908, the same twelve substituted-away bytes as above.

--- a/testing/scripts/tests/unit/test_prompt_budgets.py
+++ b/testing/scripts/tests/unit/test_prompt_budgets.py
@@ -208,7 +208,7 @@ BUDGETS: dict[str, int] = {
     # reviewer spend 1,500 bytes describing a one-sentence fix — the exact smell
     # engineering-quality.md names. Fixing a determined defect is now in scope;
     # re-planning is not, and the observers that always enforced that half do it.
-    "plan/plan_verify/prompts/plan_verify.md": 17621,
+    "plan/plan_verify/prompts/plan_verify.md": 18127,
     # RATCHETED DOWN 14_437 -> 9_896, the other side of the same move. It stays
     # above the FLOOR, so it keeps its line rather than dropping off the table.
     # Then 9_896 -> 9_908, the same twelve substituted-away bytes as above.


### PR DESCRIPTION
The prohibition bundled two rules under one reason:

    | **Edit a phase doc** — you are the plan's READER, not a second author |
    | **Re-plan the component** — add, merge, split or drop a phase |

*Do not re-plan* protects the seam and is unchanged. *Do not edit at all* is far
broader than that reason, and it is what parked a one-sentence fix as a
1,500-byte candidate row (C-114) — the exact shape `engineering-quality.md`
names: "The process of recording it taking longer than the fix is the smell."

`research_verify` is the same shape and holds the pen: fresh context, did not
author the artifact, so `author != judge` survives because child 1 wrote it and
child 2 judges it. The industry line is apply-a-correction versus redesign, not
write versus do-not-write — GitHub ships suggested-changes for exactly this.

WHAT MOVED, and the grant was never the real enforcement:

  * grant widened from `roadmap.md` to `[^/]+\.md$` — the same shape
    `plan_feature.permitted_paths` holds. It reaches no subdirectory, so
    `research/` stays read-only: a run that edits the evidence has made the
    evidence agree with its own verdict.
  * add/merge/split/drop was ALREADY enforced by `roadmap_phase_links` counted
    both directions, and a vanished doc by `ids_deleted` over `phase_docs_of`.
    Neither depended on the grant.
  * checkbox observer widened from the roadmap alone to `plan_boxes` over every
    granted doc — a phase doc shipping with its steps pre-ticked is the likelier
    mistake once phase docs are writable, since that is where the checklist is.
  * NEW prohibition, mechanically observed for free: rewording a completion
    criterion. `plan_boxes` is keyed on box TEXT, so a reword presents as one
    text gone and one arrived.
  * JUDGEMENT, stated as such: "change what a phase delivers" is prose inside a
    granted file and no comparator can tell it from a correction. Held by the
    report's integrity clause — every correction named, with whether it moved an
    estimate.

`plan_docs`/`plan_boxes` promoted to `plan_activities` (§10.1, two consumers),
re-exported from `plan_feature_activities` rather than rewritten at ~20 call
sites.

TWO TESTS PINNED THE OLD DESIGN AND WERE RE-AIMED, not deleted. Both were right
for the design they guarded: one asserted every non-roadmap file in the
component is a crossing, the other that an EDITED phase doc reaches the boundary
check. `research/` is what still separates the two guards, and the harness stub
had to become recursive to see it — a stub that cannot see the one remaining
offence makes every assertion about that boundary vacuous.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

`1848 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)