### PR TITLE
build-draft: a run derives its context once, at the boundary, and says so

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -626,7 +626,7 @@ claude-dot-files/
 │                   │                                #   is DERIVED from splitlines() rather than from a remembered list, and the round trip
 │                   │                                #   is the property: for any accepted value, reading the file returns what was written
 │                   ├── test_dispatch_context.py     # The run context's behaviour: the worktree name follows the workflow key (every key,
-│                   │                                #   because the drift was in one of eleven), the object is frozen, the echo is gated on
+│                   │                                #   because the drift was in a single runner), the object is frozen, the echo is gated on
 │                   │                                #   `is_the_run` rather than on `minted` — a retry supplies its name and is exactly the
 │                   │                                #   caller who needs the echo — and the rehearsal renders the same object as the live
 │                   │                                #   run. Also two AST sweeps over the entrypoints: every one builds and echoes, and
@@ -674,7 +674,11 @@ claude-dot-files/
 │                                                    #   run_*.py by AST (never substring: the sibling sweep shipped green because a COMMENT
 │                                                    #   satisfied its grep) and fails when one starts a run with no bag. Also checks ORDER —
 │                                                    #   the bag precedes the first side effect — with a self-contained non-conforming fixture
-│                                                    #   for both, and names the swept scope in its own failure message
+│                                                    #   for both, and names the swept scope in its own failure message. And PLACEMENT: the
+│                                                    #   call must sit inside a `try` whose except catches RuntimeError, which its failure
+│                                                    #   message had demanded in prose since it was written while nothing checked it —
+│                                                    #   run_plan.py had drifted above the handler, turning a bad --run-id and a full journal
+│                                                    #   into tracebacks in one file of eleven and one-line diagnostics in the other ten
 │
 ├── testing/                                         # TIER 1 + TIER 2 of the Testing Standard's three-tier hierarchy
 │   ├── README.md                                    # How to run the suite and how to add a test

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -223,9 +223,20 @@ claude-dot-files/
 │           │                                        #   a run's CONTENT here — that is Phase 3. Imports no workflow module, so a
 │           │                                        #   measurement helper can load it without dragging in temporalio
 │           ├── scripts/                             # Kickoff entrypoints, until an SDK path replaces them — plus preflight.py,
-│           │                                        #   validate_bag.py and dispatch_identity.py, which are NOT kickoffs: they are what a
-│           │                                        #   run checks before, what an operator checks after, and who NAMES the run. All three
-│           │                                        #   live here because they are launch concerns rather than workflow concerns
+│           │                                        #   validate_bag.py, dispatch_identity.py and dispatch_context.py, which are NOT
+│           │                                        #   kickoffs: they are what a run checks before, what an operator checks after, who
+│           │                                        #   NAMES the run, and what the run DERIVED. All four live here because they are
+│           │                                        #   launch concerns rather than workflow concerns. None is named run_*.py, and that
+│           │                                        #   is load-bearing — the entrypoint sweeps glob that prefix, so a helper wearing it
+│           │                                        #   is swept as a runner and fails five guards at once (measured 2026-09-01)
+│           │                                        #   dispatch_context.py is Workflow Decomposition Phase 4's answer to "what did this
+│           │                                        #   run work out for itself": a frozen RunContext extending RunIdentity, built ONCE at
+│           │                                        #   the dispatch boundary, carrying the repo root, journal root, workflow key, worktree
+│           │                                        #   name, PR number and target — each field stating its marker, algorithm, override and
+│           │                                        #   scope of effect. It echoes itself on stderr before the first side effect, and the
+│           │                                        #   same render() is what every --dry-run previews, so a rehearsal cannot show
+│           │                                        #   something other than what runs. The worktree name lived at ELEVEN sites in THREE
+│           │                                        #   spellings before it moved here, one of them already drifted from its workflow key
 │           │                                        #   dispatch_identity.py is Phase 9's answer to "who names a run": it declares --run-id
 │           │                                        #   and --writer once for every entrypoint, validates a supplied name, and mints one
 │           │                                        #   ONLY when nothing supplied it — then prints it, because a name nobody was told is a
@@ -307,6 +318,18 @@ claude-dot-files/
 │                   │                                #   success — $8.60, nine findings left open (MDC #204)
 │                   ├── test_a_gh_reply_is_checked_for_SHAPE_not_only_parsed.py # Every `gh`-reply `json.loads` asks what SHAPE came
 │                   │                                #   back — a decode guard alone lets `{"message": …}` through to a `TypeError`
+│                   ├── test_a_WRONG_TARGET_is_NAMED_before_the_run_costs_anything.py # Phase 4 r5, DEMONSTRATED rather
+│                   │                                                   #   than asserted: a real entrypoint's live main(), pointed at the wrong
+│                   │                                                   #   component, with bag-open replaced by a raise. A wrong target is the
+│                   │                                                   #   one derived value that fails SILENTLY — the run plans the wrong
+│                   │                                                   #   thing competently and opens a real PR. Carries the verbatim transcript
+│                   ├── test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py # No worktree_add call assembles the name it cuts with.
+│                   │                                                   #   Keyed on the CALL SITE, matched on the function NAME so a module
+│                   │                                                   #   alias cannot hide it (review_pr_workflow reaches it as _shared., and
+│                   │                                                   #   the act.-keyed predicates in test_isolation_invariants are blind to
+│                   │                                                   #   that today). Received = a .worktree_name attribute, or a PARAMETER
+│                   │                                                   #   of that name — a local assignment is not received, which is what all
+│                   │                                                   #   eleven sites were. A fourth spelling fails without being anticipated
 │                   ├── test_a_new_branch_STARTS_FROM_THE_DEFAULT_BRANCH.py # A run with no --pr is cut from the DEFAULT BRANCH, never the
 │                   │                                                   #   operator's HEAD. Keyed on worktree_add's ref argument, so an inline
 │                   │                                                   #   literal is as visible as an assignment — the 11th call site was inline.
@@ -602,6 +625,17 @@ claude-dot-files/
 │                   │                                #   more. Sweeps every f"{label}: {value}" for an undeclared value; the battery beside it
 │                   │                                #   is DERIVED from splitlines() rather than from a remembered list, and the round trip
 │                   │                                #   is the property: for any accepted value, reading the file returns what was written
+│                   ├── test_dispatch_context.py     # The run context's behaviour: the worktree name follows the workflow key (every key,
+│                   │                                #   because the drift was in one of eleven), the object is frozen, the echo is gated on
+│                   │                                #   `is_the_run` rather than on `minted` — a retry supplies its name and is exactly the
+│                   │                                #   caller who needs the echo — and the rehearsal renders the same object as the live
+│                   │                                #   run. Also two AST sweeps over the entrypoints: every one builds and echoes, and
+│                   │                                #   every --dry-run branch renders a context instead of assembling its own preview
+│                   ├── test_every_context_FIELD_STATES_ITSELF.py # Phase 4 r6. Every field of RunContext names its marker, its
+│                   │                                #   algorithm, its override-or-none and its scope of effect. The population is
+│                   │                                #   dataclasses.fields() — a language primitive, which is why this is NOT the tree-wide
+│                   │                                #   enumeration the phase deleted: that one had no population to read (four marker
+│                   │                                #   conventions, zero hits across 225 files). Asserts PRESENCE, never truth
 │                   ├── test_dispatch_identity.py    # The BEHAVIOURAL half of Phase 9 r3 and r4, against a real journal root — the sweeps
 │                   │                                #   are source greps and both requirements fail in ways a grep cannot see. r3's failure
 │                   │                                #   is SILENT (two bags for one run reads as two runs forever); r4's is a child quietly

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -263,7 +263,7 @@ claude-dot-files/
 │           └── tests/                               # TIER 3 — this code unit owns its tests (Testing Standard § per-unit ownership)
 │               ├── conftest.py                      # Component-scoped import path (replaces the per-file sys.path preambles), AND the
 │               │                                    #   session-wide autouse fixture that points every bag the suite opens at a temp
-│               │                                    #   root — the FIX for the defect test_the_suite_never_writes_… guards, since five
+│               │                                    #   root — the FIX for the defect test_the_suite_never_writes_… guards, since six
 │               │                                    #   unit modules drive an entrypoint main() and were writing real bags into the
 │               │                                    #   operator's ~/.local/state/. Redirects CONFIG_PATH, not XDG_STATE_HOME, so a
 │               │                                    #   configured root cannot silently lose the protection
@@ -328,8 +328,11 @@ claude-dot-files/
 │                   │                                                   #   alias cannot hide it (review_pr_workflow reaches it as _shared., and
 │                   │                                                   #   the act.-keyed predicates in test_isolation_invariants are blind to
 │                   │                                                   #   that today). Received = a .worktree_name attribute, or a PARAMETER
-│                   │                                                   #   of that name — a local assignment is not received, which is what all
-│                   │                                                   #   eleven sites were. A fourth spelling fails without being anticipated
+│                   │                                                   #   of that name, NOT rebound inside it. Ten sites were local assignments
+│                   │                                                   #   and the 11th was an inline argument with none — an assignment-keyed
+│                   │                                                   #   guard would have walked past it, which is how base_ref's first guard
+│                   │                                                   #   shipped green. A fourth spelling fails without being anticipated, and a
+│                   │                                                   #   CLOCK read at the call site is assembly whatever else it references
 │                   ├── test_a_new_branch_STARTS_FROM_THE_DEFAULT_BRANCH.py # A run with no --pr is cut from the DEFAULT BRANCH, never the
 │                   │                                                   #   operator's HEAD. Keyed on worktree_add's ref argument, so an inline
 │                   │                                                   #   literal is as visible as an assignment — the 11th call site was inline.
@@ -592,7 +595,7 @@ claude-dot-files/
 │                   │                                #   as one checked at all eight. Missing / mismatched / unlisted are distinguished — the
 │                   │                                #   third is a write landing AFTER the seal, invisible to any check that walks the manifest
 │                   ├── test_the_suite_never_writes_to_the_operators_journal.py # Making bag-open structural made the SUITE a
-│                   │                                #   dispatch: five modules drive an entrypoint main(), so every pytest run left a real bag
+│                   │                                #   dispatch: six modules drive an entrypoint main(), so every pytest run left a real bag
 │                   │                                #   under ~/.local/state — 24 in one day, and the integration tier was grading them as
 │                   │                                #   dispatch output. Keyed on the observable (did the real root change), not the mechanism
 │                   ├── test_journal_containment.py  # The CLASS behind four escapes found one-per-review-pass: an externally-supplied string
@@ -629,8 +632,10 @@ claude-dot-files/
 │                   │                                #   because the drift was in a single runner), the object is frozen, the echo is gated on
 │                   │                                #   `is_the_run` rather than on `minted` — a retry supplies its name and is exactly the
 │                   │                                #   caller who needs the echo — and the rehearsal renders the same object as the live
-│                   │                                #   run. Also two AST sweeps over the entrypoints: every one builds and echoes, and
-│                   │                                #   every --dry-run branch renders a context instead of assembling its own preview
+│                   │                                #   run. Also AST sweeps over the entrypoints: every one builds and echoes, the echo
+│                   │                                #   PRECEDES the bag and is unconditional (presence alone was blind — moving it below
+│                   │                                #   bag-open left the tier green), and every --dry-run branch renders a context inside
+│                   │                                #   that branch instead of assembling its own preview
 │                   ├── test_every_context_FIELD_STATES_ITSELF.py # Phase 4 r6. Every field of RunContext names its marker, its
 │                   │                                #   algorithm, its override-or-none and its scope of effect. The population is
 │                   │                                #   dataclasses.fields() — a language primitive, which is why this is NOT the tree-wide
@@ -678,7 +683,10 @@ claude-dot-files/
 │                                                    #   call must sit inside a `try` whose except catches RuntimeError, which its failure
 │                                                    #   message had demanded in prose since it was written while nothing checked it —
 │                                                    #   run_plan.py had drifted above the handler, turning a bad --run-id and a full journal
-│                                                    #   into tracebacks in one file of eleven and one-line diagnostics in the other ten
+│                                                    #   into tracebacks in one file of eleven and one-line diagnostics in the other ten.
+│                                                    #   Placement covers RunContext.build as well as open_run_bag — both raise a
+│                                                    #   RuntimeError carrying an operator remedy, and a guard watching only the older of
+│                                                    #   the two was measured blind to the newer one
 │
 ├── testing/                                         # TIER 1 + TIER 2 of the Testing Standard's three-tier hierarchy
 │   ├── README.md                                    # How to run the suite and how to add a test

--- a/scripts/workflows/temporal/modules/assistant/build/build/build_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/build/build/build_workflow.py
@@ -108,7 +108,7 @@ def run_build(task: BuildInput, repo_root: Path, worktree_name: str) -> BuildRes
     # --- Steps 2 & 3: REFINE then DISPOSITION, bounded by helper.MAX_LOOPS ---
     loops = 0
     verdict = _refine_then_dispose(task, description, pr, repo_root,
-                                   worktree, notes, correction=False)
+                                   worktree, worktree_name, notes, correction=False)
 
     while helper.should_loop_back(verdict, loops):
         loops += 1
@@ -121,7 +121,7 @@ def run_build(task: BuildInput, repo_root: Path, worktree_name: str) -> BuildRes
                      + (" This is the last automated pass."
                         if loops == helper.MAX_LOOPS else ""))
         verdict = _refine_then_dispose(task, description, pr, repo_root, worktree,
-                                       notes, correction=True,
+                                       worktree_name, notes, correction=True,
                                        loops_left=helper.MAX_LOOPS - loops)
 
     if verdict is Verdict.HOLD_NEEDS_ASSISTANCE:
@@ -155,7 +155,7 @@ def run_build(task: BuildInput, repo_root: Path, worktree_name: str) -> BuildRes
 
 
 def _refine_then_dispose(task: BuildInput, description: str, pr: str,
-                         repo_root: Path, worktree: Path,
+                         repo_root: Path, worktree: Path, worktree_name: str,
                          notes: list[str], *, correction: bool,
                          loops_left: int = 0) -> Verdict:
     """One refine pass followed by one disposition pass."""
@@ -205,9 +205,13 @@ def _refine_then_dispose(task: BuildInput, description: str, pr: str,
     if hold is not None:
         return hold
 
+    # THREADED FROM THE RUN'S CONTEXT, NOT REBUILT. `run_review` cuts a
+    # per-pass tree on the PR's branch and takes the run's own worktree name
+    # as its stem, so the tree it makes is traceable to the run the bag
+    # recorded. See `review_pr_workflow.run_review`.
     result = review_pr.run_review(
         ReviewInput(pr_number=pr, repo_target=task.repo_target, verbose=task.verbose),
-        repo_root,
+        repo_root, worktree_name=worktree_name,
     )
     notes.extend(result.notes)
     return Verdict(result.verdict.value)

--- a/scripts/workflows/temporal/modules/assistant/build/build_minor/build_minor_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/build/build_minor/build_minor_workflow.py
@@ -72,7 +72,7 @@ def run_build_minor(task: BuildInput, repo_root: Path, worktree_name: str) -> Bu
 
     loops = 0
     verdict = _refine_then_dispose(task, description, pr, repo_root,
-                                   worktree, notes, correction=False)
+                                   worktree, worktree_name, notes, correction=False)
 
     # Same bound as the major tier and for the same reason: self-correction
     # plateaus at roughly 3-5 passes, and past it the model justifies rather than
@@ -84,7 +84,7 @@ def run_build_minor(task: BuildInput, repo_root: Path, worktree_name: str) -> Bu
                      + (" The last automated pass."
                         if loops == helper.MAX_LOOPS else ""))
         verdict = _refine_then_dispose(task, description, pr, repo_root, worktree,
-                                       notes, correction=True,
+                                       worktree_name, notes, correction=True,
                                        loops_left=helper.MAX_LOOPS - loops)
 
     if verdict is Verdict.HOLD_NEEDS_ASSISTANCE:
@@ -106,7 +106,7 @@ def run_build_minor(task: BuildInput, repo_root: Path, worktree_name: str) -> Bu
 
 
 def _refine_then_dispose(task: BuildInput, description: str, pr: str,
-                         repo_root: Path, worktree: Path,
+                         repo_root: Path, worktree: Path, worktree_name: str,
                          notes: list[str], *, correction: bool,
                          loops_left: int = 0) -> Verdict:
     ci_settled = wait_for_ci(pr, repo_root=repo_root)
@@ -132,10 +132,14 @@ def _refine_then_dispose(task: BuildInput, description: str, pr: str,
     if hold is not None:
         return hold
 
+    # THREADED FROM THE RUN'S CONTEXT, NOT REBUILT. `run_review` cuts a
+    # per-pass tree on the PR's branch and takes the run's own worktree name
+    # as its stem, so the tree it makes is traceable to the run the bag
+    # recorded. See `review_pr_workflow.run_review`.
     result = review_pr.run_review(
         ReviewInput(pr_number=pr, repo_target=task.repo_target,
                     verbose=task.verbose, review_type=ReviewType.BUILD),
-        repo_root,
+        repo_root, worktree_name=worktree_name,
     )
     notes.extend(result.notes)
     return Verdict(result.verdict.value)

--- a/scripts/workflows/temporal/modules/assistant/plan/plan/plan_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan/plan_workflow.py
@@ -79,7 +79,7 @@ def run_plan(*, component: Path, repo_root: Path, worktree_name: str,
 
     verdict = _refine_size_and_dispose(
         component=component, repo_root=repo_root, worktree=worktree,
-        sprint_path=sprint_path, candidates_path=candidates_path, pr=pr,
+        worktree_name=worktree_name, sprint_path=sprint_path, candidates_path=candidates_path, pr=pr,
         repo_target=repo_target, notes=notes, correction_pass=False,
         verbose=verbose,
     )
@@ -118,7 +118,7 @@ def run_plan(*, component: Path, repo_root: Path, worktree_name: str,
         notes.append(f"HOLD (redispatch): loop-back {loops} of {routing.MAX_LOOPS}.")
         verdict = _refine_size_and_dispose(
             component=component, repo_root=repo_root, worktree=worktree,
-            sprint_path=sprint_path, candidates_path=candidates_path, pr=pr,
+            worktree_name=worktree_name, sprint_path=sprint_path, candidates_path=candidates_path, pr=pr,
             repo_target=repo_target, notes=notes, correction_pass=True,
             verbose=verbose,
         )
@@ -142,6 +142,7 @@ def run_plan(*, component: Path, repo_root: Path, worktree_name: str,
 
 
 def _refine_size_and_dispose(*, component: Path, repo_root: Path, worktree: Path,
+                             worktree_name: str,
                              sprint_path: Path, candidates_path: Path, pr: str,
                              repo_target: str | None, notes: list[str],
                              correction_pass: bool, verbose: bool) -> routing.Verdict:
@@ -179,10 +180,14 @@ def _refine_size_and_dispose(*, component: Path, repo_root: Path, worktree: Path
     if hold is not None:
         return hold
 
+    # THREADED FROM THE RUN'S CONTEXT, NOT REBUILT. `run_review` cuts a
+    # per-pass tree on the PR's branch and takes the run's own worktree name
+    # as its stem, so the tree it makes is traceable to the run the bag
+    # recorded. See `review_pr_workflow.run_review`.
     result = review_pr.run_review(
         ReviewInput(pr_number=pr, repo_target=repo_target,
                     review_type=ReviewType.PLANNING, verbose=verbose),
-        repo_root,
+        repo_root, worktree_name=worktree_name,
     )
     notes.extend(result.notes)
     return result.verdict

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_workflow.py
@@ -171,7 +171,7 @@ def run_plan_project(*, repo_root: Path, worktree_name: str,
 
     # --- Step 3: DISPOSITION, with one bounded loop-back -------------------
     loops = 0
-    verdict = _dispose(pr, repo_root, repo_target, notes, verbose)
+    verdict = _dispose(pr, repo_root, repo_target, worktree_name, notes, verbose)
 
     while routing.should_loop_back(verdict, loops):
         loops += 1
@@ -212,7 +212,7 @@ def run_plan_project(*, repo_root: Path, worktree_name: str,
             candidates_path=candidates_path, research_dir=research_dir,
             pr_number=pr, verbose=verbose,
         )
-        verdict = _dispose(pr, repo_root, repo_target, notes, verbose)
+        verdict = _dispose(pr, repo_root, repo_target, worktree_name, notes, verbose)
 
     if verdict is routing.Verdict.HOLD_NEEDS_ASSISTANCE:
         # THE LOOP DECISION AND NOTHING ELSE. Wiring the CI gate into `_dispose`
@@ -242,6 +242,7 @@ def run_plan_project(*, repo_root: Path, worktree_name: str,
 
 
 def _dispose(pr: str, repo_root: Path, repo_target: str | None,
+             worktree_name: str,
              notes: list[str], verbose: bool) -> routing.Verdict:
     """One disposition pass, judged against the PLANNING criteria, behind the gate.
 
@@ -272,10 +273,14 @@ def _dispose(pr: str, repo_root: Path, repo_target: str | None,
     if hold is not None:
         return hold
 
+    # THREADED FROM THE RUN'S CONTEXT, NOT REBUILT. `run_review` cuts a
+    # per-pass tree on the PR's branch and takes the run's own worktree name
+    # as its stem, so the tree it makes is traceable to the run the bag
+    # recorded. See `review_pr_workflow.run_review`.
     result = review_pr.run_review(
         ReviewInput(pr_number=pr, repo_target=repo_target,
                     review_type=ReviewType.PLANNING, verbose=verbose),
-        repo_root,
+        repo_root, worktree_name=worktree_name,
     )
     notes.extend(result.notes)
     return result.verdict

--- a/scripts/workflows/temporal/modules/assistant/research/research/research_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/research/research/research_workflow.py
@@ -58,7 +58,7 @@ def run_research(*, research_dir: Path, repo_root: Path, worktree_name: str,
 
     loops = 0
     verdict = _verify_then_dispose(research_dir, pr, repo_root, worktree,
-                                   notes, verbose, correction=False)
+                                   worktree_name, notes, verbose, correction=False)
 
     # ONE loop-back. Self-correction plateaus at 3-5 passes; past it the model
     # justifies rather than corrects. Counting across the pipeline:
@@ -67,7 +67,7 @@ def run_research(*, research_dir: Path, repo_root: Path, worktree_name: str,
         loops += 1
         notes.append("HOLD (redispatch): looping back ONCE — the last automated pass.")
         verdict = _verify_then_dispose(research_dir, pr, repo_root, worktree,
-                                       notes, verbose, correction=True)
+                                       worktree_name, notes, verbose, correction=True)
 
     if verdict is Verdict.HOLD_NEEDS_ASSISTANCE:
         # THE LOOP DECISION AND NOTHING ELSE. Wiring the CI gate above gave this
@@ -88,7 +88,8 @@ def run_research(*, research_dir: Path, repo_root: Path, worktree_name: str,
 
 
 def _verify_then_dispose(research_dir: Path, pr: str, repo_root: Path,
-                         worktree: Path, notes: list[str], verbose: bool,
+                         worktree: Path, worktree_name: str,
+                         notes: list[str], verbose: bool,
                          *, correction: bool) -> Verdict:
     verify.run_verify(
         research_dir=research_dir, pr_number=pr, repo_root=repo_root,
@@ -119,9 +120,13 @@ def _verify_then_dispose(research_dir: Path, pr: str, repo_root: Path,
 
     # --type research: candidates are CARGO, not findings. A clean research PR
     # returns MERGE with zero findings, and that is the expected outcome.
+    # THREADED FROM THE RUN'S CONTEXT, NOT REBUILT. `run_review` cuts a
+    # per-pass tree on the PR's branch and takes the run's own worktree name
+    # as its stem, so the tree it makes is traceable to the run the bag
+    # recorded. See `review_pr_workflow.run_review`.
     result = review_pr.run_review(
         ReviewInput(pr_number=pr, verbose=verbose, review_type=ReviewType.RESEARCH),
-        repo_root,
+        repo_root, worktree_name=worktree_name,
     )
     notes.extend(result.notes)
     return result.verdict

--- a/scripts/workflows/temporal/modules/assistant/review_pr/review_pr_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/review_pr/review_pr_workflow.py
@@ -204,8 +204,16 @@ def run_review(task: ReviewInput, worktree: Path, *,
     # The reviewer must read the PR's branch, not the repo's checkout. The name
     # DERIVES FROM THE ONE THIS RUN WAS GIVEN — no clock, and nothing assembled
     # from values this function was not handed.
+    #
+    # ⚠ THE PR NUMBER STAYS IN THE NAME AND THAT IS NOT DECORATION. The stem is
+    # `<workflow-key>-<ts>`, so two `review-pr` dispatches against DIFFERENT PRs
+    # that start in the same wall-clock second share a stem — and on their first
+    # pass they would share the whole directory. The expression this replaced
+    # carried `pr` for exactly that reason; dropping it in the consolidation
+    # would have been a regression the run-context field's own scope-of-effect
+    # docstring predicts ("two runs collide on one directory").
     pr_tree = _shared.worktree_add(
-        worktree, f"{worktree_name}-review-{this_pass}",
+        worktree, f"{worktree_name}-review-{task.pr_number}-{this_pass}",
         f"origin/{pr['headRefName']}",
     )
     # THE NONCE BINDS THE LOG'S NAME, not just the record inside it — this

--- a/scripts/workflows/temporal/modules/assistant/review_pr/review_pr_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/review_pr/review_pr_workflow.py
@@ -133,8 +133,29 @@ def _append_shadow_pair(log_file, *, invocation_id: str, pr: str, expected_ref) 
         pass
 
 
-def run_review(task: ReviewInput, worktree: Path) -> ReviewResult:
-    """Disposition one PR and return its typed verdict."""
+def run_review(task: ReviewInput, worktree: Path, *,
+               worktree_name: str) -> ReviewResult:
+    """Disposition one PR and return its typed verdict.
+
+    `worktree_name` IS RECEIVED, NEVER ASSEMBLED HERE, and this parameter is the
+    whole of Workflow Decomposition Phase 4's reconciliation of `review-pr`.
+    This function used to build `f"review-pr-{pr}-{int(time.time())}"` inline —
+    the eleventh and oddest of the eleven sites that derived a worktree name for
+    themselves, and the one with no assignment to key a guard on. Worse, it made
+    the fleet contradict itself: `run_review_pr.py` recorded
+    `worktree_name=None` in the run bag with the comment *"the ONE workflow that
+    cuts no worktree"*, while this line cut one. Nothing was lying — the two
+    halves were written in two places and only one was updated.
+
+    THE TREE THIS CUTS IS PER-PASS, NOT PER-RUN, WHICH IS WHY THE NAME ARRIVES
+    RATHER THAN COMING OFF A CONTEXT FIELD DIRECTLY. A parent calls this once
+    per loop-back on one run, each pass needing its own tree on the PR's branch,
+    so the value cannot be a frozen boundary field — `dispatch_context.py`'s own rule
+    is that a value computed inside the work is not a context field. What IS
+    run-scoped is the STEM: the entrypoint passes `ctx.worktree_name`, a parent
+    passes the name of the tree it is working in, and the pass number — which
+    this function reads off the PR's own history — makes it unique.
+    """
     notes: list[str] = []
 
     pr = act.fetch_pr(task.pr_number, worktree)
@@ -180,9 +201,11 @@ def run_review(task: ReviewInput, worktree: Path) -> ReviewResult:
         invocation_id=invocation_id,
     )
 
-    # The reviewer must read the PR's branch, not the repo's checkout.
+    # The reviewer must read the PR's branch, not the repo's checkout. The name
+    # DERIVES FROM THE ONE THIS RUN WAS GIVEN — no clock, and nothing assembled
+    # from values this function was not handed.
     pr_tree = _shared.worktree_add(
-        worktree, f"review-pr-{task.pr_number}-{int(time.time())}",
+        worktree, f"{worktree_name}-review-{this_pass}",
         f"origin/{pr['headRefName']}",
     )
     # THE NONCE BINDS THE LOG'S NAME, not just the record inside it — this

--- a/scripts/workflows/temporal/modules/journal/journal_activities.py
+++ b/scripts/workflows/temporal/modules/journal/journal_activities.py
@@ -230,6 +230,7 @@ def _git(repo_root: Path, *args: str) -> str:
 
 def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
                  workflow_key: str, worktree_name: str | None,
+                 journal_root: Path | None = None,
                  config_path: Path | None = None,
                  env: Mapping[str, str] | None = None) -> Bag:
     """Resolve the journal root and open this run's bag. Raises to stop the run.
@@ -271,8 +272,14 @@ def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
     optional control is a skipped control; a keyword with no default applies it
     to the package's own parameter, and the next entrypoint added fails at the
     call rather than writing a placeholder nobody notices. Pass `None`
-    explicitly to state that a workflow cuts no worktree — `run_review_pr` is the
-    one that genuinely does not.
+    explicitly to state that a workflow cuts no worktree.
+
+    ⚠ NO ENTRYPOINT PASSES `None` TODAY, AND THE ONE THAT USED TO WAS WRONG.
+    `run_review_pr` passed it with the comment *"the ONE workflow that cuts no
+    worktree — it reviews a PR in place"*, while `review_pr_workflow` cut one
+    through `worktree_add` on the very next call. The `None` arm stays because
+    the distinction it draws is real and a future workflow may need it; what is
+    gone is the claim that anything currently uses it.
 
     THE ORIGINATING REPO IS A FIRST-CLASS FIELD, recorded here rather than left
     to Phase 3. The run log it supersedes is keyed per repo CHECKOUT while the
@@ -284,6 +291,19 @@ def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
     different questions. `repo_root` under this fleet is usually a worktree, which
     is the run's actual working directory; the remote is the stable project
     identity that every worktree of that project shares.
+
+    `journal_root` IS THE BOUNDARY'S ANSWER, TAKEN RATHER THAN RE-DERIVED.
+    Workflow Decomposition Phase 4 resolves the root once at the dispatch
+    boundary, as a field on the run context, so the run can NAME it before it
+    spends anything and so an unusable root stops the run one step earlier. When
+    a caller supplies it, this activity uses it; when nobody does, it resolves
+    the root itself exactly as before. Both halves are load-bearing: the second
+    is what keeps `validate_bag`, the tests and any future caller with no context
+    working unchanged, and the first is what stops the fleet holding two answers
+    to one question. It is NOT re-validated here — the boundary already refused
+    a relative path, a symlink, a root inside a repo, a wrong owner and a wrong
+    mode, and running those again would mean two places could disagree about
+    what a usable root is.
 
     RAISES `RuntimeError` (`JournalRootError` or `BagError`), which every
     entrypoint's existing precondition handler already prints. That is r9: the
@@ -300,7 +320,8 @@ def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
     traceback for precisely the steady-state failure — a full journal — that r9's
     whole argument is built on being diagnosable without a working journal.
     """
-    root = resolve_journal_root(config=load_journal_config(config_path), env=env)
+    root = journal_root if journal_root is not None else resolve_journal_root(
+        config=load_journal_config(config_path), env=env)
 
     remote = _git(repo_root, "remote", "get-url", "origin")
     commit = _git(repo_root, "rev-parse", "HEAD")

--- a/scripts/workflows/temporal/modules/journal/journal_activities.py
+++ b/scripts/workflows/temporal/modules/journal/journal_activities.py
@@ -292,6 +292,16 @@ def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
     is the run's actual working directory; the remote is the stable project
     identity that every worktree of that project shares.
 
+    ⚠ `worktree_name` MAY BE A STEM RATHER THAN A DIRECTORY THAT EXISTS, and
+    `review-pr` is the one caller for which it is. That run's context names
+    `review-pr-<ts>`; the tree actually cut is `review-pr-<ts>-review-<pr>-<pass>`,
+    because a loop-back cuts one tree per review PASS and the pass number is not
+    knowable here — buying it costs a `gh` round trip, and the bag opens before
+    the first side effect. So this field is the run-scoped STEM every tree the
+    run cuts is prefixed with, which is derivable and greppable, rather than
+    `None` claiming no tree exists at all. A consumer resolving it to a path
+    must prefix-match.
+
     `journal_root` IS THE BOUNDARY'S ANSWER, TAKEN RATHER THAN RE-DERIVED.
     Workflow Decomposition Phase 4 resolves the root once at the dispatch
     boundary, as a field on the run context, so the run can NAME it before it
@@ -304,6 +314,16 @@ def open_run_bag(*, run_id: str, writer: str | None, repo_root: Path,
     a relative path, a symlink, a root inside a repo, a wrong owner and a wrong
     mode, and running those again would mean two places could disagree about
     what a usable root is.
+
+    ⚠ AND IT SUPERSEDES `config_path` AND `env`, WHICH ARE THEN UNREAD. Those
+    two exist to steer the resolution this parameter replaces, so passing a root
+    alongside either is a caller asking for two answers; the root wins and the
+    other two do nothing. No caller does this today — the entrypoints pass
+    `journal_root` and nothing else, the validator and the tests pass
+    `config_path` and nothing else — and it is written down rather than guarded
+    because a guard for a combination nobody writes is speculation, while a
+    silent precedence nobody documented is how a redirected test asserts against
+    the wrong root and passes.
 
     RAISES `RuntimeError` (`JournalRootError` or `BagError`), which every
     entrypoint's existing precondition handler already prints. That is r9: the

--- a/scripts/workflows/temporal/scripts/dispatch_context.py
+++ b/scripts/workflows/temporal/scripts/dispatch_context.py
@@ -59,14 +59,24 @@ from __future__ import annotations
 
 import sys
 import time
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 
+# `derivation` — the four-part contract every field below states — lives beside
+# `RunIdentity` rather than here, because `RunIdentity`'s own three fields use
+# it and the import runs context -> identity. Read it there; it is the
+# documentation contract for THIS object.
 from dispatch_identity import RunIdentity, derivation, resolve_identity
 from modules.journal.journal_activities import load_journal_config
 from modules.journal.root import resolve_journal_root
 
-__all__ = ["RunContext", "DRY_RUN_RUN_ID"]
+__all__ = ["RunContext", "DRY_RUN_RUN_ID", "context_field_documentation"]
+
+#: What `clock` is: the wall clock, injected so a test can pin the instant the
+#: worktree name is stamped with. Named rather than left implicit because this
+#: module's whole subject is stating what a value is.
+Clock = Callable[[], float]
 
 # The run id a rehearsal carries. A dry run states "nothing invoked, nothing
 # posted", and minting a name would make that false — `resolve_identity`'s own
@@ -176,8 +186,11 @@ class RunContext(RunIdentity):
         marker="the positional path the operator pointed the run at, already "
                "resolved against `repo_root` and refused if it escapes.",
         algorithm="the entrypoint's resolved operator path, stated "
-                  "repo-relative. `None` for the runs that take no target — "
-                  "`build`, `build-minor`, `plan-project` and `review-pr`.",
+                  "repo-relative. `None` for the FIVE runs that take no "
+                  "target — `build`, `build-minor`, `plan-project`, "
+                  "`review-pr` and `plan-revision`, which revises whatever a "
+                  "free-text description names and has no operator-supplied "
+                  "PATH at all.",
         override="the positional argument is itself the only input.",
         scope="THE ONE A WRONG ANSWER IS SILENT ABOUT, and the reason this "
               "object echoes at all. A wrong target plans, researches or "
@@ -187,11 +200,28 @@ class RunContext(RunIdentity):
               "why the echo happens before the first side effect rather than "
               "somewhere in the transcript."))
 
+    @staticmethod
+    def _worktree_name(workflow_key: str, clock: Clock) -> str:
+        """The run's tree name, derived in ONE place for both constructors.
+
+        ⚠ THIS FUNCTION EXISTS BECAUSE THE EXPRESSION WAS WRITTEN TWICE, INSIDE
+        THE OBJECT BUILT TO END THAT. `build` and `for_dry_run` each carried
+        `f"{workflow_key}-{int(clock())}"`, and every worktree-name assertion in
+        the suite drove the rehearsal, so perturbing the LIVE copy alone left
+        3051 tests green while a rehearsal previewed a name the run would not
+        use. That is requirement 4's own defect — a rule with two statements
+        that agree until one is edited — reproduced one level inside its fix,
+        and it is the same shape as `run_build_minor` naming its trees `build-…`
+        under `workflow_key="build-minor"`. Measured 2026-09-01 by mutation.
+        """
+        return f"{workflow_key}-{int(clock())}"
+
     @classmethod
     def build(cls, *, identity: RunIdentity, repo_root: Path, workflow_key: str,
               pr_number: str | None = None, target: str | None = None,
               config_path: Path | None = None,
-              env=None, clock=time.time) -> "RunContext":
+              env: Mapping[str, str] | None = None,
+              clock: Clock = time.time) -> "RunContext":
         """The dispatch boundary. Everything derived, once, before anything runs.
 
         RESOLVES THE JOURNAL ROOT HERE RATHER THAN LEAVING IT TO `open_run_bag`,
@@ -214,14 +244,14 @@ class RunContext(RunIdentity):
             run_id=identity.run_id, writer=identity.writer, minted=identity.minted,
             repo_root=repo_root, journal_root=journal_root,
             workflow_key=workflow_key,
-            worktree_name=f"{workflow_key}-{int(clock())}",
+            worktree_name=cls._worktree_name(workflow_key, clock),
             pr_number=pr_number, target=target,
         )
 
     @classmethod
     def for_dry_run(cls, *, repo_root: Path, workflow_key: str,
                     pr_number: str | None = None, target: str | None = None,
-                    clock=time.time) -> "RunContext":
+                    clock: Clock = time.time) -> "RunContext":
         """The same object for a rehearsal — nothing minted, nothing created.
 
         ⚠ THE BOUNDARY IS NARROWER THAN "THE ENTRYPOINT", which is why this
@@ -240,7 +270,7 @@ class RunContext(RunIdentity):
         return cls(
             run_id=DRY_RUN_RUN_ID, writer=None, minted=False,
             repo_root=repo_root, journal_root=None, workflow_key=workflow_key,
-            worktree_name=f"{workflow_key}-{int(clock())}",
+            worktree_name=cls._worktree_name(workflow_key, clock),
             pr_number=pr_number, target=target,
         )
 
@@ -264,7 +294,14 @@ class RunContext(RunIdentity):
                    else "(a new one will be opened)"),
         ]
         width = max(len(label) for label, _ in rows)
-        head = "run context — derived here, before anything is created:"
+        # ⚠ NOT "before anything is created", WHICH IS WHAT THIS SAID AND WHICH
+        # IS FALSE ON THE LIVE PATH. `build` resolves the journal root, and
+        # `resolve_journal_root` CREATES it at 0700 when absent — it has to, or
+        # the line below could not name it. Nothing this run will spend money on
+        # has happened; a directory has. The header says the true thing, because
+        # a reader who later discovers the mkdir discounts the whole block.
+        head = ("run context — derived here, before this run cuts, "
+                "posts or spends:")
         return "\n".join([head] + [f"  {label:<{width}} : {value}"
                                    for label, value in rows])
 
@@ -290,6 +327,18 @@ class RunContext(RunIdentity):
         answers "did I make the NAME"; the echo asks "did I make the CONTEXT",
         and `writer` is the field that answers it.
 
+        ⚠ AND `writer` IS A PROXY FOR "RECEIVED", NOT THE FACT ITSELF — stated
+        because it stops being true at a known trigger rather than gradually.
+        Today every context is constructed by the process that uses it, so the
+        gate is exact. A child invoked as a SEPARATE PROCESS constructs its own
+        context and cannot be handed one, so if such a child is also passed
+        `--writer` it will derive a worktree name and a target and say nothing —
+        the invisibility this object exists to close, on the runs that spend the
+        model time. `Dual-mode children` is the phase that adds six such
+        entrypoints, and it carries the checkbox for teaching this gate the
+        difference. Nothing in `scripts/` passes `--writer` today, so no live
+        run is affected.
+
         stderr rather than stdout because several entrypoints' stdout is a
         rendered report an operator or a tool reads.
         """
@@ -300,6 +349,12 @@ class RunContext(RunIdentity):
 
 def context_field_documentation() -> dict[str, dict[str, str]]:
     """Every field's four-part statement, read off the object itself.
+
+    ITS ONE CALLER IS `test_every_context_FIELD_STATES_ITSELF.py`, DELIBERATELY.
+    A helper nothing calls is a claim nothing checks; routing the guard through
+    this function is what makes the paragraph below load-bearing rather than
+    decorative, and it puts the "how the population is obtained" decision in the
+    module that owns the object rather than in the test that reads it.
 
     THE POPULATION IS `dataclasses.fields()`, WHICH IS THE ENTIRE ARGUMENT FOR
     DOING IT THIS WAY. It is a language primitive: no marker convention, no tree

--- a/scripts/workflows/temporal/scripts/dispatch_context.py
+++ b/scripts/workflows/temporal/scripts/dispatch_context.py
@@ -1,0 +1,311 @@
+"""What a run WORKED OUT for itself, computed once, said out loud.
+
+WHY THIS EXISTS. A wrong flag fails loudly at parse time. A wrong DERIVATION
+produces a plausible wrong run — the workflow competently plans the wrong
+component, opens a real pull request, and nothing anywhere goes red. Workflow
+Decomposition Phase 4 closes that class, and it does it by making the question
+smaller rather than by auditing it: a run has ONE place its derived values come
+from, that place is built once at the dispatch boundary, and the run states what
+it built before it does anything that costs money.
+
+  `derivation`   — the four things every field on this object must say (in
+                   `dispatch_identity`, beside `RunIdentity`, whose fields are
+                   the first three a run carries)
+  `RunContext`   — the frozen object itself; extends `RunIdentity`
+  `.build`       — the boundary constructor, for a run that will actually run
+  `.for_dry_run` — the same object for a rehearsal, which mints nothing,
+                   resolves no journal root and creates nothing
+  `.render`      — the ONE rendering, read by the echo and by every `--dry-run`
+
+THE OBJECT IS THE ENUMERATION, WHICH IS THE WHOLE POINT. The requirement this
+replaces asked for a published table of every derived value in the fleet, held
+honest by a check that read its population off the tree. That check ran cold and
+found there IS no enumerable population of derivations: four marker conventions
+returned zero hits across 225 files. A frozen dataclass's fields ARE an
+enumerable population — `dataclasses.fields()` returns them by construction — so
+a field cannot drift from the enumeration, because it IS the enumeration.
+
+  ⚠ A FIELD EXISTING IS NOT A FIELD BEING DOCUMENTED, and that is why every
+  field carries `derivation(...)` metadata and why
+  `test_every_context_FIELD_STATES_ITSELF.py` reads it back. Two of the five
+  safe-derivation properties — the published algorithm and the stated scope of
+  effect — ARE the documentation, so nothing checking it would let this object
+  ship nine fields with none.
+
+THE WORKTREE NAME IS THE VALUE THIS WAS BUILT FOR. It reached ELEVEN sites in
+THREE spellings — `f"<key>-{int(time.time())}"` at eight, an
+`int(__import__('time').time())` variant at two, and an inline argument at one —
+and `run_build_minor` had already DRIFTED: `workflow_key="build-minor"` with a
+worktree named `build-…`. The fleet has performed exactly this consolidation
+once before, on `base_ref`, at the same call sites, and that helper's docstring
+records what a hand sweep of eleven sites produces: a fix applied to ten.
+
+WHAT DOES NOT BELONG HERE, because the object becoming a grab-bag is the
+failure mode on the other side. The test for a field is *run-scoped and derived
+once at the boundary*. A value computed inside the work, from an argument the
+work was handed, is not a context field however convenient it would be to
+reach — `paper_currency` and `due_papers` are per-pool, and the sub-worktree one
+review PASS cuts is per-pass, so neither is here.
+
+AND "PREFER DERIVATION" IS NOT THE RULE THIS OBJECT IMPLIES. Repo identity is
+DECLARED (`--repo`, explicitly never derived from the working directory) while
+component scope is derived from the path the run was pointed at. Derivation is a
+per-value decision with a stated reason. This object changes where a derived
+value is computed and recorded, not which values are derived — `workflow_key`
+sits here and is declared, and its `derivation` metadata says so.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+
+from dispatch_identity import RunIdentity, derivation, resolve_identity
+from modules.journal.journal_activities import load_journal_config
+from modules.journal.root import resolve_journal_root
+
+__all__ = ["RunContext", "DRY_RUN_RUN_ID"]
+
+# The run id a rehearsal carries. A dry run states "nothing invoked, nothing
+# posted", and minting a name would make that false — `resolve_identity`'s own
+# docstring carries the same exemption for the same reason. It is deliberately
+# not a valid run id: nothing may open a bag with it.
+DRY_RUN_RUN_ID = "(dry run — no name minted, no bag opened)"
+
+
+@dataclass(frozen=True)
+class RunContext(RunIdentity):
+    """Everything one run DERIVED rather than was told, frozen at the boundary.
+
+    EXTENDS `RunIdentity` RATHER THAN SITTING BESIDE IT. Identity is the first
+    thing a run derives — the run id when nothing supplied one — so a second
+    object holding "the rest" would be two answers to one question and would put
+    `dataclasses.fields()` over half the population.
+
+    NOTHING DOWNSTREAM RE-DERIVES A FIELD THIS CARRIES. An object handed down is
+    not the same as an object in scope: if a callee still computes its own
+    worktree name because it can, the context has been ADDED without removing
+    the thing it replaces, and the fleet now has two answers where it had one.
+    `test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py` holds that for the one
+    value that was measurably scattered, and says in terms that it holds one
+    value at one call-site shape.
+    """
+
+    repo_root: Path = field(metadata=derivation(
+        marker="the `.git` that `git rev-parse --show-toplevel` reads — a fact "
+               "on disk, never a similarity judgement.",
+        algorithm="`preflight` runs `git rev-parse --show-toplevel` inside "
+                  "`--repo` when it was given and inside the process's working "
+                  "directory otherwise, and refuses anything that is not a "
+                  "repository.",
+        override="`--repo <path>` — a FILESYSTEM PATH, never a gh OWNER/NAME slug.",
+        scope="`.claude/worktrees/` and `.claude/logs/` both hang off it, so a "
+              "root resolved at a SUBDIRECTORY scatters worktrees and logs "
+              "where `/cleanup-merged-worktrees` never looks — and a later "
+              "cleanup deletes the logs along with the workspace, after which "
+              "cost accounting for those runs is unrecoverable. Six of seven V2 "
+              "entrypoints once dropped this resolution and used the working "
+              "directory. Under this fleet the answer is normally a WORKTREE "
+              "root, which is correct for a dispatch and wrong for a tool that "
+              "expects the main checkout."))
+
+    journal_root: Path | None = field(metadata=derivation(
+        marker="`config.yaml`'s `journal.root:`, or the deployment shape's "
+               "documented default — XDG_STATE_HOME for `user`, /var/lib for "
+               "`systemd`. The `container` shape has no derivable default and "
+               "is refused rather than guessed.",
+        algorithm="`resolve_journal_root` takes the configured path or the "
+                  "shape's documented default, refuses a relative path, a "
+                  "symlink, a path inside a git working tree, a wrong owner or "
+                  "a mode that is not 0700, and creates it at 0700 when absent. "
+                  "`None` on a rehearsal, which resolves nothing and creates "
+                  "nothing.",
+        override="`journal.root:` in config.yaml.",
+        scope="wrong ⇒ every verbatim transcript and every cost record this run "
+              "writes lands somewhere nobody reads, or inside a repo where it "
+              "gets committed and pushed. Resolved HERE rather than inside "
+              "`open_run_bag` so an unusable root stops the run one step "
+              "earlier and so the echo can name it before the run spends "
+              "anything."))
+
+    workflow_key: str = field(metadata=derivation(
+        marker="none — this field is DECLARED by the entrypoint, not derived, "
+               "and it is here because a declared value still has to travel "
+               "with the derived ones it feeds.",
+        algorithm="the literal each entrypoint passes to `RunContext.build`. It "
+                  "is the key `config.yaml` looks a model up under, the key the "
+                  "bag files the run as, and the stem `worktree_name` is built "
+                  "from.",
+        override="none — a run cannot be told it is a different workflow.",
+        scope="wrong ⇒ the bag files this run as another workflow AND the "
+              "worktree derived from it is named for one. `run_build_minor` "
+              "carried exactly that: `workflow_key=\"build-minor\"` beside a "
+              "worktree named `build-…`, which is the drift this field's "
+              "consolidation fixes."))
+
+    worktree_name: str = field(metadata=derivation(
+        marker="`workflow_key` and the wall clock, read once at this boundary.",
+        algorithm="`f\"{workflow_key}-{int(time.time())}\"`, computed once here "
+                  "and passed to every caller of `worktree_add`. No entrypoint "
+                  "and no workflow module assembles it.",
+        override="none.",
+        scope="wrong ⇒ two runs collide on one directory under "
+              "`.claude/worktrees/`, or a run's tree is named for a workflow "
+              "that is not the one running and `/cleanup-merged-worktrees` "
+              "cannot pair the tree with its PR. Eleven sites derived this in "
+              "three spellings before it moved here, and one had already "
+              "drifted from the key it was supposed to follow."))
+
+    pr_number: str | None = field(metadata=derivation(
+        marker="the `--pr` flag, and nothing else.",
+        algorithm="taken verbatim from `--pr`; `None` means this run opens a PR "
+                  "of its own rather than continuing one. It is NOT parsed back "
+                  "out of a URL here — `routing.pr_number_from_url` does that "
+                  "mid-run for a PR the run has just opened, which is not a "
+                  "boundary value.",
+        override="`--pr <n>` is itself the only input.",
+        scope="wrong ⇒ the run comments on, corrects or disposes somebody "
+              "else's pull request. It also decides the base a worktree is cut "
+              "from (`base_ref`), so a wrong number branches this run's work off "
+              "unrelated commits — the shape that put another PR's commits into "
+              "three of eight open PRs on 2026-08-20."))
+
+    target: str | None = field(metadata=derivation(
+        marker="the positional path the operator pointed the run at, already "
+               "resolved against `repo_root` and refused if it escapes.",
+        algorithm="the entrypoint's resolved operator path, stated "
+                  "repo-relative. `None` for the runs that take no target — "
+                  "`build`, `build-minor`, `plan-project` and `review-pr`.",
+        override="the positional argument is itself the only input.",
+        scope="THE ONE A WRONG ANSWER IS SILENT ABOUT, and the reason this "
+              "object echoes at all. A wrong target plans, researches or "
+              "triages the WRONG component competently: it reads real files, "
+              "opens a real pull request, and nothing goes red. Every other "
+              "field here fails loudly somewhere; this one does not, which is "
+              "why the echo happens before the first side effect rather than "
+              "somewhere in the transcript."))
+
+    @classmethod
+    def build(cls, *, identity: RunIdentity, repo_root: Path, workflow_key: str,
+              pr_number: str | None = None, target: str | None = None,
+              config_path: Path | None = None,
+              env=None, clock=time.time) -> "RunContext":
+        """The dispatch boundary. Everything derived, once, before anything runs.
+
+        RESOLVES THE JOURNAL ROOT HERE RATHER THAN LEAVING IT TO `open_run_bag`,
+        and the choice was not obvious. Resolving at the boundary means an
+        unusable root stops the run one step earlier, and it means the echo can
+        NAME the root before the run spends anything — a run that says where its
+        record is going is the point of the echo. What it costs is that
+        `open_run_bag` stops owning a decision it has always owned; it keeps its
+        own resolution for every caller that has no context (the validator, the
+        tests) and takes this answer when one is passed, so there is one
+        resolution per run rather than two.
+
+        `clock` IS INJECTED FOR THE TESTS AND FOR NOTHING ELSE. The worktree name
+        is the value this object exists to consolidate, so a test has to be able
+        to pin it without pinning the module's clock globally.
+        """
+        journal_root = resolve_journal_root(
+            config=load_journal_config(config_path), env=env)
+        return cls(
+            run_id=identity.run_id, writer=identity.writer, minted=identity.minted,
+            repo_root=repo_root, journal_root=journal_root,
+            workflow_key=workflow_key,
+            worktree_name=f"{workflow_key}-{int(clock())}",
+            pr_number=pr_number, target=target,
+        )
+
+    @classmethod
+    def for_dry_run(cls, *, repo_root: Path, workflow_key: str,
+                    pr_number: str | None = None, target: str | None = None,
+                    clock=time.time) -> "RunContext":
+        """The same object for a rehearsal — nothing minted, nothing created.
+
+        ⚠ THE BOUNDARY IS NARROWER THAN "THE ENTRYPOINT", which is why this
+        exists rather than a flag on `build`. `resolve_identity` is called AFTER
+        the `--dry-run` early return on purpose: a dry run states "nothing
+        invoked, nothing posted", and minting a name would make that false. So
+        would creating a journal root at 0700. A context built for a dry run
+        must be buildable without either, and both fields say so in their
+        values rather than being quietly absent.
+
+        THE POINT IS THAT THERE IS ONE ASSEMBLY. `--dry-run` previewing values it
+        assembled itself is how a rehearsal shows something that is not what
+        runs, and this family has shipped that bug once already. Both paths
+        construct a `RunContext` and both print `render()`.
+        """
+        return cls(
+            run_id=DRY_RUN_RUN_ID, writer=None, minted=False,
+            repo_root=repo_root, journal_root=None, workflow_key=workflow_key,
+            worktree_name=f"{workflow_key}-{int(clock())}",
+            pr_number=pr_number, target=target,
+        )
+
+    def render(self) -> str:
+        """What this run derived, as the ONE block both paths print.
+
+        Read by `echo` on the live path and by every entrypoint's `--dry-run`
+        block. A second rendering would be a second assembly, which is the
+        defect requirement 4 names.
+        """
+        rows = [
+            ("run", self.run_id if self.is_the_run
+                    else f"{self.run_id} (writer {self.writer})"),
+            ("workflow", self.workflow_key),
+            ("repo root", str(self.repo_root)),
+            ("journal", str(self.journal_root) if self.journal_root
+                        else "(not resolved — rehearsal opens no bag)"),
+            ("worktree", self.worktree_name),
+            ("target", self.target or "(this workflow takes none)"),
+            ("pr", f"#{self.pr_number}" if self.pr_number
+                   else "(a new one will be opened)"),
+        ]
+        width = max(len(label) for label, _ in rows)
+        head = "run context — derived here, before anything is created:"
+        return "\n".join([head] + [f"  {label:<{width}} : {value}"
+                                   for label, value in rows])
+
+    def echo(self, stream=None) -> None:
+        """State the context on stderr, once, before the first side effect.
+
+        UNCONDITIONAL, AND NOT GATED ON `verbose`. `verbose` governs a
+        workflow's own chatter; this is the run saying what it is about to spend
+        money on. The precedent is one function away — `resolve_identity`
+        announces a minted run id on stderr unconditionally, for the same class
+        of value, because a name nobody was told is a bag nobody can retry into.
+
+        GATED ON *IS THIS INVOCATION THE RUN*, WHICH IS THE "CONSTRUCTED HERE OR
+        RECEIVED" DISCRIMINATOR. A parent that builds a context and hands it to
+        nine children should say it once; a child that was handed one should not
+        reprint what its parent already said, and `--writer` is the only thing
+        that distinguishes the two from inside the process.
+
+        ⚠ IT IS DELIBERATELY *NOT* GATED ON `minted`, and that is a correction
+        rather than a simplification. `minted` is False for an operator retrying
+        with `--run-id X` — a parent, constructing its own context, and exactly
+        the caller who most needs to see what the retry derived. `minted`
+        answers "did I make the NAME"; the echo asks "did I make the CONTEXT",
+        and `writer` is the field that answers it.
+
+        stderr rather than stdout because several entrypoints' stdout is a
+        rendered report an operator or a tool reads.
+        """
+        if not self.is_the_run:
+            return
+        print(self.render(), file=stream or sys.stderr, flush=True)
+
+
+def context_field_documentation() -> dict[str, dict[str, str]]:
+    """Every field's four-part statement, read off the object itself.
+
+    THE POPULATION IS `dataclasses.fields()`, WHICH IS THE ENTIRE ARGUMENT FOR
+    DOING IT THIS WAY. It is a language primitive: no marker convention, no tree
+    sweep, no hand-kept list, and a field added a year from now is in it the
+    moment it is declared. That is the property the deleted tree-wide enumeration
+    could not have — a table checked against itself cannot see what was never
+    added to it.
+    """
+    return {f.name: dict(f.metadata) for f in fields(RunContext)}

--- a/scripts/workflows/temporal/scripts/dispatch_identity.py
+++ b/scripts/workflows/temporal/scripts/dispatch_identity.py
@@ -101,13 +101,53 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from modules.journal.bag import (BagError, RUN_ID_PERMITTED_DESCRIPTION,
                                  validated_run_id)
 from modules.journal.journal_activities import mint_run_id
 
-__all__ = ["RunIdentity", "add_identity_arguments", "resolve_identity"]
+__all__ = ["RunIdentity", "add_identity_arguments", "derivation",
+           "resolve_identity"]
+
+
+def derivation(*, marker: str, algorithm: str, override: str,
+               scope: str) -> dict[str, str]:
+    """The four things a field of the run context must say about itself.
+
+    WHY FOUR, AND WHY THESE FOUR. The research pool behind Workflow
+    Decomposition Phase 4 names five properties a safe derivation has. Two of
+    them this fleet already satisfies structurally — `resolve_repo_root` anchors
+    on a MARKER (`git rev-parse` reads `.git`, it does not guess) and `--repo` is
+    an explicit OVERRIDE. Two were absent: the published ALGORITHM and the
+    stated SCOPE OF EFFECT. The fifth is the echo, which is behaviour rather
+    than documentation. `marker` and `override` are carried here anyway so a
+    reader of one field sees all four in one place, and so a field that has no
+    override has to SAY it has none rather than leave the reader inferring it.
+
+    SCOPE OF EFFECT IS NOT DECORATION — it answers *what else is wrong if this
+    value is wrong*, and it is what makes the echo readable. An echo that prints
+    a path tells a reader WHAT was derived; the scope tells them whether to care.
+
+    STRUCTURED METADATA RATHER THAN PROSE, AND THIS IS A DEPARTURE FROM THE
+    PLAN'S WORDING. The plan asks for a field "docstring" naming the four parts.
+    Python has no field docstrings — the nearest convention is a `#:` comment
+    the interpreter throws away — and a check asserting four NAMED parts are
+    present would then have to parse them back out of one prose blob, which
+    makes the check's population the parser's guesses rather than the four
+    parts. `dataclasses.field(metadata=...)` keeps the statement AT the field,
+    where a reader meets it, and makes each of the four separately addressable
+    by `dataclasses.fields()`. The population is unchanged; only the parsing
+    problem is gone.
+
+    ⚠ WHAT THE CHECK OVER THIS CAN AND CANNOT DO: it asserts each part is
+    PRESENT and NON-EMPTY, never that any of them is TRUE. A field naming the
+    wrong marker passes. That limit is accepted rather than worked around — the
+    truth of an algorithm sentence is a judgement, and the failure this exists to
+    catch is ABSENCE.
+    """
+    return {"marker": marker, "algorithm": algorithm,
+            "override": override, "scope": scope}
 
 
 @dataclass(frozen=True)
@@ -119,11 +159,49 @@ class RunIdentity:
     minted one is a name that exists nowhere until this process says it out loud.
     """
 
-    run_id: str
-    writer: str | None
+    run_id: str = field(metadata=derivation(
+        marker="the `--run-id` argument — or its absence, which is itself the "
+               "marker for *nothing has named this run yet*.",
+        algorithm="taken verbatim from `--run-id` when supplied and validated "
+                  "against the permitted character set; otherwise minted here "
+                  "by `mint_run_id`, the fleet's one naming authority, and "
+                  "announced on stderr.",
+        override="`--run-id <id>`, which is also how a retry aims at an "
+                 "existing bag.",
+        scope="wrong ⇒ this run's records land in another run's bag or in one "
+              "nobody can find, no retry can be aimed at the same folder, and "
+              "the run's cost is accounted against the wrong work. "
+              "Re-enumerating this repo's archived logs once returned files "
+              "named for scripts that no longer exist, because two naming "
+              "authorities were live at the same time."))
+
+    writer: str | None = field(metadata=derivation(
+        marker="the presence of `--writer`. NEVER the environment, never the "
+               "working directory, never the absence of one — a child started "
+               "by a parent, by a person, and by a person reproducing what a "
+               "parent did are indistinguishable from inside the process.",
+        algorithm="taken verbatim from `--writer`; `None` means this invocation "
+                  "IS the run rather than a member of one. `--writer` with no "
+                  "`--run-id` is refused rather than defaulted.",
+        override="none — it is declared, and `--writer` is the only input.",
+        scope="wrong ⇒ a child silently becomes its own run and its records "
+              "leave the parent's bag, or a parent adopts a bag it should have "
+              "created. It also gates the run-context echo: a member does not "
+              "reprint what its parent already said."))
 
     #: True when nothing supplied the name and this boundary made one.
-    minted: bool
+    minted: bool = field(metadata=derivation(
+        marker="whether `--run-id` reached this process.",
+        algorithm="True when nothing supplied the name and this boundary made "
+                  "one; carried rather than re-derived because the two cases "
+                  "are operator-facing and differ — a supplied name is one the "
+                  "caller can reproduce, a minted one exists nowhere until this "
+                  "process says it out loud.",
+        override="none — it is an observation about this invocation.",
+        scope="wrong ⇒ the boundary either announces a name the caller already "
+              "knew, or stays silent about one nobody was told, which is a bag "
+              "nobody can retry into. It is NOT the echo's gate: see "
+              "`RunContext.echo`, which explains why `writer` is."))
 
     @property
     def is_the_run(self) -> bool:

--- a/scripts/workflows/temporal/scripts/run_build.py
+++ b/scripts/workflows/temporal/scripts/run_build.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import preflight  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.build.build_inputs import BuildInput  # noqa: E402
@@ -73,20 +74,25 @@ def main(argv: list[str] | None = None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        # The name is computed here rather than below so the bag can record it.
-        # It is a pure string — nothing is created until `run_build` — so this
-        # does not move a side effect ahead of the bag.
-        worktree_name = f"build-{int(__import__('time').time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="build", worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. The worktree
+        # name is a FIELD rather than an expression here — eleven copies of that
+        # expression in three spellings was the defect (`dispatch_context.py`), and
+        # this file carried one of the two `__import__('time')` spellings.
+        # `target=None`: a build is pointed at a task, not at a component
+        # directory, and the task source is deliberately NOT a context field
+        # (`resolve_task_source` is not a boundary resolver and its two call
+        # sites are inside an activity).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="build", pr_number=task.pr_number)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
-        result = run_build(task, repo_root, worktree_name)
+        result = run_build(task, repo_root, ctx.worktree_name)
     except (RuntimeError, FileNotFoundError) as exc:
         # These carry operator-facing recovery instructions from the layer that
         # knew what failed. Do not wrap or reformat them.

--- a/scripts/workflows/temporal/scripts/run_build_minor.py
+++ b/scripts/workflows/temporal/scripts/run_build_minor.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import preflight  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.build.build_inputs import BuildInput  # noqa: E402
@@ -73,20 +74,28 @@ def main(argv: list[str] | None = None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        # The name is computed here rather than below so the bag can record it.
-        # It is a pure string — nothing is created until `run_build_minor` — so
-        # this does not move a side effect ahead of the bag.
-        worktree_name = f"build-{int(__import__('time').time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="build-minor", worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS.
+        #
+        # ⚠ THIS RENAMES THIS RUNNER'S WORKTREE, AND THE RENAME IS THE POINT
+        # RATHER THAN A SIDE EFFECT. The line deleted above built
+        # `build-<ts>` while this runner's `workflow_key` is `build-minor`, so
+        # its trees have been landing under `.claude/worktrees/build-…` —
+        # indistinguishable from the `build` parent's, which is precisely what
+        # `/cleanup-merged-worktrees` and the journal's `Journal-Worktree` field
+        # use to tell one run from another. Deriving the name from the key the
+        # bag already records fixes the drift; trees are now `build-minor-<ts>`.
+        # `target=None`: a build is pointed at a task, not at a component.
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="build-minor", pr_number=task.pr_number)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
-        result = run_build_minor(task, repo_root, worktree_name)
+        result = run_build_minor(task, repo_root, ctx.worktree_name)
     except (RuntimeError, FileNotFoundError) as exc:
         # These carry operator-facing recovery instructions from the layer that
         # knew what failed. Do not wrap or reformat them.

--- a/scripts/workflows/temporal/scripts/run_plan.py
+++ b/scripts/workflows/temporal/scripts/run_plan.py
@@ -89,19 +89,29 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  Loop-back  : the whole chain below the author, up to 3 times\n")
         return 0
 
-    # EVERYTHING THIS RUN DERIVED, BUILT ONCE, AND SAID OUT LOUD BEFORE THE BAG
-    # OPENS. The worktree name is a field on it rather than an expression here;
-    # see `dispatch_context.py` for why eleven copies of that expression were the
-    # defect. The echo precedes bag-open, the worktree and every `gh` call.
-    ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
-                           workflow_key="plan", pr_number=a.pr_number, target=target)
-    ctx.echo()
-    journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
-                         repo_root=ctx.repo_root, workflow_key=ctx.workflow_key,
-                         worktree_name=ctx.worktree_name,
-                         journal_root=ctx.journal_root)
-
     try:
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE, AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS. The worktree name is a field on it rather than an expression
+        # here; see `dispatch_context.py` for why eleven copies of that
+        # expression were the defect. The echo precedes bag-open, the worktree
+        # and every `gh` call.
+        #
+        # ⚠ INSIDE THE `try`, WHICH IT WAS NOT. This block sat above the handler
+        # in this one file of eleven, so `resolve_identity`'s refusal of a bad
+        # `--run-id` and `open_run_bag`'s refusal of a full journal — both
+        # `RuntimeError`s carrying operator-facing remedies — reached the
+        # operator as a traceback here and as a one-line diagnostic everywhere
+        # else. Resolving the journal root at the boundary added a THIRD raise
+        # to the unguarded region, which is what made a latent gap worth closing.
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan", pr_number=a.pr_number,
+                               target=target)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root, workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
+
         pr_url, verdict, notes = run_plan(
             component=component, repo_root=repo_root, worktree_name=ctx.worktree_name,
             sprint_path=sprint, candidates_path=cands,

--- a/scripts/workflows/temporal/scripts/run_plan.py
+++ b/scripts/workflows/temporal/scripts/run_plan.py
@@ -14,7 +14,6 @@ THE PARENT CALLS NO MODEL, so it has no `config.yaml` entry — the same as
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -22,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.assistant import assistant_activities as act  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.plan.plan.plan_workflow import run_plan  # noqa: E402
@@ -72,31 +72,38 @@ def main(argv: list[str] | None = None) -> int:
     component, cands, sprint = (resolved["component"], resolved["candidates"],
                                 resolved["sprint"])
 
+    target = str(component.relative_to(repo_root))
+
     if a.dry_run:
         print(f"{BANNER}\n  DRY RUN — no child runs, nothing posted\n{BANNER}")
-        print(f"  Component  : {component.relative_to(repo_root)}")
+        # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method. A
+        # rehearsal that assembled its own copy would preview something that is
+        # not what runs, which is the bug this family has already shipped once.
+        print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="plan",
+                                     pr_number=a.pr_number, target=target).render())
         print(f"  Sprint     : {sprint.relative_to(repo_root)}")
         print(f"  Candidates : {cands.relative_to(repo_root)}")
-        print(f"  PR         : {a.pr_number or '(a new one will be opened)'}")
         print(f"  Context    : {len(context.encode())} bytes from --task-file"
               if context else "  Context    : none")
         print("  Chain      : plan-draft → plan-refine → plan-sprint → CI gate → review-pr")
         print(f"  Loop-back  : the whole chain below the author, up to 3 times\n")
         return 0
 
-    # THE BAG OPENS BEFORE THE FIRST SIDE EFFECT, and the worktree NAME is
-    # computed here so the bag can record it. It is a pure string — nothing is
-    # created until `run_plan` — so this does not move a side effect ahead of
-    # the bag. See `journal_activities.py` for why this is not a helper.
-    worktree_name = f"plan-{int(time.time())}"
-    identity = resolve_identity(argv)
-    journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                         repo_root=repo_root, workflow_key="plan",
-                         worktree_name=worktree_name)
+    # EVERYTHING THIS RUN DERIVED, BUILT ONCE, AND SAID OUT LOUD BEFORE THE BAG
+    # OPENS. The worktree name is a field on it rather than an expression here;
+    # see `dispatch_context.py` for why eleven copies of that expression were the
+    # defect. The echo precedes bag-open, the worktree and every `gh` call.
+    ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                           workflow_key="plan", pr_number=a.pr_number, target=target)
+    ctx.echo()
+    journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                         repo_root=ctx.repo_root, workflow_key=ctx.workflow_key,
+                         worktree_name=ctx.worktree_name,
+                         journal_root=ctx.journal_root)
 
     try:
         pr_url, verdict, notes = run_plan(
-            component=component, repo_root=repo_root, worktree_name=worktree_name,
+            component=component, repo_root=repo_root, worktree_name=ctx.worktree_name,
             sprint_path=sprint, candidates_path=cands,
             context=context, pr_number=a.pr_number, repo_target=a.repo_target,
             verbose=a.verbose,

--- a/scripts/workflows/temporal/scripts/run_plan_draft.py
+++ b/scripts/workflows/temporal/scripts/run_plan_draft.py
@@ -5,12 +5,13 @@ the Temporal path exists this is replaced by a client that starts the workflow
 on a task queue; the workflow module itself does not change.
 """
 from __future__ import annotations
-import sys, time
+import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.assistant import assistant_activities as act_shared  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.plan import plan_activities as act  # noqa: E402
@@ -93,8 +94,12 @@ def main(argv=None) -> int:
             # so the preview is an actual preview — needs the count helpers to
             # take a tree rather than a path, and earns itself when real use
             # appears. Same line as `run_plan_refine.py`, which shipped it first.
+            # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method. A
+            # rehearsal that assembles its own copy previews something that is not
+            # what runs, which is the bug this family has already shipped once.
+            print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="plan-draft",
+                                         pr_number=a.pr_number, target=str(rel)).render())
             print(f"  Counted in : this checkout ({repo_root}) — a dry run cuts no worktree")
-            print(f"  Component  : {rel}")
             print(f"  Phase docs : {len(own.phase_docs(component))} · "
                   f"roadmap.md {'present' if (component / 'roadmap.md').is_file() else 'ABSENT'}")
             print(f"  Max turns  : {wf.MAX_TURNS} (estimate — nothing has measured this workflow)")
@@ -120,16 +125,21 @@ def main(argv=None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"plan-draft-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="plan-draft",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan-draft", pr_number=a.pr_number,
+                               target=str(component.relative_to(repo_root)))
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
         # "HEAD" put the run on `main`, so a correction pass opened a worktree
@@ -144,7 +154,7 @@ def main(argv=None) -> int:
         # fix applied to ten: the eleventh passed its base inline and the first
         # sweep of this did not see it.
         ref = act.base_ref(a.pr_number, repo_root)
-        worktree = act.worktree_add(repo_root, worktree_name, ref)
+        worktree = act.worktree_add(repo_root, ctx.worktree_name, ref)
         url = wf.run_plan_draft(repo_root=repo_root, worktree=worktree,
                                   component=component, candidates_path=cands,
                                   pr_number=a.pr_number, context=context,

--- a/scripts/workflows/temporal/scripts/run_plan_project.py
+++ b/scripts/workflows/temporal/scripts/run_plan_project.py
@@ -8,13 +8,13 @@ on a task queue; the workflow module itself does not change.
 from __future__ import annotations
 
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant import routing  # noqa: E402
@@ -71,20 +71,28 @@ def main(argv: list[str] | None = None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"plan-project-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="plan-project",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        # `target=None` — this runner takes NO component. It triages the
+        # candidate store and plans whatever it scaffolds, so there is nothing
+        # the operator pointed it at and the field says so rather than being
+        # handed a stand-in.
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan-project", pr_number=a.pr_number)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         url, verdict, loops, notes = run_plan_project(
             repo_root=repo_root,
-            worktree_name=worktree_name,
+            worktree_name=ctx.worktree_name,
             # DERIVED FROM AN ALREADY-CONTAINED PATH, so it needs no declaration
             # of its own: `repo_root` is proven by preflight and two literal
             # segments cannot walk back out of it. This is not an operator path.

--- a/scripts/workflows/temporal/scripts/run_plan_refine.py
+++ b/scripts/workflows/temporal/scripts/run_plan_refine.py
@@ -364,7 +364,14 @@ def main(argv=None) -> int:
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
         # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
-        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # BAG OPENS AND BEFORE THE WORKTREE IS CUT.
+        #
+        # ⚠ NOT BEFORE EVERY `gh` CALL, WHICH IS WHAT THIS SAID AND WHICH IS
+        # FALSE HERE. `unclosed_hold` and `pr_branch` above read the PR thread
+        # over `gh`, and they stay there because they are REFUSALS — a held PR
+        # dispatched without `--correction-pass` stops the run — and opening a
+        # bag ahead of a refusal files a run that never starts. Nothing is
+        # SPENT or POSTED before this line. Identity comes
         # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
         # worktree name is a FIELD rather than an expression here, because
         # eleven copies of that expression in three spellings was the defect

--- a/scripts/workflows/temporal/scripts/run_plan_refine.py
+++ b/scripts/workflows/temporal/scripts/run_plan_refine.py
@@ -5,12 +5,13 @@ the Temporal path exists this is replaced by a client that starts the workflow
 on a task queue; the workflow module itself does not change.
 """
 from __future__ import annotations
-import sys, time
+import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.assistant.review_pr import review_pr_activities as review_act  # noqa: E402
 from modules.assistant import assistant_activities as act_shared  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
@@ -244,7 +245,12 @@ def main(argv=None) -> int:
         if a.dry_run:
             phases = own.phase_docs_of(component)
             print(f"{BANNER}\n  DRY RUN — nothing invoked, nothing posted\n{BANNER}")
-            print(f"  Component  : {component_rel}")
+            # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method. A
+            # rehearsal that assembles its own copy previews something that is not
+            # what runs, which is the bug this family has already shipped once.
+            print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="plan-refine",
+                                         pr_number=a.pr_number,
+                                         target=str(component_rel)).render())
             # THE TREE THE COUNTS CAME FROM, NAMED RATHER THAN LEFT TO BE
             # ASSUMED. No worktree exists on a dry run, so every figure below is
             # read off THIS checkout — while a `--pr` run cuts its worktree from
@@ -357,16 +363,21 @@ def main(argv=None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"plan-refine-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="plan-refine",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan-refine", pr_number=a.pr_number,
+                               target=str(component.relative_to(repo_root)))
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
         # "HEAD" put the run on `main`, so a correction pass opened a worktree
@@ -389,7 +400,7 @@ def main(argv=None) -> int:
         # was never a defensible base — see `base_ref`'s docstring for what that
         # cost on three of eight open PRs.
         ref = f"origin/{branch}" if a.pr_number else act.base_ref(None, repo_root)
-        worktree = act.worktree_add(repo_root, worktree_name, ref)
+        worktree = act.worktree_add(repo_root, ctx.worktree_name, ref)
         url = wf.run_plan_refine(repo_root=repo_root, worktree=worktree, context=context,
                                  component=component, candidates_path=cands,
                                  pr_number=a.pr_number, verbose=a.verbose,

--- a/scripts/workflows/temporal/scripts/run_plan_revision.py
+++ b/scripts/workflows/temporal/scripts/run_plan_revision.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import preflight  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.plan import plan_activities as act  # noqa: E402
@@ -161,18 +161,24 @@ def main(argv: list[str] | None = None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"plan-revision-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="plan-revision",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        # `target=None` — this runner revises whatever a free-text description
+        # names; there is no operator-supplied PATH for the field to carry.
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan-revision", pr_number=a.pr_number)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
-        worktree = act.worktree_add(repo_root, worktree_name, ref)
+        worktree = act.worktree_add(repo_root, ctx.worktree_name, ref)
 
         url = wf.run_plan_revision(
             description=a.description, repo_root=repo_root, worktree=worktree,

--- a/scripts/workflows/temporal/scripts/run_plan_revision.py
+++ b/scripts/workflows/temporal/scripts/run_plan_revision.py
@@ -162,7 +162,16 @@ def main(argv: list[str] | None = None) -> int:
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
         # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
-        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # BAG OPENS AND BEFORE THE WORKTREE IS CUT.
+        #
+        # ⚠ NOT BEFORE EVERY `gh` CALL, WHICH IS WHAT THIS SAID AND WHICH IS
+        # FALSE HERE. `base_ref` above reads the PR's branch over `gh` when
+        # `--pr` was given. It stays there deliberately: it is a REFUSAL — a
+        # bad `--pr` stops the run — and opening a bag ahead of it would file a
+        # run that never starts. Three of eleven entrypoints have such a read
+        # (here, `plan-refine` and `plan-sprint`); the other eight echo before
+        # any `gh` call at all. Nothing is SPENT or POSTED before this line in
+        # any of the eleven, which is the property requirement 3 asks for. Identity comes
         # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
         # worktree name is a FIELD rather than an expression here, because
         # eleven copies of that expression in three spellings was the defect

--- a/scripts/workflows/temporal/scripts/run_plan_sprint.py
+++ b/scripts/workflows/temporal/scripts/run_plan_sprint.py
@@ -141,7 +141,13 @@ def main(argv=None) -> int:
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
         # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
-        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # BAG OPENS AND BEFORE THE WORKTREE IS CUT.
+        #
+        # ⚠ NOT BEFORE EVERY `gh` CALL, WHICH IS WHAT THIS SAID AND WHICH IS
+        # FALSE HERE. `unclosed_hold` above reads the PR thread over `gh`, and
+        # it stays there because it is a REFUSAL — opening a bag ahead of it
+        # files a run that never starts. Nothing is SPENT or POSTED before
+        # this line. Identity comes
         # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
         # worktree name is a FIELD rather than an expression here, because
         # eleven copies of that expression in three spellings was the defect

--- a/scripts/workflows/temporal/scripts/run_plan_sprint.py
+++ b/scripts/workflows/temporal/scripts/run_plan_sprint.py
@@ -1,11 +1,12 @@
 """Kickoff entrypoint for plan-sprint."""
 from __future__ import annotations
-import sys, time
+import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.assistant.review_pr import review_pr_activities as review_act  # noqa: E402
 from modules.assistant import assistant_activities as act_shared  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
@@ -113,8 +114,13 @@ def main(argv=None) -> int:
             # so the preview is an actual preview — needs the count helpers to
             # take a tree rather than a path, and earns itself when real use
             # appears. Same line as `run_plan_refine.py`, which shipped it first.
+            # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method. A
+            # rehearsal that assembles its own copy previews something that is not
+            # what runs, which is the bug this family has already shipped once.
+            print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="plan-sprint",
+                                         pr_number=a.pr_number,
+                                         target=str(component.relative_to(repo_root))).render())
             print(f"  Counted in : this checkout ({repo_root}) — a dry run cuts no worktree")
-            print(f"  Component  : {component.relative_to(repo_root)}")
             print(f"  Sprint     : {sprint.relative_to(repo_root)}")
             print(f"  Phases     : {len(sizing.rows)} · {len(sizing.unsized)} unsized")
             print(f"  TOTAL      : {sizing.total:g} h  (summed in code, not by the model)")
@@ -134,16 +140,21 @@ def main(argv=None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"plan-sprint-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="plan-sprint",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="plan-sprint", pr_number=a.pr_number,
+                               target=str(component.relative_to(repo_root)))
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
         # "HEAD" put the run on `main`, so a correction pass opened a worktree
@@ -158,7 +169,7 @@ def main(argv=None) -> int:
         # fix applied to ten: the eleventh passed its base inline and the first
         # sweep of this did not see it.
         ref = act.base_ref(a.pr_number, repo_root)
-        worktree = act.worktree_add(repo_root, worktree_name, ref)
+        worktree = act.worktree_add(repo_root, ctx.worktree_name, ref)
         url = wf.run_plan_sprint(repo_root=repo_root, worktree=worktree,
                                  sprint_path=sprint, component=component,
                                  pr_number=a.pr_number, context=context,

--- a/scripts/workflows/temporal/scripts/run_research.py
+++ b/scripts/workflows/temporal/scripts/run_research.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.assistant import assistant_activities as act_shared  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.research.research import research_workflow as rw  # noqa: E402
@@ -52,8 +53,7 @@ def main(argv=None) -> int:
         print(f"\n✗ {exc}", file=sys.stderr)
         return 1
     research_dir = resolved["research_dir"]
-    import time
-    wt = f"research-{int(time.time())}"
+    target = str(research_dir.relative_to(repo_root))
 
     try:
         if a.dry_run:
@@ -71,8 +71,13 @@ def main(argv=None) -> int:
             # ruling 2026-08-24, on measured evidence. The stronger remedy reads
             # `origin/<branch>` so the preview is an actual preview, and earns
             # itself when real operator use appears.
+            # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same
+            # method. A rehearsal that assembles its own copy previews something
+            # that is not what runs, which is the bug this family has already
+            # shipped once.
+            print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="research",
+                                         pr_number=a.pr_number, target=target).render())
             print(f"  Counted in : this checkout ({repo_root}) — a dry run cuts no worktree")
-            print(f"  Pool      : {research_dir}")
             print(f"  Due papers: {len(due)}"
                   + ("" if due else " — nothing to revalidate this cycle"))
             for d in due:
@@ -84,21 +89,28 @@ def main(argv=None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="research", worktree_name=wt)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="research", pr_number=a.pr_number,
+                               target=target)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         # NO --refresh BRANCH. Revalidation is not a mode of this parent any
         # more: the write child computes the due set in code and routes each
         # due topic to `research-currency` itself, so one run covers new topics
         # and expired ones together instead of two runs over one pool.
         result = rw.run_research(research_dir=research_dir, repo_root=repo_root,
-                                 worktree_name=wt, context=context,
+                                 worktree_name=ctx.worktree_name, context=context,
                                  pr_number=a.pr_number, verbose=a.verbose)
     except (RuntimeError, FileNotFoundError, ValueError) as exc:
         print(f"\n✗ {exc}", file=sys.stderr)

--- a/scripts/workflows/temporal/scripts/run_review_pr.py
+++ b/scripts/workflows/temporal/scripts/run_review_pr.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import preflight  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.review_pr import review_pr_activities as act  # noqa: E402
@@ -56,7 +57,7 @@ def parse_args(argv: list[str] | None = None) -> tuple[ReviewInput, bool]:
     return task, args.dry_run
 
 
-def _dry_run(task: ReviewInput, repo_root: Path) -> int:
+def _dry_run(task: ReviewInput, repo_root: Path, ctx: RunContext) -> int:
     """Prove the plumbing without invoking the model.
 
     Everything the real path does up to the model call: fetch the PR, count
@@ -85,7 +86,10 @@ def _dry_run(task: ReviewInput, repo_root: Path) -> int:
         invocation_id=uuid.uuid4().hex,
     )
     print(f"{BANNER}\n  DRY RUN — nothing was invoked, nothing was posted\n{BANNER}")
-    print(f"  PR       : #{task.pr_number} ({pr['headRefName']}) — {pr['state']}")
+    # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method — the
+    # rehearsal receives the context rather than assembling a second copy of it.
+    print(ctx.render())
+    print(f"  Branch   : {pr['headRefName']} — {pr['state']}")
     print(f"  Title    : {pr['title']}")
     print(f"  Pass     : {this_pass} (prior: {prior_pass})")
     print(f"  Type     : {task.review_type.value}")
@@ -107,30 +111,37 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     try:
         if dry:
-            return _dry_run(task, repo_root)
+            return _dry_run(task, repo_root,
+                            RunContext.for_dry_run(repo_root=repo_root,
+                                                   workflow_key="review-pr",
+                                                   pr_number=task.pr_number))
 
-        # REQUIREMENT 11 — the run's bag is opened BEFORE the first side
-        # effect, and a root that will not resolve stops the run here (r9). Why
-        # this is not a helper each file remembers to call, and what the sweep
-        # that enforces it can and cannot see: `journal_activities.py`'s module
-        # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
-        # once there rather than eleven times here.
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="review-pr",
-                             # The ONE workflow that cuts no worktree — it
-                             # reviews a PR in place. Stated rather than
-                             # defaulted, so `-` in a bag means "this run had
-                             # none" and never "somebody forgot the argument".
-                             worktree_name=None)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`).
+        #
+        # ⚠ THIS RUN DOES CUT A WORKTREE, AND THIS ARGUMENT USED TO SAY IT DID
+        # NOT. `worktree_name=None` sat here with the comment *"the ONE workflow
+        # that cuts no worktree — it reviews a PR in place"*, while
+        # `review_pr_workflow` cut `review-pr-<n>-<ts>` through the same
+        # `worktree_add` whose docstring opens "ISOLATION IS AN INVARIANT, NOT A
+        # PARAMETER". Nothing was lying: the two halves were written in two
+        # places and only one of them was updated. The bag now records the stem
+        # the tree is actually named from — a review PASS appends its pass
+        # number, because a loop-back cuts one tree per pass.
+        #
+        # `target=None`: a review is pointed at a PR, which `pr_number` carries.
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="review-pr", pr_number=task.pr_number)
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         worktree = repo_root
-        result = wf.run_review(task, worktree)
+        result = wf.run_review(task, worktree, worktree_name=ctx.worktree_name)
     # OSError covers the log-path freshness guard's FileExistsError, which is a
     # runtime state with an operator-facing message, not a programming error.
     # TypeError is deliberately NOT caught: a signature mismatch should traceback

--- a/scripts/workflows/temporal/scripts/run_triage_candidates.py
+++ b/scripts/workflows/temporal/scripts/run_triage_candidates.py
@@ -1,11 +1,12 @@
 """Kickoff entrypoint for triage-candidates."""
 from __future__ import annotations
-import sys, time
+import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from preflight import RepoPathParser  # noqa: E402
 from dispatch_identity import add_identity_arguments, resolve_identity  # noqa: E402
+from dispatch_context import RunContext  # noqa: E402
 from modules.journal import journal_activities as journal  # noqa: E402
 from modules.assistant.plan import plan_activities as act  # noqa: E402
 from modules.assistant.plan.triage_candidates import triage_candidates_workflow as wf  # noqa: E402
@@ -58,6 +59,12 @@ def main(argv=None) -> int:
             # so the preview is an actual preview — needs the count helpers to
             # take a tree rather than a path, and earns itself when real use
             # appears. Same line as `run_plan_refine.py`, which shipped it first.
+            # THE SAME OBJECT THE LIVE RUN PRINTS, rendered by the same method. A
+            # rehearsal that assembles its own copy previews something that is not
+            # what runs, which is the bug this family has already shipped once.
+            print(RunContext.for_dry_run(repo_root=repo_root, workflow_key="triage-candidates",
+                                         pr_number=a.pr_number,
+                                         target=str(cands.relative_to(repo_root))).render())
             print(f"  Counted in : this checkout ({repo_root}) — a dry run cuts no worktree")
             print(f"  Candidates : {counts['total']} total · {counts['untriaged']} UNTRIAGED · {counts['triaged']} ruled")
             print(f"  Max turns  : {wf.MAX_TURNS} (estimate — nothing has measured this workflow)")
@@ -78,16 +85,21 @@ def main(argv=None) -> int:
         # that enforces it can and cannot see: `journal_activities.py`'s module
         # docstring and `tests/unit/test_every_parent_opens_a_run_bag.py`. Said
         # once there rather than eleven times here.
-        worktree_name = f"triage-candidates-{int(time.time())}"
-        # PHASE 9 r2 and r4 — the run's NAME arrives from outside this
-        # process, and `writer` says whether this invocation IS the run or
-        # is part of one. Why both, and where a name comes from when no
-        # orchestrator supplies it: `dispatch_identity.py`. Said once there.
-        identity = resolve_identity(argv)
-        journal.open_run_bag(run_id=identity.run_id, writer=identity.writer,
-                             repo_root=repo_root,
-                             workflow_key="triage-candidates",
-                             worktree_name=worktree_name)
+        # EVERYTHING THIS RUN DERIVED, BUILT ONCE AND SAID OUT LOUD BEFORE THE
+        # BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS. Identity comes
+        # from outside the process (Phase 9 r2/r4, `dispatch_identity.py`); the
+        # worktree name is a FIELD rather than an expression here, because
+        # eleven copies of that expression in three spellings was the defect
+        # (`dispatch_context.py`).
+        ctx = RunContext.build(identity=resolve_identity(argv), repo_root=repo_root,
+                               workflow_key="triage-candidates", pr_number=a.pr_number,
+                               target=str(cands.relative_to(repo_root)))
+        ctx.echo()
+        journal.open_run_bag(run_id=ctx.run_id, writer=ctx.writer,
+                             repo_root=ctx.repo_root,
+                             workflow_key=ctx.workflow_key,
+                             worktree_name=ctx.worktree_name,
+                             journal_root=ctx.journal_root)
 
         # A `--pr` PASS MUST START FROM THE WORK IT IS CORRECTING. Hard-coding
         # "HEAD" put the run on `main`, so a correction pass opened a worktree
@@ -102,7 +114,7 @@ def main(argv=None) -> int:
         # fix applied to ten: the eleventh passed its base inline and the first
         # sweep of this did not see it.
         ref = act.base_ref(a.pr_number, repo_root)
-        worktree = act.worktree_add(repo_root, worktree_name, ref)
+        worktree = act.worktree_add(repo_root, ctx.worktree_name, ref)
         url = wf.run_triage_candidates(repo_root=repo_root, worktree=worktree,
                                        candidates_path=cands, research_dir=research,
                                        pr_number=a.pr_number, verbose=a.verbose)

--- a/scripts/workflows/temporal/tests/unit/journal_entrypoint_facts.py
+++ b/scripts/workflows/temporal/tests/unit/journal_entrypoint_facts.py
@@ -114,6 +114,11 @@ NON_STARTING_FILES = {
     "dispatch_identity.py":
         "the client-side identity boundary the entrypoints call. It parses two "
         "flags and mints a name; it starts nothing and opens no bag.",
+    "dispatch_context.py":
+        "the frozen run context the entrypoints construct at their boundary. "
+        "Like `dispatch_identity.py` beside it, it derives values and resolves "
+        "the journal root; it starts nothing, cuts nothing and opens no bag — "
+        "the entrypoint that built it does all three.",
     "validate_bag.py":
         "an operator tool that READS a finished bag and prints a report. It is "
         "the one file here that addresses the journal without being a run, and "

--- a/scripts/workflows/temporal/tests/unit/test_a_WRONG_TARGET_is_NAMED_before_the_run_costs_anything.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_WRONG_TARGET_is_NAMED_before_the_run_costs_anything.py
@@ -1,0 +1,162 @@
+"""Point a run at the wrong component and it says so, before it spends anything.
+
+THIS IS THE DEMONSTRATION, NOT AN ASSERTION ABOUT THE CODE. Workflow
+Decomposition Phase 4 requirement 5 says a wrong derivation must be DEMONSTRATED
+to be visible, and explicitly that it is not to be established by reading the
+implementation. So this drives a real entrypoint's `main()` on the LIVE path,
+with a real repository on disk, pointed at a component that is not the one
+intended, and reads what actually came out of stderr.
+
+WHY THE TARGET AND NOT SOME OTHER FIELD. Every other value on the run context
+fails loudly somewhere: a bad `--repo` is refused by preflight, an unusable
+journal root stops the run, a wrong `--pr` fails at `gh`. A wrong TARGET does
+none of that. The run reads real files, plans a real component, opens a real
+pull request, and nothing anywhere goes red — the operator finds out when they
+read the PR. That asymmetry is the entire reason the echo exists.
+
+WHAT "BEFORE THE RUN COSTS ANYTHING" IS PINNED TO HERE. The first side effect on
+a run's WORK is the bag directory, then the worktree, then `gh`, then the model.
+This drives the entrypoint with bag-open replaced by a raise, so reaching the
+echo proves it precedes all four. One thing does happen earlier and is stated
+rather than hidden: resolving the journal root creates it at 0700 if it is
+absent, because the echo NAMES that root and cannot name what has not been
+resolved. Nothing is spent, nothing is dispatched, and nothing is posted.
+
+⚠ WHAT THIS DOES NOT PROVE. It shows the echo reaches stderr on one entrypoint's
+live path. That every entrypoint builds and echoes a context is a separate,
+population-wide sweep in `test_dispatch_context.py`; that no call site re-derives
+the worktree name is `test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py`.
+
+THE TRANSCRIPT, CAPTURED VERBATIM ON 2026-09-01 from a shell, against a scratch
+repository holding two components — `RIGHT` and `WRONG` — with the wrong one
+asked for and `open_run_bag` replaced by a raise so the run stops at its first
+side effect. This is the output, not a reconstruction of it:
+
+    $ python3 -c '<stub open_run_bag>; run_plan_draft.main(
+        ["development/edge-assistant/WRONG", "--repo", "/tmp/demo-wrong-target"])'
+    journal: run id 6d563e5c4fa84609895c711c9102b57e (minted here — pass `--run-id 6d563e5c4fa84609895c711c9102b57e` to retry this run into the same bag)
+    run context — derived here, before anything is created:
+      run       : 6d563e5c4fa84609895c711c9102b57e
+      workflow  : plan-draft
+      repo root : /tmp/demo-wrong-target
+      journal   : /tmp/demo-journal-root/journal
+      worktree  : plan-draft-1788242234
+      target    : development/edge-assistant/WRONG
+      pr        : (a new one will be opened)
+
+    ✗ STOPPED HERE BY THE DEMONSTRATION — nothing was cut, nothing was posted
+    (exit 1)
+
+The `target` line is the whole point: it is the last moment before the run cuts a
+worktree and starts spending, and it names the component in the operator's own
+vocabulary rather than leaving it in a path three call frames down. `.claude/
+worktrees/` did not exist in that repository afterwards, and no `gh` process ran.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FLEET = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(FLEET / "scripts"))
+
+import run_plan_draft  # noqa: E402
+
+RIGHT = "development/edge-assistant/fleet-reliability"
+WRONG = "development/edge-assistant/workflow-decomposition"
+
+
+class _FirstSideEffect(RuntimeError):
+    """Raised in place of bag-open, so anything after it is provably unreached."""
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real repository holding two components, one of which is the wrong one."""
+    for name in (RIGHT, WRONG):
+        (tmp_path / name).mkdir(parents=True)
+        (tmp_path / name / "roadmap.md").write_text("# roadmap\n", encoding="utf-8")
+    (tmp_path / "tracked" / "candidates").mkdir(parents=True)
+    for cmd in (["git", "init", "-q"],
+                ["git", "config", "user.email", "t@example.com"],
+                ["git", "config", "user.name", "t"],
+                ["git", "add", "-A"],
+                ["git", "commit", "-qm", "seed"]):
+        subprocess.run(cmd, cwd=tmp_path, check=True, capture_output=True)
+    return tmp_path
+
+
+def test_a_run_pointed_at_the_WRONG_component_NAMES_IT_on_stderr(
+        repo: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """The live path — not `--dry-run`, which is the mode where nothing is at stake."""
+    monkeypatch.setattr(
+        run_plan_draft.journal, "open_run_bag",
+        lambda **kw: (_ for _ in ()).throw(_FirstSideEffect("bag would open here")))
+
+    exit_code = run_plan_draft.main([WRONG, "--repo", str(repo)])
+
+    err = capsys.readouterr().err
+    assert exit_code == 1, "the stand-in for the first side effect did not stop the run"
+    assert "run context" in err, (
+        f"the live run said nothing about what it derived:\n{err}")
+    assert WRONG in err, (
+        f"the run derived {WRONG!r} and never named it — an operator watching "
+        f"this could not tell it from a run against {RIGHT!r}:\n{err}")
+    assert "plan-draft-" in err, "the derived worktree name is not in the echo"
+
+
+def test_THE_ECHO_PRECEDES_the_first_side_effect(
+        repo: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """Ordering, read off the output rather than argued from the source.
+
+    The stand-in for bag-open writes its own marker. If the echo appeared after
+    it — or not at all — the marker would come first, which is the failure this
+    orders against: an echo *somewhere in the transcript* is not an echo *before
+    the run commits*.
+    """
+    def refuse(**kw):
+        print("FIRST-SIDE-EFFECT", file=sys.stderr, flush=True)
+        raise _FirstSideEffect("bag would open here")
+
+    monkeypatch.setattr(run_plan_draft.journal, "open_run_bag", refuse)
+    run_plan_draft.main([WRONG, "--repo", str(repo)])
+
+    err = capsys.readouterr().err
+    assert "FIRST-SIDE-EFFECT" in err, "the stand-in never ran, so nothing is ordered"
+    assert err.index("run context") < err.index("FIRST-SIDE-EFFECT"), (
+        f"the context was stated AFTER the run's first side effect:\n{err}")
+
+
+def test_NOTHING_WAS_CUT_and_NOTHING_WAS_POSTED(
+        repo: Path, monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    """The demonstration must itself be free — otherwise it is not a demonstration.
+
+    A worktree on disk or a `gh` invocation would mean the echo arrived after the
+    run had already committed to something, which is the property under test
+    inverted. Both are replaced by raising stand-ins: reaching either is a
+    failure, and neither is reached.
+    """
+    reached: list[str] = []
+
+    def forbid(label):
+        def stub(*a, **k):
+            reached.append(label)
+            raise AssertionError(f"{label} ran before the echo could matter")
+        return stub
+
+    monkeypatch.setattr(run_plan_draft.act, "worktree_add", forbid("worktree_add"))
+    monkeypatch.setattr(run_plan_draft.act_shared, "gh", forbid("gh"))
+    monkeypatch.setattr(
+        run_plan_draft.journal, "open_run_bag",
+        lambda **kw: (_ for _ in ()).throw(_FirstSideEffect("bag would open here")))
+
+    run_plan_draft.main([WRONG, "--repo", str(repo)])
+
+    assert reached == [], f"the run reached {reached} before it was stopped"
+    assert not (repo / ".claude" / "worktrees").exists(), \
+        "a worktree was cut before the operator could read the echo"
+    assert WRONG in capsys.readouterr().err

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -176,7 +176,7 @@ _HERE = Path(__file__).resolve().parent
 # literals driving `_loop_callees`, one of them a `while` that is not a loop-back
 # and must contribute nothing — and the control earned its place immediately by
 # catching the predicate collecting the loop's own TEST as a callee.
-_PINNED = (33, 22)
+_PINNED = (35, 24)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -176,6 +176,14 @@ _HERE = Path(__file__).resolve().parent
 # literals driving `_loop_callees`, one of them a `while` that is not a loop-back
 # and must contribute nothing — and the control earned its place immediately by
 # catching the predicate collecting the loop's own TEST as a callee.
+# 33 -> 35 AND 22 -> 24 for Workflow Decomposition Phase 4's two guards —
+# `test_a_worktree_NAME_comes_from_the_RUN_CONTEXT` (no `worktree_add` call
+# assembles the name it cuts with) and `test_dispatch_context` (the entrypoint
+# sweeps behind requirements 3 and 4). BOTH numbers move by TWO, which is the
+# check that each arrived WITH a control: the first ships eight positive
+# spellings and six negative ones driven on literals, the second controls its
+# build/echo, ordering, gating and dry-run predicates the same way. Verified
+# rather than assumed — `_walks_the_tree` returns True for both files.
 _PINNED = (35, 24)
 
 

--- a/scripts/workflows/temporal/tests/unit/test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py
@@ -1,0 +1,297 @@
+"""A worktree name is RECEIVED, never assembled where the worktree is cut.
+
+THE DEFECT, MEASURED 2026-08-28 AND RE-MEASURED 2026-09-01. Eleven sites built a
+per-run worktree name for themselves, in THREE spellings:
+
+  * eight runners        `f"<key>-{int(time.time())}"`
+  * two build runners    `f"build-{int(__import__('time').time())}"`
+  * one workflow module  `f"review-pr-{pr}-{int(time.time())}"`, INLINE, with no
+                         assignment for a guard to key on
+
+and `run_build_minor` had already DRIFTED — `workflow_key="build-minor"` beside a
+worktree named `build-…`, so its trees were indistinguishable on disk from the
+`build` parent's. `review-pr` cost more than duplication: `run_review_pr.py`
+recorded `worktree_name=None` in the run bag, commenting *"the ONE workflow that
+cuts no worktree"*, while `review_pr_workflow` cut one on the very next call.
+
+WHY THIS KEYS ON THE CALL SITE AND NOT ON THE NAME'S SPELLING. `assistant_
+activities.base_ref` is the same consolidation, done once already, and its
+docstring records the outcome: the first guard written to replace the hand sweep
+keyed on `ref = ...`, which is how ten of eleven sites happened to be written,
+and the eleventh passed its value INLINE and walked straight past. The same
+shape is here — `grep -n "int(time.time())"` returned nine of these eleven and
+missed the two `__import__('time')` ones outright, because that string does not
+occur in them. A check keyed on today's three spellings passes a twelfth site
+written in a fourth. `worktree_add`'s CALL SITES are a population a parser can
+enumerate, and a new caller cannot avoid calling it.
+
+⚠ MATCH ON THE FUNCTION NAME, NEVER ON THE MODULE ALIAS. `review_pr_workflow`
+reaches it as `_shared.worktree_add` while everything else says `act.`
+`test_isolation_invariants._classify` keys on the literal `"act.worktree_add("`
+and is BLIND to that file today — it classifies `review_pr_workflow` as a child
+while the module cuts a worktree. That is the one site this guard most needs to
+see, so it reads the callee's NAME off the AST and ignores what it arrived as.
+
+WHAT THIS DOES NOT LOOK AT, said plainly so nobody over-reads it:
+
+  * IT HOLDS ONE VALUE AT ONE CALL-SITE SHAPE. "A run-scoped derived value is a
+    field on the run context" stays a judgement in general; this makes it
+    checkable for the value that was measurably scattered. A SECOND value that
+    scatters later needs its own call-site check — the rule is enforced per
+    value, not as a class.
+  * IT DOES NOT CHECK THAT THE NAME IS RIGHT, only that it was received. A
+    context whose `worktree_name` field computed nonsense passes here and fails
+    in `test_dispatch_context.py`.
+  * IT CANNOT SEE A NAME THREADED THROUGH A DATA STRUCTURE — a dict, a dataclass
+    field assigned three functions away. That is invisible to any source-level
+    check, as it is to the head-base guard beside this one.
+  * IT SAYS NOTHING ABOUT `worktree_add`'s FETCH BEHAVIOUR or about where the
+    worktree is cut FROM. Those are `test_a_new_branch_STARTS_FROM_THE_DEFAULT_
+    BRANCH.py`'s, and they are a different guarantee.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+FLEET = Path(__file__).resolve().parents[2]
+SEARCH = [FLEET / "scripts", FLEET / "modules"]
+
+#: The name the run context carries the value under. A call site must reference
+#: it — as `<anything>.worktree_name`, or as a PARAMETER of the enclosing
+#: function called `worktree_name`. Keying on the receiving side rather than on
+#: the offending side is deliberate: the receiving side is what we author, and a
+#: twelfth site that invents a different spelling fails LOUD here rather than
+#: sliding past, which is the safe direction for a false positive to point.
+FIELD = "worktree_name"
+
+
+def _fleet_sources() -> list[Path]:
+    found = [p for root in SEARCH for p in root.rglob("*.py")
+             if "tests" not in p.parts]
+    assert len(found) > 20, (
+        f"only {len(found)} fleet modules found under {SEARCH} — the walk is "
+        f"wrong, and every assertion below would pass vacuously")
+    return found
+
+
+def _params(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    a = fn.args
+    names = {arg.arg for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+    for extra in (a.vararg, a.kwarg):
+        if extra is not None:
+            names.add(extra.arg)
+    return names
+
+
+def _name_argument(call: ast.Call) -> ast.expr | None:
+    """`worktree_add(repo_root, NAME, ref)` — positional 1, or the `name=` kwarg."""
+    if len(call.args) > 1:
+        return call.args[1]
+    return next((k.value for k in call.keywords if k.arg == "name"), None)
+
+
+def _assembled_names(tree: ast.Module) -> list[tuple[int, str]]:
+    """Every `worktree_add` call whose name argument was NOT received.
+
+    TAKES A PARSED TREE so a control can drive the predicate on a literal — the
+    convention `_bases_in_tree` uses one file over, and it is load-bearing: the
+    census guard recognises a tree-walker by an `ast.parse` of a file read and a
+    CONTROL by an `ast.parse` of anything else, so splitting on the source
+    string would drop this module out of that population instead of adding a
+    control to it.
+
+    RECEIVED MEANS ONE OF TWO THINGS, and the second is not a weakening. Either
+    the argument reaches an attribute called `worktree_name` — `ctx.worktree_name`
+    — or it references a PARAMETER of the enclosing function of that name. The
+    second admits `f"{worktree_name}-review-{this_pass}"`, which is
+    `review_pr_workflow` deriving a PER-PASS tree from the run's own name: the
+    tree it cuts is not run-scoped (a loop-back cuts one per pass) so it cannot
+    BE a frozen field, but its stem is received rather than invented. What the
+    rule refuses is an argument built only out of values the enclosing function
+    was never handed — every one of the eleven sites, in all three spellings.
+
+    ⚠ A LOCAL ASSIGNMENT IS NOT A PARAMETER, and that distinction is the whole
+    guard. `worktree_name = f"plan-{int(time.time())}"` followed by
+    `worktree_add(repo_root, worktree_name, ref)` is exactly what eight runners
+    did, and reading only the argument's spelling would call it received.
+    """
+    hits: list[tuple[int, str]] = []
+
+    def walk(node: ast.AST, received: frozenset[str]) -> None:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            received = received | _params(node)
+        if isinstance(node, ast.Call):
+            fn = node.func
+            callee = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+            if callee == "worktree_add":
+                arg = _name_argument(node)
+                if arg is None:
+                    hits.append((node.lineno, "worktree_add(...) with no name argument"))
+                else:
+                    inner = list(ast.walk(arg))
+                    by_attribute = any(isinstance(n, ast.Attribute) and n.attr == FIELD
+                                       for n in inner)
+                    by_parameter = FIELD in received and any(
+                        isinstance(n, ast.Name) and n.id == FIELD for n in inner)
+                    if not (by_attribute or by_parameter):
+                        hits.append((node.lineno,
+                                     f"worktree_add(..., {ast.unparse(arg)}, ...)"))
+        for child in ast.iter_child_nodes(node):
+            walk(child, received)
+
+    walk(tree, frozenset())
+    return hits
+
+
+def _calls_in(tree: ast.Module) -> int:
+    """How many `worktree_add` calls the predicate actually examined."""
+    return sum(1 for n in ast.walk(tree)
+               if isinstance(n, ast.Call)
+               and (getattr(n.func, "attr", None) == "worktree_add"
+                    or getattr(n.func, "id", None) == "worktree_add"))
+
+
+def _trees() -> list[tuple[Path, ast.Module]]:
+    out = []
+    for path in _fleet_sources():
+        try:
+            out.append((path, ast.parse(path.read_text(encoding="utf-8"))))
+        except SyntaxError:  # a module that will not parse is a different failure
+            continue
+    return out
+
+
+def test_no_call_site_ASSEMBLES_the_name_it_cuts_a_worktree_with() -> None:
+    offenders = [(p, ln, what) for p, tree in _trees()
+                 for ln, what in _assembled_names(tree)]
+    assert not offenders, (
+        "these calls build the worktree name where the worktree is cut, instead "
+        "of taking it from the run context:\n"
+        + "\n".join(f"  {p.relative_to(FLEET)}:{ln}  {what}"
+                    for p, ln, what in offenders)
+        + f"\n\nThe name is a FIELD — `RunContext.worktree_name`, derived once at "
+          f"the dispatch boundary from the workflow key. Take `{FIELD}` from the "
+          f"context, or receive it as a parameter of this function. Measured "
+          f"2026-08-28: eleven sites in three spellings, one already drifted from "
+          f"the workflow key it was supposed to follow."
+    )
+
+
+def test_THE_WALK_EXAMINED_A_POPULATION() -> None:
+    """THE VACUITY FLOOR, and it is not optional for an absence assertion.
+
+    The assertion above is phrased as an absence, so a walk that found no files —
+    a moved directory, a renamed package — or a predicate that recognised no
+    calls passes it while checking nothing. Two things are proved: that calls
+    were actually examined, and that the file whose ALIAS defeats the existing
+    `act.`-keyed predicates is among them.
+    """
+    trees = _trees()
+    examined = sum(_calls_in(tree) for _, tree in trees)
+    assert examined >= 10, (
+        f"the predicate recognised only {examined} `worktree_add` calls across "
+        f"{len(trees)} fleet modules — it was written against eleven production "
+        f"call sites plus the definition, so it is no longer reading the tree "
+        f"it claims to")
+
+    seen = {p.name for p, tree in trees if _calls_in(tree)}
+    for expected in ("review_pr_workflow.py", "build_workflow.py",
+                     "plan_workflow.py", "run_plan_draft.py"):
+        assert expected in seen, (
+            f"{expected} holds a `worktree_add` call and this walk did not see "
+            f"it, so the guard is narrower than its docstring claims")
+
+    # THE ALIAS, ASSERTED RATHER THAN HOPED FOR. `review_pr_workflow` calls it as
+    # `_shared.worktree_add`, and a predicate keyed on `act.` — which is what
+    # `test_isolation_invariants._classify` still uses — reads zero calls here.
+    alias_file = next(t for p, t in trees if p.name == "review_pr_workflow.py")
+    assert _calls_in(alias_file) >= 1, (
+        "the predicate cannot see `_shared.worktree_add` — it has been rewritten "
+        "to key on a module alias, which is the exact blindness this guard was "
+        "written to avoid")
+
+
+def test_THE_DETECTOR_FIRES_on_every_spelling_the_defect_TOOK() -> None:
+    """A POSITIVE CONTROL ON THE DETECTOR, not on the fleet.
+
+    THE FOURTH SPELLING IS THE ONE THAT MATTERS. The first three are the shapes
+    that were actually in the tree; `datetime` is a spelling nobody has written
+    yet, and it is here because the whole argument for keying on the call site
+    rather than on `time.time()` is that a spelling nobody anticipated must still
+    fail. A control that only exercised the three shapes already fixed would
+    prove the detector works on the population it can already see.
+    """
+    cases = {
+        # spelling 1 — eight runners, via a local assignment
+        "local_assign.py":
+            'def m(repo_root, ref):\n'
+            '    worktree_name = f"plan-{int(time.time())}"\n'
+            '    act.worktree_add(repo_root, worktree_name, ref)\n',
+        # spelling 2 — the two build runners; contains no `time.time()` substring
+        "dunder_import.py":
+            'def m(repo_root, ref):\n'
+            '    wt = f"build-{int(__import__(\'time\').time())}"\n'
+            '    act.worktree_add(repo_root, wt, ref)\n',
+        # spelling 3 — inline, no assignment, reached through a DIFFERENT alias
+        "inline_via_alias.py":
+            'def m(task, worktree, pr):\n'
+            '    _shared.worktree_add(worktree, f"review-pr-{task.pr_number}-'
+            '{int(time.time())}", pr)\n',
+        # a fourth spelling nobody has written — the point of the call-site key
+        "fourth_spelling.py":
+            'def m(repo_root, ref):\n'
+            '    act.worktree_add(repo_root, "plan-" + str(datetime.now().timestamp()), ref)\n',
+        # bare call, no module qualifier at all
+        "bare_call.py":
+            'def m(repo_root, ref):\n'
+            '    worktree_add(repo_root, f"plan-{stamp()}", ref)\n',
+        # the `name=` keyword form
+        "kwarg_form.py":
+            'def m(repo_root, ref):\n'
+            '    act.worktree_add(repo_root, name=f"plan-{stamp()}", ref=ref)\n',
+        # ⚠ A PARAMETER OF THE RIGHT NAME IS NOT ENOUGH — the ARGUMENT has to use
+        # it. This is the half-migration shape: signature updated, call was not.
+        "param_present_but_unused.py":
+            'def m(repo_root, worktree_name, ref):\n'
+            '    act.worktree_add(repo_root, f"plan-{stamp()}", ref)\n',
+        # ⚠ AND REFERENCING *SOME* PARAMETER IS NOT ENOUGH EITHER. This is
+        # exactly `review_pr_workflow`'s old line, which reads `task` — a real
+        # parameter — while inventing the whole name.
+        "references_a_different_param.py":
+            'def m(task, worktree, ref):\n'
+            '    _shared.worktree_add(worktree, f"review-pr-{task.pr_number}-{stamp()}", ref)\n',
+    }
+    for name, src in cases.items():
+        assert _assembled_names(ast.parse(src)), f"the detector missed {name}: {src!r}"
+
+
+def test_THE_DETECTOR_IS_SILENT_on_code_that_is_already_correct() -> None:
+    """A NEGATIVE CONTROL. A guard that fails a fixed tree gets deleted, rightly."""
+    clean = {
+        "from_the_context.py":
+            'def m(repo_root, ctx, ref):\n'
+            '    act.worktree_add(repo_root, ctx.worktree_name, ref)\n',
+        "received_as_a_parameter.py":
+            'def m(repo_root, worktree_name, ref):\n'
+            '    act.worktree_add(repo_root, worktree_name, ref)\n',
+        "per_pass_tree_from_the_received_stem.py":
+            'def m(worktree, worktree_name, this_pass, ref):\n'
+            '    _shared.worktree_add(worktree, f"{worktree_name}-review-{this_pass}", ref)\n',
+        "kwarg_from_the_context.py":
+            'def m(repo_root, ctx, ref):\n'
+            '    act.worktree_add(repo_root, name=ctx.worktree_name, ref=ref)\n',
+        "closure_over_an_enclosing_parameter.py":
+            'def outer(worktree_name):\n'
+            '    def inner(repo_root, ref):\n'
+            '        act.worktree_add(repo_root, worktree_name, ref)\n',
+        # An unrelated function of the same shape must not be swept up.
+        "not_worktree_add.py":
+            'def m(repo_root, ref):\n'
+            '    act.branch_add(repo_root, f"plan-{stamp()}", ref)\n',
+    }
+    for name, src in clean.items():
+        assert not _assembled_names(ast.parse(src)), (
+            f"the detector fires on {name}, which is CORRECT code — it would fail "
+            f"a fixed tree and teach the next reader to weaken it")

--- a/scripts/workflows/temporal/tests/unit/test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py
@@ -92,6 +92,49 @@ def _name_argument(call: ast.Call) -> ast.expr | None:
     return next((k.value for k in call.keywords if k.arg == "name"), None)
 
 
+#: Anything that stamps a value with "now". A worktree name is derived from one
+#: of these EXACTLY ONCE in this fleet — in `RunContext._worktree_name` — so a
+#: call site reading one is assembling, whatever else its argument references.
+_CLOCKS = {"time", "monotonic", "now", "utcnow", "today", "time_ns", "uuid4", "uuid1"}
+
+
+def _rebound(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Names this function ASSIGNS, which a parameter of the same name loses to.
+
+    Nested functions are excluded: an inner `def` rebinding a name shadows it
+    only inside itself, and the enclosing call site is still reading the
+    parameter it was handed.
+    """
+    out: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node is not fn:
+            continue
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+            targets = [node.target]
+        elif isinstance(node, (ast.For, ast.AsyncFor)):
+            targets = [node.target]
+        elif isinstance(node, ast.NamedExpr):
+            targets = [node.target]
+        for target in targets:
+            out |= {n.id for n in ast.walk(target) if isinstance(n, ast.Name)}
+    return out
+
+
+def _reads_a_clock(nodes: list[ast.AST]) -> bool:
+    """Does this argument expression call something that stamps it with "now"?"""
+    for node in nodes:
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
+        if name in _CLOCKS:
+            return True
+    return False
+
+
 def _assembled_names(tree: ast.Module) -> list[tuple[int, str]]:
     """Every `worktree_add` call whose name argument was NOT received.
 
@@ -116,12 +159,29 @@ def _assembled_names(tree: ast.Module) -> list[tuple[int, str]]:
     guard. `worktree_name = f"plan-{int(time.time())}"` followed by
     `worktree_add(repo_root, worktree_name, ref)` is exactly what eight runners
     did, and reading only the argument's spelling would call it received.
+
+    ⚠ AND A PARAMETER THAT WAS REBOUND IS NO LONGER RECEIVED. Measured
+    2026-09-01, driving this predicate on literals: a function with a
+    `worktree_name` parameter that reassigns it — `worktree_name =
+    f"review-pr-{int(time.time())}"` on the first line of `run_review` — passed.
+    That is the HALF-MIGRATION shape at the one site this guard's own docstring
+    calls "the one it most needs to see": signature converted, body not. So a
+    name is dropped from `received` the moment anything in the function binds
+    it, and the argument is then judged on what it actually references.
+
+    ⚠ AND A CLOCK IN THE ARGUMENT IS ASSEMBLY WHATEVER ELSE IT REFERENCES.
+    `f"{worktree_name}-{int(time.time())}"` referenced a received parameter and
+    passed, which would have let a twelfth site re-scatter the derivation while
+    reading as a suffix. The per-pass suffix that IS legitimate
+    (`review_pr_workflow`'s `-review-{pr}-{this_pass}`) is built from values the
+    function was handed; a wall clock is not one of them, and the fleet has
+    exactly one place allowed to read it (`RunContext._worktree_name`).
     """
     hits: list[tuple[int, str]] = []
 
     def walk(node: ast.AST, received: frozenset[str]) -> None:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            received = received | _params(node)
+            received = (received | _params(node)) - _rebound(node)
         if isinstance(node, ast.Call):
             fn = node.func
             callee = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", "")
@@ -135,7 +195,11 @@ def _assembled_names(tree: ast.Module) -> list[tuple[int, str]]:
                                        for n in inner)
                     by_parameter = FIELD in received and any(
                         isinstance(n, ast.Name) and n.id == FIELD for n in inner)
-                    if not (by_attribute or by_parameter):
+                    if _reads_a_clock(inner):
+                        hits.append((node.lineno,
+                                     f"worktree_add(..., {ast.unparse(arg)}, ...) "
+                                     f"— reads a clock at the call site"))
+                    elif not (by_attribute or by_parameter):
                         hits.append((node.lineno,
                                      f"worktree_add(..., {ast.unparse(arg)}, ...)"))
         for child in ast.iter_child_nodes(node):
@@ -190,11 +254,13 @@ def test_THE_WALK_EXAMINED_A_POPULATION() -> None:
     """
     trees = _trees()
     examined = sum(_calls_in(tree) for _, tree in trees)
-    assert examined >= 10, (
+    assert examined >= 11, (
         f"the predicate recognised only {examined} `worktree_add` calls across "
-        f"{len(trees)} fleet modules — it was written against eleven production "
-        f"call sites plus the definition, so it is no longer reading the tree "
-        f"it claims to")
+        f"{len(trees)} fleet modules — it was written against ELEVEN production "
+        f"call sites (the twelfth match is the `def` in `assistant_activities`, "
+        f"which `_calls_in` does not count), so it is no longer reading the tree "
+        f"it claims to. A floor one below the real population lets an entire "
+        f"runner drop out of the walk unnoticed.")
 
     seen = {p.name for p, tree in trees if _calls_in(tree)}
     for expected in ("review_pr_workflow.py", "build_workflow.py",
@@ -262,6 +328,22 @@ def test_THE_DETECTOR_FIRES_on_every_spelling_the_defect_TOOK() -> None:
         "references_a_different_param.py":
             'def m(task, worktree, ref):\n'
             '    _shared.worktree_add(worktree, f"review-pr-{task.pr_number}-{stamp()}", ref)\n',
+        # ⚠ THE HALF-MIGRATION: signature converted, body not. This shape PASSED
+        # until 2026-09-01, at the one site the docstring above calls the one
+        # this guard most needs to see.
+        "parameter_rebound_before_use.py":
+            'def run_review(task, worktree, *, worktree_name):\n'
+            '    worktree_name = f"review-pr-{int(time.time())}"\n'
+            '    _shared.worktree_add(worktree, worktree_name, ref)\n',
+        # ⚠ AND THE RE-SCATTER WEARING A SUFFIX. It references a received
+        # parameter, so the "received" arm alone called it clean.
+        "received_stem_plus_a_fresh_clock.py":
+            'def m(worktree, worktree_name, ref):\n'
+            '    _shared.worktree_add(worktree, f"{worktree_name}-{int(time.time())}", ref)\n',
+        # The same, through the alias-free `datetime` spelling.
+        "received_stem_plus_a_datetime.py":
+            'def m(worktree, worktree_name, ref):\n'
+            '    act.worktree_add(worktree, f"{worktree_name}-{datetime.now()}", ref)\n',
     }
     for name, src in cases.items():
         assert _assembled_names(ast.parse(src)), f"the detector missed {name}: {src!r}"

--- a/scripts/workflows/temporal/tests/unit/test_convergence.py
+++ b/scripts/workflows/temporal/tests/unit/test_convergence.py
@@ -911,7 +911,8 @@ def test_the_convergence_event_is_written_and_carries_its_evidence(
     fake = _FakeWorkflow(_record(run_id="@ISSUED@"), "VERDICT: MERGE\n", block=block)
     wf = fake.install(monkeypatch, tmp_path)
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     events = [e for e in _log_events(tmp_path) if e.get("type") == "convergence"]
     assert len(events) == 1, "the convergence observable was not persisted"
@@ -942,7 +943,8 @@ def test_the_parent_route_event_is_UNCHANGED_by_the_addition(
 
     fake = _FakeWorkflow(_record(run_id="@ISSUED@"), "VERDICT: MERGE\n")
     wf = fake.install(monkeypatch, tmp_path)
-    wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     routes = [e for e in _log_events(tmp_path) if e.get("type") == "parent_route"]
     assert len(routes) == 1
@@ -1029,7 +1031,8 @@ def test_an_undetermined_route_still_produces_an_assessment(
 
     fake = _FakeWorkflow(None, "VERDICT: HOLD - needs-assistance\n", block=None)
     wf = fake.install(monkeypatch, tmp_path)
-    wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     events = [e for e in _log_events(tmp_path) if e.get("type") == "convergence"]
     assert len(events) == 1
@@ -1056,7 +1059,8 @@ def test_an_exhausted_thread_read_reports_history_unreadable_not_a_bad_pass(
         raise RuntimeError("gh pr view failed: API rate limit exceeded")
 
     monkeypatch.setattr(act, "thread_snapshot", _boom)
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     events = [e for e in _log_events(tmp_path) if e.get("type") == "convergence"]
     assert events[0]["reason"] == "history_unreadable", (
@@ -1096,7 +1100,8 @@ def test_the_incumbent_flag_is_shadowed_and_a_disagreement_is_reported(
     # The window: the prior pass's block plus this pass's, in comment order.
     _window(monkeypatch, [prior, now])
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     event = [e for e in _log_events(tmp_path) if e.get("type") == "convergence"][0]
     assert event["asserted_converged"] is True
@@ -1130,7 +1135,8 @@ def test_the_operator_note_says_the_signal_routes_nothing(
     wf = fake.install(monkeypatch, tmp_path)
     _window(monkeypatch, [prior, now])
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     notes = [n for n in result.notes if n.startswith("Computed convergence")]
     assert len(notes) == 1, f"the signal was not surfaced: {result.notes}"
@@ -1157,7 +1163,8 @@ def test_an_assessment_with_NOTHING_TO_REPORT_emits_no_note_but_still_an_event(
 
     fake = _FakeWorkflow(_record(run_id="@ISSUED@"), "VERDICT: MERGE\n")
     wf = fake.install(monkeypatch, tmp_path)
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert not [n for n in result.notes if n.startswith("Computed convergence")], (
         "a no_prior_pass assessment with nothing open printed an operator note"

--- a/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
+++ b/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
@@ -1,0 +1,306 @@
+"""The run context: derived once, frozen, and previewed by the same renderer.
+
+WHAT IS UNDER TEST. `RunContext` is the object Workflow Decomposition Phase 4
+introduces so that a run has ONE place its derived values come from. Three
+properties are checkable here and each had a measured failure behind it:
+
+  * THE WORKTREE NAME FOLLOWS THE WORKFLOW KEY. Eleven sites derived it
+    independently and `run_build_minor` had drifted — `workflow_key="build-minor"`
+    beside a worktree named `build-…`, so its trees were indistinguishable on
+    disk from the `build` parent's.
+  * THE ECHO IS GATED ON *IS THIS INVOCATION THE RUN*, not on `verbose` and not
+    on `minted`. An operator retrying with `--run-id X` has `minted=False` and is
+    exactly the caller who most needs to see what the retry derived.
+  * THE REHEARSAL AND THE LIVE RUN PRINT THE SAME OBJECT. A `--dry-run` that
+    assembles its own copy previews something that is not what runs, and this
+    family has shipped that bug once already (`run_review`'s own docstring
+    records `render_prompt` diverging between the two paths).
+
+WHAT THIS DOES NOT COVER. It says nothing about whether a field's value is
+CORRECT for a given invocation — `repo_root` comes from `preflight`, which has
+its own suite — only about what the context does with what it is handed. The
+call-site property (nothing re-derives the worktree name) is
+`test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py`, and the four-part field
+documentation is `test_every_context_FIELD_STATES_ITSELF.py`.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+FLEET = Path(__file__).resolve().parents[2]
+ENTRYPOINTS = FLEET / "scripts"
+sys.path.insert(0, str(ENTRYPOINTS))
+
+from dispatch_context import DRY_RUN_RUN_ID, RunContext  # noqa: E402
+from dispatch_identity import RunIdentity  # noqa: E402
+
+FROZEN_CLOCK = lambda: 1788240530.9  # noqa: E731 — a pinned instant, not a helper
+
+
+def _ctx(**over) -> RunContext:
+    base = dict(repo_root=Path("/repo"), workflow_key="plan-draft",
+                pr_number=None, target="development/x/y", clock=FROZEN_CLOCK)
+    base.update(over)
+    return RunContext.for_dry_run(**base)
+
+
+# --- the worktree name -------------------------------------------------------
+
+@pytest.mark.parametrize("key", [
+    "plan", "plan-draft", "plan-refine", "plan-sprint", "plan-project",
+    "plan-revision", "triage-candidates", "research", "build", "build-minor",
+    "review-pr",
+])
+def test_the_worktree_name_FOLLOWS_THE_WORKFLOW_KEY(key: str) -> None:
+    """Every key, not a sample — the drift was in exactly one of eleven.
+
+    Parametrised over the whole fleet because the defect this replaces was a
+    single runner whose name and key disagreed. A test that checked two keys
+    would have passed over it.
+    """
+    ctx = _ctx(workflow_key=key)
+    assert ctx.worktree_name == f"{key}-1788240530"
+
+
+def test_build_minor_NO_LONGER_NAMES_ITS_TREE_LIKE_THE_BUILD_PARENT() -> None:
+    """The drift, asserted as itself rather than as a corollary.
+
+    `run_build_minor` built `f"build-{...}"` under `workflow_key="build-minor"`,
+    so `.claude/worktrees/build-…` held trees from two different workflows and
+    `/cleanup-merged-worktrees` could not tell them apart. This is a BEHAVIOUR
+    CHANGE shipped deliberately, so it gets an assertion of its own that will
+    fail loudly if anyone "restores" the old name.
+    """
+    minor = _ctx(workflow_key="build-minor").worktree_name
+    major = _ctx(workflow_key="build").worktree_name
+    assert minor.startswith("build-minor-")
+    assert minor != major
+    assert not minor.startswith(f"{major}-"), (
+        "the minor tier's name is a prefix-extension of the major tier's, so a "
+        "prefix match still cannot tell them apart")
+
+
+def test_the_context_is_FROZEN() -> None:
+    """A boundary value that can be reassigned downstream is not a boundary value."""
+    ctx = _ctx()
+    for field in ("worktree_name", "repo_root", "workflow_key", "target"):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(ctx, field, "mutated")
+
+
+def test_the_context_EXTENDS_identity_rather_than_sitting_beside_it() -> None:
+    """`is_the_run` and the three identity fields come for free, or they diverge."""
+    assert issubclass(RunContext, RunIdentity)
+    ctx = _ctx()
+    assert ctx.is_the_run is True
+    names = {f.name for f in dataclasses.fields(RunContext)}
+    assert {"run_id", "writer", "minted"} <= names
+
+
+# --- the echo ----------------------------------------------------------------
+
+def _echoed(ctx: RunContext) -> str:
+    buffer = io.StringIO()
+    ctx.echo(stream=buffer)
+    return buffer.getvalue()
+
+
+def test_the_run_ECHOES_what_it_derived() -> None:
+    out = _echoed(_ctx(pr_number="42"))
+    assert "plan-draft-1788240530" in out, "the worktree name is not in the echo"
+    assert "development/x/y" in out, "the TARGET is not in the echo"
+    assert "/repo" in out
+    assert "#42" in out
+
+
+def test_a_MEMBER_of_a_run_does_NOT_REPRINT_what_its_parent_said() -> None:
+    """The `constructed here or received` discriminator, exercised.
+
+    `--writer` is the only thing that distinguishes a child started by a parent
+    from a child started by a person reproducing what a parent did, so it is the
+    only honest gate. A parent that hands nine children one context should say it
+    once.
+    """
+    member = RunContext(run_id="r1", writer="plan_refine", minted=False,
+                        repo_root=Path("/repo"), journal_root=None,
+                        workflow_key="plan-refine", worktree_name="plan-refine-1",
+                        pr_number=None, target=None)
+    assert _echoed(member) == ""
+
+
+def test_the_echo_is_NOT_GATED_ON_MINTED_because_a_RETRY_needs_it_most() -> None:
+    """A supplied `--run-id` means `minted=False` — and it is still the run.
+
+    This is the correction the phase makes to its own brief, which named `minted`
+    as the discriminator. An operator retrying into an existing bag supplies the
+    name, so `minted` is False for the caller with the strongest claim on seeing
+    what the retry derived.
+    """
+    retried = RunContext(run_id="20260901-abc", writer=None, minted=False,
+                         repo_root=Path("/repo"), journal_root=Path("/j"),
+                         workflow_key="plan", worktree_name="plan-1",
+                         pr_number="42", target="development/x")
+    assert "plan-1" in _echoed(retried)
+
+
+def test_the_echo_defaults_to_STDERR() -> None:
+    """stdout is a rendered report for several entrypoints; the echo is not that."""
+    ctx = _ctx()
+    err, out = io.StringIO(), io.StringIO()
+    real_err, real_out = sys.stderr, sys.stdout
+    sys.stderr, sys.stdout = err, out
+    try:
+        ctx.echo()
+    finally:
+        sys.stderr, sys.stdout = real_err, real_out
+    assert "plan-draft-1788240530" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+# --- the rehearsal -----------------------------------------------------------
+
+def test_a_REHEARSAL_mints_nothing_and_resolves_no_journal_root() -> None:
+    """`--dry-run` says "nothing invoked, nothing posted" and must stay true.
+
+    `resolve_identity` is called AFTER the dry-run early return for exactly this
+    reason. A context built for a rehearsal must be buildable without minting a
+    name and without creating a 0700 directory, and both facts are VALUES on the
+    object rather than quiet absences.
+    """
+    ctx = _ctx()
+    assert ctx.run_id == DRY_RUN_RUN_ID
+    assert ctx.minted is False
+    assert ctx.journal_root is None
+    assert "rehearsal" in ctx.render()
+
+
+def test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT() -> None:
+    """One assembly, one renderer — which is requirement 4 stated as a test.
+
+    Constructed both ways with the same inputs, the two renderings differ only in
+    the two fields a rehearsal genuinely does not have. Every derived value the
+    operator is previewing — the worktree, the target, the repo root — is
+    identical, because there is one `render` and one set of fields behind it.
+    """
+    live = RunContext.build.__wrapped__ if hasattr(RunContext.build, "__wrapped__") else None
+    assert live is None  # not decorated; construct directly to avoid touching disk
+    rehearsal = _ctx(pr_number="42")
+    same = RunContext(run_id="20260901-abc", writer=None, minted=True,
+                      repo_root=rehearsal.repo_root, journal_root=Path("/j"),
+                      workflow_key=rehearsal.workflow_key,
+                      worktree_name=rehearsal.worktree_name,
+                      pr_number=rehearsal.pr_number, target=rehearsal.target)
+
+    def derived_lines(text: str) -> list[str]:
+        return [ln for ln in text.splitlines()
+                if not ln.strip().startswith(("run ", "journal "))]
+
+    assert derived_lines(rehearsal.render()) == derived_lines(same.render())
+
+
+# --- requirement 4, held structurally over the entrypoints -------------------
+
+def _entrypoints() -> list[Path]:
+    found = sorted(p for p in ENTRYPOINTS.glob("run_*.py"))
+    assert len(found) >= 10, (
+        f"only {len(found)} entrypoints discovered under {ENTRYPOINTS} — the "
+        f"glob is wrong and every assertion below would pass vacuously")
+    return found
+
+
+def _calls(tree: ast.AST) -> set[str]:
+    """Every call, as `<attr>` or `<name>`, so `.build`/`.echo` are visible."""
+    out = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            out.add(fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", ""))
+    return out
+
+
+def _declares_a_dry_run(tree: ast.AST) -> bool:
+    return any(isinstance(n, ast.Constant) and n.value == "--dry-run"
+               for n in ast.walk(tree))
+
+
+def test_every_entrypoint_BUILDS_a_context_and_SAYS_IT() -> None:
+    """Discovered rather than listed, so the next entrypoint is covered on day one."""
+    missing = []
+    for path in _entrypoints():
+        calls = _calls(ast.parse(path.read_text(encoding="utf-8")))
+        for required in ("build", "echo"):
+            if required not in calls:
+                missing.append(f"{path.name}: never calls `.{required}()`")
+    assert not missing, (
+        "these entrypoints do not construct or do not announce a run context:\n"
+        + "\n".join(f"  {m}" for m in missing)
+        + "\n\nWrite `ctx = RunContext.build(identity=resolve_identity(argv), …)` "
+          "followed by `ctx.echo()`, before `open_run_bag` and before anything "
+          "is created."
+    )
+
+
+def test_every_dry_run_PREVIEWS_THE_SAME_OBJECT() -> None:
+    """Requirement 4, where it can actually be lost — in the rehearsal branch.
+
+    An entrypoint that declares `--dry-run` and does not build a context for it
+    is previewing values it assembled itself, which is the exact divergence this
+    requirement exists to close.
+    """
+    missing = []
+    for path in _entrypoints():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        if not _declares_a_dry_run(tree):
+            continue
+        calls = _calls(tree)
+        if "for_dry_run" not in calls or "render" not in calls:
+            missing.append(f"{path.name}: declares --dry-run but never renders a context")
+    assert not missing, (
+        "these rehearsals preview something other than the object the live run "
+        "prints:\n" + "\n".join(f"  {m}" for m in missing)
+        + "\n\nPrint `RunContext.for_dry_run(...).render()` in the --dry-run "
+          "branch. A second assembly of the same values is the bug."
+    )
+
+
+def test_THE_ENTRYPOINT_SWEEPS_DISCRIMINATE() -> None:
+    """CONTROLS on both sweeps above, driven on literals.
+
+    Both assertions are phrased as absences over a discovered population, so
+    each needs a positive case proving the predicate reads what it claims —
+    including the half-migration shape where the import is present and the call
+    is not.
+    """
+    built_and_echoed = ('from dispatch_context import RunContext\n'
+                        'def main(argv):\n'
+                        '    ctx = RunContext.build(identity=i, repo_root=r, workflow_key="k")\n'
+                        '    ctx.echo()\n')
+    assert {"build", "echo"} <= _calls(ast.parse(built_and_echoed))
+
+    # The half-migration: imported, never called. `_names_used`-style checks pass
+    # this, which is why the sweep asks for a CALL.
+    imported_only = ('from dispatch_context import RunContext\n'
+                     'def main(argv):\n'
+                     '    journal.open_run_bag(run_id="x")\n')
+    assert "build" not in _calls(ast.parse(imported_only))
+    assert "echo" not in _calls(ast.parse(imported_only))
+
+    assert _declares_a_dry_run(ast.parse('p.add_argument("--dry-run")\n'))
+    assert not _declares_a_dry_run(ast.parse('p.add_argument("--verbose")\n'))
+
+    previewing = ('def main(a):\n'
+                  '    if a.dry_run:\n'
+                  '        print(RunContext.for_dry_run(repo_root=r, workflow_key="k").render())\n')
+    assert {"for_dry_run", "render"} <= _calls(ast.parse(previewing))
+
+    hand_rolled = ('def main(a):\n'
+                   '    if a.dry_run:\n'
+                   '        print(f"  Component : {component}")\n')
+    assert "for_dry_run" not in _calls(ast.parse(hand_rolled))

--- a/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
+++ b/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
@@ -44,6 +44,33 @@ from dispatch_identity import RunIdentity  # noqa: E402
 FROZEN_CLOCK = lambda: 1788240530.9  # noqa: E731 — a pinned instant, not a helper
 
 
+def _live(tmp_root: Path, **over) -> RunContext:
+    """`RunContext.build` — the LIVE constructor — against a scratch journal root.
+
+    ⚠ THIS EXISTS BECAUSE NOTHING DROVE `build` AT ALL, and that is how the value
+    this whole object exists to consolidate came to be written TWICE. `build`
+    and `for_dry_run` each carried their own `f"{key}-{int(clock())}"`; every
+    assertion below went through `for_dry_run`, so perturbing the live copy
+    alone left the entire suite green (measured 2026-09-01: 3051 passed) while
+    the rehearsal previewed a name no run would use. Requirement 4's own defect,
+    inside requirement 4's fix.
+
+    `config_path` points at a generated config so the boundary's journal-root
+    resolution lands in `tmp_path` — the session fixture in `tests/conftest.py`
+    already redirects `CONFIG_PATH`, and this is the same protection stated at
+    the call rather than relied on.
+    """
+    config = tmp_root / "config.yaml"
+    config.write_text(f'journal:\n  root: "{tmp_root / "journal"}"\n  deployment: user\n',
+                      encoding="utf-8")
+    base = dict(identity=RunIdentity(run_id="20260901-abc", writer=None, minted=True),
+                repo_root=Path("/repo"), workflow_key="plan-draft",
+                pr_number=None, target="development/x/y",
+                config_path=config, clock=FROZEN_CLOCK)
+    base.update(over)
+    return RunContext.build(**base)
+
+
 def _ctx(**over) -> RunContext:
     base = dict(repo_root=Path("/repo"), workflow_key="plan-draft",
                 pr_number=None, target="development/x/y", clock=FROZEN_CLOCK)
@@ -65,8 +92,19 @@ def test_the_worktree_name_FOLLOWS_THE_WORKFLOW_KEY(key: str) -> None:
     single runner whose name and key disagreed. A test that checked two keys
     would have passed over it.
     """
-    ctx = _ctx(workflow_key=key)
-    assert ctx.worktree_name == f"{key}-1788240530"
+    assert _ctx(workflow_key=key).worktree_name == f"{key}-1788240530"
+
+
+@pytest.mark.parametrize("key", ["plan-draft", "build", "build-minor", "review-pr"])
+def test_the_LIVE_constructor_derives_the_SAME_NAME_as_the_rehearsal(
+        key: str, tmp_path: Path) -> None:
+    """The half nothing drove, which is why the expression could be duplicated.
+
+    A sample of keys rather than all eleven: the parametrised test above holds
+    the key-following property, and what this adds is that `build` — the
+    constructor a real run uses — reaches it by the same route.
+    """
+    assert _live(tmp_path, workflow_key=key).worktree_name == f"{key}-1788240530"
 
 
 def test_build_minor_NO_LONGER_NAMES_ITS_TREE_LIKE_THE_BUILD_PARENT() -> None:
@@ -181,7 +219,7 @@ def test_a_REHEARSAL_mints_nothing_and_resolves_no_journal_root() -> None:
     assert "rehearsal" in ctx.render()
 
 
-def test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT() -> None:
+def test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT(tmp_path: Path) -> None:
     """One assembly, one renderer — which is requirement 4 stated as a test.
 
     Constructed both ways with the same inputs, the two renderings differ only in
@@ -189,20 +227,23 @@ def test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT() -> None:
     operator is previewing — the worktree, the target, the repo root — is
     identical, because there is one `render` and one set of fields behind it.
     """
-    live = RunContext.build.__wrapped__ if hasattr(RunContext.build, "__wrapped__") else None
-    assert live is None  # not decorated; construct directly to avoid touching disk
     rehearsal = _ctx(pr_number="42")
-    same = RunContext(run_id="20260901-abc", writer=None, minted=True,
-                      repo_root=rehearsal.repo_root, journal_root=Path("/j"),
-                      workflow_key=rehearsal.workflow_key,
-                      worktree_name=rehearsal.worktree_name,
-                      pr_number=rehearsal.pr_number, target=rehearsal.target)
+    live = _live(tmp_path, pr_number="42")
 
     def derived_lines(text: str) -> list[str]:
         return [ln for ln in text.splitlines()
                 if not ln.strip().startswith(("run ", "journal "))]
 
-    assert derived_lines(rehearsal.render()) == derived_lines(same.render())
+    assert derived_lines(rehearsal.render()) == derived_lines(live.render())
+    # And the FIELDS agree, not merely their rendering — a renderer that dropped
+    # a row would make two different objects print identically.
+    differing = {f.name for f in dataclasses.fields(RunContext)
+                 if getattr(rehearsal, f.name) != getattr(live, f.name)}
+    assert differing == {"run_id", "minted", "journal_root"}, (
+        f"the rehearsal and the live run differ on {differing}; only the run id, "
+        f"`minted` and the journal root may differ — a rehearsal mints no name "
+        f"and resolves no root, and every DERIVED value must be identical or the "
+        f"preview is showing something other than what runs")
 
 
 # --- the per-pass tree a review cuts BENEATH the run's own -------------------
@@ -220,10 +261,19 @@ def _review_tree_name(worktree_name: str, pr_number: str, this_pass: int) -> str
     so the f-string is lifted out of the file and evaluated, and a change to it
     that breaks a property below fails rather than passing against a copy.
     """
-    src = (FLEET / "modules" / "assistant" / "review_pr"
-           / "review_pr_workflow.py").read_text(encoding="utf-8")
+    module = (FLEET / "modules" / "assistant" / "review_pr"
+              / "review_pr_workflow.py")
+    src = module.read_text(encoding="utf-8")
     marker = "worktree, f\""
-    start = src.index(marker, src.index("pr_tree = _shared.worktree_add")) + len(marker)
+    call = src.find("pr_tree = _shared.worktree_add")
+    start = src.find(marker, call) if call != -1 else -1
+    assert call != -1 and start != -1, (
+        f"the per-pass tree name could not be read out of {module.name}: this lifts "
+        f"the f-string argument of `pr_tree = _shared.worktree_add`. If that call "
+        f"was reformatted or renamed, update this reader — do NOT retype the "
+        f"template here, because a literal copy is a second statement of the rule "
+        f"and that is exactly what this phase exists to stop.")
+    start += len(marker)
     template = src[start:src.index('"', start)]
     return eval(f'f"{template}"', {},  # noqa: S307 — the template is our own source
                 {"worktree_name": worktree_name, "task": type("T", (), {"pr_number": pr_number}),
@@ -286,6 +336,31 @@ def _declares_a_dry_run(tree: ast.AST) -> bool:
                for n in ast.walk(tree))
 
 
+def _call_lines(tree: ast.AST, name: str) -> list[int]:
+    return sorted(n.lineno for n in ast.walk(tree)
+                  if isinstance(n, ast.Call)
+                  and (getattr(n.func, "attr", None) == name
+                       or getattr(n.func, "id", None) == name))
+
+
+def _conditional_calls(tree: ast.AST, name: str) -> list[int]:
+    """Lines where `name` is called from inside an `if` — i.e. not unconditionally.
+
+    The `--dry-run` early return is not one of these: it RETURNS, so a call after
+    it is still unconditional on the live path. What this catches is
+    `if a.verbose: ctx.echo()`, which is the requirement's own named failure —
+    the echo is not chatter and is not the operator's to switch off.
+    """
+    conditional: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        for branch in (node.body, node.orelse):
+            for stmt in branch:
+                conditional.extend(_call_lines(stmt, name))
+    return conditional
+
+
 def test_every_entrypoint_BUILDS_a_context_and_SAYS_IT() -> None:
     """Discovered rather than listed, so the next entrypoint is covered on day one."""
     missing = []
@@ -300,6 +375,45 @@ def test_every_entrypoint_BUILDS_a_context_and_SAYS_IT() -> None:
         + "\n\nWrite `ctx = RunContext.build(identity=resolve_identity(argv), …)` "
           "followed by `ctx.echo()`, before `open_run_bag` and before anything "
           "is created."
+    )
+
+
+def test_every_entrypoint_SAYS_IT_BEFORE_THE_BAG_OPENS_and_UNCONDITIONALLY() -> None:
+    """PLACEMENT, which the presence sweep above cannot see — and it was needed.
+
+    ⚠ MEASURED 2026-09-01 BY MUTATION. Moving `ctx.echo()` BELOW
+    `journal.open_run_bag(...)` in `run_plan.py` left the whole unit tier green
+    (3051 passed): the presence sweep collects call NAMES anywhere in the file,
+    so requirement 3's ordering was held on exactly ONE entrypoint of eleven —
+    `run_plan_draft`, by the live demonstration in
+    `test_a_WRONG_TARGET_is_NAMED_before_the_run_costs_anything.py`. That is the
+    same defect this PR found in `test_every_parent_opens_a_run_bag` (a guard
+    that checks presence cannot see placement), reproduced in the guard written
+    beside it.
+
+    TWO PROPERTIES, BOTH FROM REQUIREMENT 3. The echo precedes the bag — the
+    run's first side effect — and it is UNCONDITIONAL, because the requirement
+    rules that `verbose` does not gate it: the context line is not a workflow's
+    chatter, it is the run saying what it is about to spend money on.
+    """
+    offenders = []
+    for path in _entrypoints():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        echoes, bags = _call_lines(tree, "echo"), _call_lines(tree, "open_run_bag")
+        if not echoes or not bags:
+            continue                       # the presence sweep above owns that
+        if min(echoes) > min(bags):
+            offenders.append(f"{path.name}: `.echo()` at {min(echoes)} comes AFTER "
+                             f"`open_run_bag` at {min(bags)}")
+        for line in _conditional_calls(tree, "echo"):
+            offenders.append(f"{path.name}:{line}: `.echo()` is inside an `if`")
+    assert not offenders, (
+        "these entrypoints announce their context too late, or only sometimes:\n"
+        + "\n".join(f"  {o}" for o in offenders)
+        + "\n\nThe echo exists for the operator about to spend an hour of model "
+          "time on the wrong component, so it goes BEFORE the bag opens and it "
+          "is not switchable. `RunContext.echo` gates itself on whether this "
+          "invocation IS the run; nothing at the call site may gate it further."
     )
 
 
@@ -318,6 +432,12 @@ def test_every_dry_run_PREVIEWS_THE_SAME_OBJECT() -> None:
         calls = _calls(tree)
         if "for_dry_run" not in calls or "render" not in calls:
             missing.append(f"{path.name}: declares --dry-run but never renders a context")
+        elif not _conditional_calls(tree, "for_dry_run"):
+            # PLACEMENT, not presence: a `for_dry_run(...)` sitting outside the
+            # rehearsal branch means the branch is still previewing something
+            # else, with the context built somewhere it is never printed.
+            missing.append(f"{path.name}: builds a rehearsal context outside the "
+                           f"`--dry-run` branch, so the branch is not what it previews")
     assert not missing, (
         "these rehearsals preview something other than the object the live run "
         "prints:\n" + "\n".join(f"  {m}" for m in missing)
@@ -360,3 +480,30 @@ def test_THE_ENTRYPOINT_SWEEPS_DISCRIMINATE() -> None:
                    '    if a.dry_run:\n'
                    '        print(f"  Component : {component}")\n')
     assert "for_dry_run" not in _calls(ast.parse(hand_rolled))
+    assert _conditional_calls(ast.parse(previewing), "for_dry_run") == [3]
+
+    # CONTROLS ON THE ORDERING AND GATING PREDICATES, driven on literals so each
+    # verdict is attributable to one shape.
+    late = ('def main(a):\n'
+            '    journal.open_run_bag(run_id=ctx.run_id)\n'
+            '    ctx.echo()\n')
+    assert min(_call_lines(ast.parse(late), "echo")) > \
+        min(_call_lines(ast.parse(late), "open_run_bag"))
+
+    early = ('def main(a):\n'
+             '    ctx.echo()\n'
+             '    journal.open_run_bag(run_id=ctx.run_id)\n')
+    assert min(_call_lines(ast.parse(early), "echo")) < \
+        min(_call_lines(ast.parse(early), "open_run_bag"))
+
+    gated = ('def main(a):\n'
+             '    if a.verbose:\n'
+             '        ctx.echo()\n'
+             '    journal.open_run_bag(run_id=ctx.run_id)\n')
+    assert _conditional_calls(ast.parse(gated), "echo") == [3]
+    # A `--dry-run` EARLY RETURN above the echo is not a gate on it.
+    after_early_return = ('def main(a):\n'
+                          '    if a.dry_run:\n'
+                          '        return 0\n'
+                          '    ctx.echo()\n')
+    assert _conditional_calls(ast.parse(after_early_return), "echo") == []

--- a/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
+++ b/scripts/workflows/temporal/tests/unit/test_dispatch_context.py
@@ -205,6 +205,62 @@ def test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT() -> None:
     assert derived_lines(rehearsal.render()) == derived_lines(same.render())
 
 
+# --- the per-pass tree a review cuts BENEATH the run's own -------------------
+#
+# HERE RATHER THAN BESIDE `run_review`, because the naming scheme is ONE rule
+# with two halves — a run-scoped stem from the context, plus a per-pass suffix —
+# and testing half of it in another file is how a rule ends up with two owners
+# that agree until one is edited. That is this component's own recurring defect.
+
+def _review_tree_name(worktree_name: str, pr_number: str, this_pass: int) -> str:
+    """The expression `review_pr_workflow` uses, read back from its source.
+
+    DERIVED FROM THE MODULE, NOT RETYPED. A literal here would be a second
+    statement of the same rule, which is exactly what this phase exists to stop —
+    so the f-string is lifted out of the file and evaluated, and a change to it
+    that breaks a property below fails rather than passing against a copy.
+    """
+    src = (FLEET / "modules" / "assistant" / "review_pr"
+           / "review_pr_workflow.py").read_text(encoding="utf-8")
+    marker = "worktree, f\""
+    start = src.index(marker, src.index("pr_tree = _shared.worktree_add")) + len(marker)
+    template = src[start:src.index('"', start)]
+    return eval(f'f"{template}"', {},  # noqa: S307 — the template is our own source
+                {"worktree_name": worktree_name, "task": type("T", (), {"pr_number": pr_number}),
+                 "this_pass": this_pass})
+
+
+def test_two_reviews_of_DIFFERENT_PRs_in_the_SAME_SECOND_do_not_collide() -> None:
+    """The regression the consolidation nearly shipped, asserted as itself.
+
+    The expression this replaced was `f"review-pr-{pr}-{int(time.time())}"`, and
+    the PR number in it was load-bearing: the context's stem is
+    `<workflow-key>-<ts>`, so two `review-pr` dispatches aimed at different PRs
+    that start in the same wall-clock second share a stem. On their first pass
+    they would have shared the whole directory, and `git worktree add` would
+    have failed one of them — loud, but avoidable and caused by this change.
+    """
+    stem = _ctx(workflow_key="review-pr").worktree_name
+    assert _review_tree_name(stem, "42", 1) != _review_tree_name(stem, "43", 1)
+
+
+def test_two_PASSES_of_ONE_review_do_not_collide() -> None:
+    """A loop-back cuts one tree per pass, which is why the tree is not a field.
+
+    A parent that HOLDs re-enters `run_review` on the same PR inside one run, so
+    the run-scoped stem is identical on both passes and only the pass number
+    separates them.
+    """
+    stem = _ctx(workflow_key="plan").worktree_name
+    assert _review_tree_name(stem, "42", 1) != _review_tree_name(stem, "42", 2)
+
+
+def test_the_review_tree_is_ROOTED_IN_the_runs_own_name() -> None:
+    """The stem is the run's, so a tree on disk is traceable to the bag record."""
+    stem = _ctx(workflow_key="review-pr").worktree_name
+    assert _review_tree_name(stem, "42", 1).startswith(f"{stem}-")
+
+
 # --- requirement 4, held structurally over the entrypoints -------------------
 
 def _entrypoints() -> list[Path]:

--- a/scripts/workflows/temporal/tests/unit/test_every_context_FIELD_STATES_ITSELF.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_context_FIELD_STATES_ITSELF.py
@@ -1,0 +1,189 @@
+"""Every field of the run context says what it is, or the suite goes red.
+
+WHY THIS EXISTS, AND IT IS NOT THE ENUMERATION THE RE-PLAN DELETED. Workflow
+Decomposition Phase 4 originally asked for a published table of every derived
+value in the fleet, held honest by a check that read its population off the tree.
+That check ran cold and returned nothing usable: `@derived`, `DERIVED_VALUES`,
+`register_derivation` and `DERIVATION_SITES` returned ZERO hits across 225 Python
+files, and three of six known derived values reached none of the five named
+resolvers. There is no enumerable population of derivations, so the requirement
+was deleted rather than weakened.
+
+A FROZEN DATACLASS'S FIELDS *ARE* AN ENUMERABLE POPULATION. `dataclasses.fields()`
+returns them by construction — no marker convention, no tree sweep, no hand-kept
+list — which is the reason the deleted requirement is not needed rather than a
+smaller version of it. The population problem that killed it does not exist here.
+
+AND FIELD EXISTENCE IS NOT FIELD DOCUMENTATION, WHICH IS THE WHOLE OF THIS
+MODULE. The re-plan is right that a field cannot drift from the enumeration —
+it IS the enumeration. That says nothing about whether the field is DOCUMENTED,
+and two of the five safe-derivation properties, the published ALGORITHM and the
+stated SCOPE OF EFFECT, are exactly that documentation. Without this, all five
+requirements could pass with eight of nine fields carrying nothing, and a tenth
+field added a year later would carry nothing with nothing going red. That is the
+deleted clause's own property — *a table checked against itself cannot see what
+was never added to it* — reappearing one level down.
+
+⚠ WHAT THIS CANNOT DO, said plainly so nobody over-reads it. It asserts each of
+the four parts is PRESENT and NON-EMPTY. It does NOT assert any of them is TRUE:
+a field naming the wrong marker passes here. That limit is accepted rather than
+worked around — the truth of an algorithm sentence is a judgement, and the
+failure this requirement addresses is ABSENCE, not error. It also says nothing
+about any object other than `RunContext`; a second frozen boundary object would
+need its own line in `_POPULATION`.
+
+THE SHAPE IS THIS REPO'S, NOT INVENTED HERE — `test_promotion_guard_prose_
+figures_are_DERIVED.py` and `test_a_prose_COUNT_of_a_collection_is_DERIVED.py`
+both bind a claim to something that computes it rather than to a restatement.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from pathlib import Path
+
+import pytest
+
+FLEET = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(FLEET / "scripts"))
+
+from dispatch_context import RunContext  # noqa: E402
+from dispatch_identity import derivation  # noqa: E402
+
+#: The four things every field must say about itself. `marker` and `override`
+#: are the two properties this fleet already satisfied structurally; `algorithm`
+#: and `scope` are the two that were absent, and they are why this check exists.
+#: Read off `derivation()`'s own contract rather than restated, so adding a fifth
+#: part there cannot leave this checking four.
+REQUIRED = tuple(sorted(derivation(marker="x", algorithm="x",
+                                   override="x", scope="x")))
+
+#: Every frozen boundary object whose fields carry derived values. One entry
+#: today. A second object added without a row here is invisible to this check —
+#: which is a real limit and is why it is a named constant rather than a literal.
+_POPULATION = (RunContext,)
+
+
+def _fields(cls):
+    return list(dataclasses.fields(cls))
+
+
+@pytest.mark.parametrize("cls", _POPULATION, ids=lambda c: c.__name__)
+def test_the_population_is_NOT_EMPTY(cls) -> None:
+    """THE VACUITY FLOOR. Every assertion below is per-field; zero fields passes.
+
+    A refactor that split the context, renamed it, or turned it into a plain
+    class would leave `dataclasses.fields()` returning an empty list or raising,
+    and the parametrised checks below would report green over nothing.
+    """
+    assert dataclasses.is_dataclass(cls), f"{cls.__name__} is not a dataclass"
+    assert len(_fields(cls)) >= 6, (
+        f"{cls.__name__} has {len(_fields(cls))} fields — it was written with "
+        f"nine, so either the object has been gutted or this check is no longer "
+        f"reading it")
+    # The three inherited from `RunIdentity` must be in the population too: a
+    # subclass that stopped extending it would silently halve what is checked.
+    names = {f.name for f in _fields(cls)}
+    assert {"run_id", "writer", "minted"} <= names, (
+        f"{cls.__name__} no longer carries identity's own fields, so this check "
+        f"has stopped covering the three values a run derives FIRST")
+
+
+@pytest.mark.parametrize("cls", _POPULATION, ids=lambda c: c.__name__)
+def test_every_field_NAMES_its_marker_algorithm_override_and_scope(cls) -> None:
+    """The four-part statement, on every field, read off the object itself."""
+    missing = []
+    for f in _fields(cls):
+        for part in REQUIRED:
+            value = f.metadata.get(part)
+            if not (isinstance(value, str) and value.strip()):
+                missing.append(f"{cls.__name__}.{f.name}: {part}")
+    assert not missing, (
+        "these fields do not say what they are:\n"
+        + "\n".join(f"  {m}" for m in missing)
+        + "\n\nEvery field carries `field(metadata=derivation(marker=…, "
+          "algorithm=…, override=…, scope=…))`. `override` states the flag or "
+          "says it has none — an absent override and an undocumented one are "
+          "not the same fact. `scope` answers *what else is wrong if this value "
+          "is wrong*, which is what makes the run's echo readable rather than "
+          "decorative."
+    )
+
+
+@pytest.mark.parametrize("cls", _POPULATION, ids=lambda c: c.__name__)
+def test_a_scope_of_effect_says_what_BREAKS_not_what_the_value_IS(cls) -> None:
+    """The one quality floor, and it is deliberately the only one.
+
+    A `scope` reading "the repository root" restates the field and answers
+    nothing; the property is *what else is wrong if this is wrong*. Length is a
+    crude proxy and it is the honest one available — the truth of the sentence is
+    a judgement no check reaches, so this asserts only that somebody wrote a
+    sentence rather than a noun phrase. `algorithm` gets the same floor for the
+    same reason.
+    """
+    thin = [f"{f.name}.{part} = {f.metadata[part]!r}"
+            for f in _fields(cls) for part in ("scope", "algorithm")
+            if len(f.metadata[part].split()) < 8]
+    assert not thin, (
+        "these are noun phrases where a statement belongs:\n"
+        + "\n".join(f"  {t}" for t in thin)
+        + "\n\n`scope` answers *what else is wrong if this value is wrong*. "
+          "`resolve_repo_root`'s own comments are the model: worktrees and logs "
+          "both hang off it, so a root at a subdirectory scatters both where "
+          "cleanup never looks — and then deletes the logs with the workspace."
+    )
+
+
+def test_THE_CHECK_FIRES_when_a_field_stops_stating_itself() -> None:
+    """A CONTROL ON THE PREDICATE, driven on a throwaway dataclass.
+
+    DERIVED FROM THE CLAIM THE MODULE MAKES ABOUT ITSELF, not from whatever is
+    easy to break: the module claims a field ADDED LATER cannot arrive
+    undocumented, so the control adds one. Each case names which part is absent,
+    because a control that fires for the wrong reason proves nothing.
+    """
+    ok = derivation(marker="a git directory on disk", algorithm="reads it",
+                    override="the --repo flag", scope="everything hangs off it")
+
+    def sample(**overrides):
+        meta = {**ok, **overrides}
+        @dataclasses.dataclass(frozen=True)
+        class Sample:
+            documented: str = dataclasses.field(metadata=ok)
+            added_later: str = dataclasses.field(metadata=meta)
+        return Sample
+
+    for part in REQUIRED:
+        cls = sample(**{part: ""})
+        holes = [f"{f.name}:{p}" for f in dataclasses.fields(cls) for p in REQUIRED
+                 if not (isinstance(f.metadata.get(p), str) and f.metadata[p].strip())]
+        assert holes == [f"added_later:{part}"], (
+            f"blanking {part!r} on one field produced {holes} — the predicate is "
+            f"not isolating the part it claims to")
+
+    # A field with NO metadata at all — the shape a new field takes when its
+    # author writes `name: str` and stops.
+    @dataclasses.dataclass(frozen=True)
+    class Undocumented:
+        documented: str = dataclasses.field(metadata=ok)
+        added_later: str = ""
+
+    holes = [f.name for f in dataclasses.fields(Undocumented)
+             if not all(f.metadata.get(p) for p in REQUIRED)]
+    assert holes == ["added_later"], (
+        f"a field declared with no metadata was not caught: {holes}")
+
+
+def test_THE_CHECK_IS_SILENT_on_a_fully_stated_field() -> None:
+    """A NEGATIVE CONTROL. A check that fails correct code gets deleted, rightly."""
+    @dataclasses.dataclass(frozen=True)
+    class Fine:
+        value: str = dataclasses.field(metadata=derivation(
+            marker="the presence of a .git directory, read rather than guessed",
+            algorithm="git rev-parse --show-toplevel, run in the repo target",
+            override="none — this value is declared by the caller",
+            scope="wrong means every path below it is resolved somewhere else"))
+
+    assert all(all(f.metadata.get(p, "").strip() for p in REQUIRED)
+               for f in dataclasses.fields(Fine))

--- a/scripts/workflows/temporal/tests/unit/test_every_context_FIELD_STATES_ITSELF.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_context_FIELD_STATES_ITSELF.py
@@ -48,7 +48,7 @@ import pytest
 FLEET = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(FLEET / "scripts"))
 
-from dispatch_context import RunContext  # noqa: E402
+from dispatch_context import RunContext, context_field_documentation  # noqa: E402
 from dispatch_identity import derivation  # noqa: E402
 
 #: The four things every field must say about itself. `marker` and `override`
@@ -58,6 +58,11 @@ from dispatch_identity import derivation  # noqa: E402
 #: part there cannot leave this checking four.
 REQUIRED = tuple(sorted(derivation(marker="x", algorithm="x",
                                    override="x", scope="x")))
+
+#: How many fields `RunContext` was written with. Named once so the floor below
+#: and its failure message cannot state different numbers — which they did, at
+#: `>= 6` against a message saying nine.
+_WRITTEN_WITH = 9
 
 #: Every frozen boundary object whose fields carry derived values. One entry
 #: today. A second object added without a row here is invisible to this check —
@@ -78,10 +83,21 @@ def test_the_population_is_NOT_EMPTY(cls) -> None:
     and the parametrised checks below would report green over nothing.
     """
     assert dataclasses.is_dataclass(cls), f"{cls.__name__} is not a dataclass"
-    assert len(_fields(cls)) >= 6, (
+    assert len(_fields(cls)) >= _WRITTEN_WITH, (
         f"{cls.__name__} has {len(_fields(cls))} fields — it was written with "
-        f"nine, so either the object has been gutted or this check is no longer "
-        f"reading it")
+        f"{_WRITTEN_WITH}, so either the object has been gutted or this check is "
+        f"no longer reading it. The floor is the FULL count deliberately: a floor "
+        f"below it (this said `>= 6`) lets three fields be dropped while the "
+        f"message still insists nine were expected, which is a message and an "
+        f"assertion disagreeing about the same fact.")
+
+    # AND THE MODULE'S OWN ACCESSOR AGREES WITH `dataclasses.fields()`. The
+    # object exports `context_field_documentation()` as the one place the
+    # population is obtained; a helper nothing calls is a claim nothing checks.
+    assert set(context_field_documentation()) == {f.name for f in _fields(cls)}, (
+        "`context_field_documentation()` and `dataclasses.fields()` disagree "
+        "about the population, so the module's stated accessor is not the one "
+        "this guard reads")
     # The three inherited from `RunIdentity` must be in the population too: a
     # subclass that stopped extending it would silently halve what is checked.
     names = {f.name for f in _fields(cls)}

--- a/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
@@ -140,6 +140,60 @@ def _missing_bag_open(directory: Path) -> list[str]:
     return missing
 
 
+def _bag_open_outside_the_handler(directory: Path) -> list[str]:
+    """Entrypoints whose `open_run_bag` is not inside a `RuntimeError` handler.
+
+    ⚠ THE MESSAGE BELOW ALREADY DEMANDED THIS AND NOTHING CHECKED IT. The sweep
+    above asks that the call EXISTS; its own failure text says *"inside the try
+    block that prints RuntimeError"*, and that half was prose. Measured
+    2026-09-01 on `run_plan.py`: the block sat ABOVE the handler in one file of
+    eleven, so `resolve_identity`'s refusal of a bad `--run-id` and
+    `open_run_bag`'s refusal of a full journal — the two failures Phase 1 r9 and
+    Phase 9 exist to make diagnosable — reached the operator as a traceback there
+    and as a one-line diagnostic in the other ten. Nothing went red, because a
+    guard that checks presence cannot see placement.
+
+    KEYED ON THE HANDLER'S EXCEPTION SET, NOT ON "IS IT IN A TRY". A `try` whose
+    `except` catches only `ValueError` would satisfy the weaker property while
+    letting exactly these two escape, and `RuntimeError` is the type every layer
+    in this fleet raises with an operator-facing remedy attached
+    (`JournalRootError` and `BagError` both subclass it, deliberately, so this
+    one clause catches them).
+    """
+    offenders = []
+    for path in _entrypoints(directory):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        guarded = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            if not any(_names_runtime_error(h) for h in node.handlers):
+                continue
+            for stmt in node.body:
+                for inner in ast.walk(stmt):
+                    if _is_bag_open(inner):
+                        guarded.add(inner.lineno)
+        every = {n.lineno for n in ast.walk(tree) if _is_bag_open(n)}
+        for line in sorted(every - guarded):
+            offenders.append(f"{path.name}:{line}")
+    return offenders
+
+
+def _is_bag_open(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Call)
+            and (getattr(node.func, "id", None) == BAG_OPEN
+                 or getattr(node.func, "attr", None) == BAG_OPEN))
+
+
+def _names_runtime_error(handler: ast.ExceptHandler) -> bool:
+    """`except RuntimeError`, or a tuple containing it. A bare `except:` counts."""
+    if handler.type is None:
+        return True
+    parts = (handler.type.elts if isinstance(handler.type, ast.Tuple)
+             else [handler.type])
+    return any(getattr(p, "id", None) == "RuntimeError" for p in parts)
+
+
 # --- the sweep -------------------------------------------------------------------
 
 def test_every_entrypoint_actually_opens_a_run_bag() -> None:
@@ -166,6 +220,74 @@ def test_every_entrypoint_actually_opens_a_run_bag() -> None:
         f"about arguments and never could.\n"
         f"SCOPE OF THIS SWEEP: {ENTRYPOINTS_DIR.relative_to(REPO_ROOT)}/run_*.py "
         f"and nothing else. A run initiated from anywhere else is INVISIBLE here.")
+
+
+def test_bag_open_is_INSIDE_the_handler_that_prints_the_refusal() -> None:
+    """The placement half, which the sweep above only ever stated in prose.
+
+    A bag-open above the handler turns two operator-facing refusals — an
+    unusable `--run-id`, a full or misconfigured journal root — into tracebacks,
+    for precisely the failures whose whole design argument is that they must be
+    diagnosable WITHOUT a working journal. Measured on `run_plan.py`: one file of
+    eleven had drifted, and every other check in this module passed it.
+    """
+    offenders = _bag_open_outside_the_handler(ENTRYPOINTS_DIR)
+    assert not offenders, (
+        f"these bag-opens are not inside a `try` that catches `RuntimeError`: "
+        f"{offenders}.\n"
+        f"  failing property: `JournalRootError` and `BagError` both subclass "
+        f"`RuntimeError` so that ONE handler prints the remedy the layer that "
+        f"knew what failed wrote. Outside it, the operator gets a traceback for "
+        f"a misconfiguration.\n"
+        f"  remedy: move the boundary block inside the entrypoint's existing "
+        f"`except (RuntimeError, ...)` block — `print(f\"\\n\u2717 {{exc}}\", "
+        f"file=sys.stderr); return 1`.")
+
+
+def test_THE_PLACEMENT_PREDICATE_DISCRIMINATES(tmp_path: Path) -> None:
+    """CONTROLS on `_bag_open_outside_the_handler`, on a self-contained tree.
+
+    A SCRATCH DIRECTORY, NOT THE FLEET, and that is the point: a control sharing
+    a fixture with the code under mutation over-fires on things the assertion
+    would only have caught by accident. These four files are written here and
+    nowhere else, so each verdict is attributable to exactly one shape.
+    """
+    cases = {
+        "run_guarded.py":
+            "def main(a):\n"
+            "    try:\n"
+            "        journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    except (RuntimeError, FileNotFoundError):\n"
+            "        return 1\n",
+        "run_outside.py":
+            "def main(a):\n"
+            "    journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    try:\n"
+            "        work()\n"
+            "    except RuntimeError:\n"
+            "        return 1\n",
+        "run_wrong_exception.py":
+            "def main(a):\n"
+            "    try:\n"
+            "        journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    except ValueError:\n"
+            "        return 1\n",
+        "run_nested_guarded.py":
+            "def main(a):\n"
+            "    try:\n"
+            "        if a.x:\n"
+            "            journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    except RuntimeError:\n"
+            "        return 1\n",
+    }
+    for name, src in cases.items():
+        (tmp_path / name).write_text(src, encoding="utf-8")
+
+    found = {o.split(":")[0] for o in _bag_open_outside_the_handler(tmp_path)}
+    assert found == {"run_outside.py", "run_wrong_exception.py"}, (
+        f"the predicate reported {found}; it must flag the call above the handler "
+        f"and the one under a handler that cannot catch the refusal, and must not "
+        f"flag a correctly-guarded call or one nested inside the guarded block")
 
 
 def test_the_sweep_is_not_vacuous() -> None:

--- a/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
@@ -140,8 +140,30 @@ def _missing_bag_open(directory: Path) -> list[str]:
     return missing
 
 
+#: The calls that must sit inside the handler, not merely the bag-open. Both
+#: RAISE `RuntimeError` subclasses carrying an operator-facing remedy:
+#: `RunContext.build` resolves the journal root (`JournalRootError`) and calls
+#: `resolve_identity`, which refuses a malformed `--run-id` (`BagError`);
+#: `open_run_bag` refuses a full or unwritable journal.
+#:
+#: ⚠ `build` IS IN THIS SET BECAUSE THE GUARD WITHOUT IT WAS BLIND TO THE RAISE
+#: THAT MOTIVATED IT. Measured 2026-09-01 by mutation: hoisting `ctx =
+#: RunContext.build(...)` above the `try` in `run_plan.py` while leaving
+#: `open_run_bag` inside it left the whole unit tier green (3051 passed) — and a
+#: `JournalRootError` from the boundary then reaches the operator as a
+#: traceback, which is exactly the drift this guard was written after. The
+#: original guard checked the OLD raise's placement and not the NEW one's.
+_MUST_BE_GUARDED = (BAG_OPEN, "build")
+
+
 def _bag_open_outside_the_handler(directory: Path) -> list[str]:
-    """Entrypoints whose `open_run_bag` is not inside a `RuntimeError` handler.
+    """Entrypoints whose boundary calls are not inside a `RuntimeError` handler.
+
+    COVERS `RunContext.build` AS WELL AS `open_run_bag`, and that is not
+    generalisation for its own sake — see `_MUST_BE_GUARDED`. Both raise
+    `RuntimeError` subclasses whose whole design argument is that they must be
+    diagnosable WITHOUT a working journal, and a guard that watched only the
+    older of the two was measured blind to the newer one.
 
     ⚠ THE MESSAGE BELOW ALREADY DEMANDED THIS AND NOTHING CHECKED IT. The sweep
     above asks that the call EXISTS; its own failure text says *"inside the try
@@ -171,18 +193,20 @@ def _bag_open_outside_the_handler(directory: Path) -> list[str]:
                 continue
             for stmt in node.body:
                 for inner in ast.walk(stmt):
-                    if _is_bag_open(inner):
+                    if _is_boundary_call(inner):
                         guarded.add(inner.lineno)
-        every = {n.lineno for n in ast.walk(tree) if _is_bag_open(n)}
-        for line in sorted(every - guarded):
-            offenders.append(f"{path.name}:{line}")
+        every = {n.lineno: _callee(n) for n in ast.walk(tree) if _is_boundary_call(n)}
+        for line in sorted(set(every) - guarded):
+            offenders.append(f"{path.name}:{line} ({every[line]})")
     return offenders
 
 
-def _is_bag_open(node: ast.AST) -> bool:
-    return (isinstance(node, ast.Call)
-            and (getattr(node.func, "id", None) == BAG_OPEN
-                 or getattr(node.func, "attr", None) == BAG_OPEN))
+def _callee(node: ast.Call) -> str:
+    return getattr(node.func, "attr", None) or getattr(node.func, "id", "") or ""
+
+
+def _is_boundary_call(node: ast.AST) -> bool:
+    return isinstance(node, ast.Call) and _callee(node) in _MUST_BE_GUARDED
 
 
 def _names_runtime_error(handler: ast.ExceptHandler) -> bool:
@@ -233,8 +257,8 @@ def test_bag_open_is_INSIDE_the_handler_that_prints_the_refusal() -> None:
     """
     offenders = _bag_open_outside_the_handler(ENTRYPOINTS_DIR)
     assert not offenders, (
-        f"these bag-opens are not inside a `try` that catches `RuntimeError`: "
-        f"{offenders}.\n"
+        f"these boundary calls are not inside a `try` that catches "
+        f"`RuntimeError`: {offenders}.\n"
         f"  failing property: `JournalRootError` and `BagError` both subclass "
         f"`RuntimeError` so that ONE handler prints the remedy the layer that "
         f"knew what failed wrote. Outside it, the operator gets a traceback for "
@@ -279,15 +303,35 @@ def test_THE_PLACEMENT_PREDICATE_DISCRIMINATES(tmp_path: Path) -> None:
             "            journal.open_run_bag(run_id=ctx.run_id)\n"
             "    except RuntimeError:\n"
             "        return 1\n",
+        # ⚠ THE SHAPE THE PREDICATE WAS BLIND TO UNTIL 2026-09-01: the context is
+        # built above the handler while the bag-open sits correctly inside it, so
+        # the journal-root refusal the boundary raises escapes as a traceback.
+        "run_context_hoisted.py":
+            "def main(a):\n"
+            "    ctx = RunContext.build(identity=i, repo_root=r, workflow_key='k')\n"
+            "    try:\n"
+            "        journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    except RuntimeError:\n"
+            "        return 1\n",
+        "run_both_guarded.py":
+            "def main(a):\n"
+            "    try:\n"
+            "        ctx = RunContext.build(identity=i, repo_root=r, workflow_key='k')\n"
+            "        journal.open_run_bag(run_id=ctx.run_id)\n"
+            "    except RuntimeError:\n"
+            "        return 1\n",
     }
     for name, src in cases.items():
         (tmp_path / name).write_text(src, encoding="utf-8")
 
     found = {o.split(":")[0] for o in _bag_open_outside_the_handler(tmp_path)}
-    assert found == {"run_outside.py", "run_wrong_exception.py"}, (
-        f"the predicate reported {found}; it must flag the call above the handler "
-        f"and the one under a handler that cannot catch the refusal, and must not "
-        f"flag a correctly-guarded call or one nested inside the guarded block")
+    assert found == {"run_outside.py", "run_wrong_exception.py",
+                     "run_context_hoisted.py"}, (
+        f"the predicate reported {found}; it must flag the call above the handler, "
+        f"the one under a handler that cannot catch the refusal, and a CONTEXT "
+        f"BUILT above the handler even when the bag-open below it is correct — "
+        f"and must not flag a correctly-guarded call, one nested inside the "
+        f"guarded block, or a file where both boundary calls are guarded")
 
 
 def test_the_sweep_is_not_vacuous() -> None:

--- a/scripts/workflows/temporal/tests/unit/test_exit_record.py
+++ b/scripts/workflows/temporal/tests/unit/test_exit_record.py
@@ -599,7 +599,8 @@ def _review(monkeypatch, tmp_path, record, prose, denials=None,
     from modules.assistant.review_pr.review_pr_helper import ReviewInput
     fake = _FakeWorkflow(record, prose, denials, block, prior_blocks, posts_block)
     wf = fake.install(monkeypatch, tmp_path)
-    return wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    return wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
 
 def test_both_channels_agreeing_routes_and_records_the_agreement(monkeypatch, tmp_path) -> None:
@@ -633,7 +634,8 @@ def test_the_log_is_NAMED_with_the_nonce_the_parent_issued(monkeypatch, tmp_path
         return tmp_path / "run.jsonl"
 
     monkeypatch.setattr(wf._shared, "claude_log_path", _alloc)
-    wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     # A LOCAL SPY DICT, NOT A WIRE RECORD, so its key follows the parameter name
     # rather than the archived field: `claude_log_path` takes `invocation_id`
@@ -900,7 +902,8 @@ def test_a_MALFORMED_gh_REPLY_degrades_like_any_other_blip(
     monkeypatch.setattr(act, "thread_snapshot", real_reader)
     monkeypatch.setattr(act._shared, "gh", lambda *a, **k: "<html>502 Bad Gateway</html>")
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert result.verdict is routing.Verdict.MERGE, (
         "a malformed reply killed the run — it took the pre-fix path, where the "
@@ -932,7 +935,8 @@ def test_a_transient_thread_read_is_retried_and_the_review_survives(
     monkeypatch.setattr(act, "thread_snapshot",
                         _flaky_reader(1, lambda *a, **k: (1, [fake.block])))
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert result.verdict is routing.Verdict.MERGE
     assert slept, "the read was not retried — it failed on the first attempt"
@@ -964,7 +968,8 @@ def test_a_PERSISTENT_thread_read_failure_completes_the_run_and_says_so(
 
     monkeypatch.setattr(act, "thread_snapshot", _boom)
 
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert result.verdict is routing.Verdict.MERGE, (
         "a failed READ changed the routing — the policy question was supposed "
@@ -995,7 +1000,8 @@ def test_the_route_is_PERSISTED_even_when_the_check_never_runs(
     _no_sleep(monkeypatch)
     monkeypatch.setattr(act, "thread_snapshot", _flaky_reader(99, lambda *a, **k: (0, [])))
 
-    wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     events = [json.loads(line) for line in
               (tmp_path / "run.jsonl").read_text().splitlines() if line.strip()]
@@ -1024,7 +1030,8 @@ def test_a_REAL_disagreement_still_raises_after_a_transient_read(
                         _flaky_reader(1, lambda *a, **k: (1, [wrong])))
 
     with pytest.raises(RuntimeError, match="disagree on findings"):
-        wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+        wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
 
 def test_the_invariant_is_not_run_when_there_was_no_record_to_compare(
@@ -2233,7 +2240,8 @@ def test_a_later_foreign_block_does_NOT_become_this_passs_block(monkeypatch, tmp
     fake = _FakeWorkflow(_record(run_id="@ISSUED@"), "VERDICT: MERGE\n",
                          block_carries_nonce=True, after_blocks=(foreign,))
     wf = fake.install(monkeypatch, tmp_path)
-    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+    result = wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert result.verdict is routing.Verdict.MERGE
     assert not any("selected BY POSITION" in n for n in result.notes), (
@@ -2259,7 +2267,8 @@ def test_the_SAME_fixture_fails_when_the_nonce_is_not_echoed(monkeypatch, tmp_pa
                          block_carries_nonce=False, after_blocks=(foreign,))
     wf = fake.install(monkeypatch, tmp_path)
     with pytest.raises(RuntimeError, match="disagree on findings"):
-        wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+        wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
 
 
@@ -2360,7 +2369,8 @@ def test_the_pair_is_RECORDED_when_the_completion_gate_kills_the_run(monkeypatch
     monkeypatch.setattr(act, "run_disposition", _gate_fails)
 
     with pytest.raises(RuntimeError, match="completion pattern not found"):
-        wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+        wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
     assert rows, (
         "the run died and NOTHING was recorded — this is exactly C-45bhs5cm: the pair "
@@ -2397,7 +2407,8 @@ def test_the_completion_gate_still_FAILS_the_run(monkeypatch, tmp_path):
     monkeypatch.setattr(act, "run_disposition", _boom)
 
     with pytest.raises(RuntimeError, match="the original failure, verbatim"):
-        wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+        wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")
 
 
 def test_an_UNREADABLE_log_does_not_stack_a_second_failure(monkeypatch, tmp_path):
@@ -2424,4 +2435,5 @@ def test_an_UNREADABLE_log_does_not_stack_a_second_failure(monkeypatch, tmp_path
     monkeypatch.setattr(act, "run_disposition", _boom)
 
     with pytest.raises(RuntimeError, match="the original failure"):
-        wf.run_review(ReviewInput(pr_number="67"), tmp_path)
+        wf.run_review(ReviewInput(pr_number="67"), tmp_path,
+                          worktree_name="review-pr-1")

--- a/scripts/workflows/temporal/tests/unit/test_plan_project_loop.py
+++ b/scripts/workflows/temporal/tests/unit/test_plan_project_loop.py
@@ -123,7 +123,8 @@ def wired(monkeypatch: pytest.MonkeyPatch) -> _Calls:
 
 def _verdicts(monkeypatch: pytest.MonkeyPatch, calls: _Calls, *sequence: routing.Verdict) -> None:
     """Make review-pr return each verdict in turn, then repeat the last."""
-    def fake_review(review_input: object, repo_root: Path) -> ReviewResult:
+    def fake_review(review_input: object, repo_root: Path, *,
+                    worktree_name: str) -> ReviewResult:
         v = sequence[min(calls.review, len(sequence) - 1)]
         calls.review += 1
         return ReviewResult(pr_number="43", verdict=v, this_pass=calls.review, notes=[])
@@ -427,7 +428,8 @@ def test_the_parent_judges_against_PLANNING_criteria(wired: _Calls, monkeypatch:
     """
     seen: list[object] = []
 
-    def capture(review_input: object, repo_root: Path) -> ReviewResult:
+    def capture(review_input: object, repo_root: Path, *,
+                worktree_name: str) -> ReviewResult:
         seen.append(review_input.review_type)
         return ReviewResult(pr_number="43", verdict=routing.Verdict.MERGE, this_pass=1, notes=[])
 
@@ -457,9 +459,10 @@ def test_isolation_is_established_once_by_the_parent(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(pm, "wait_for_ci", lambda pr, **kw: True)
     monkeypatch.setattr(pm, "ci_verdict", lambda pr, **kw: (routing.CiVerdict.GREEN, []))
     monkeypatch.setattr(pm.review_pr, "run_review",
-                        lambda ri, rr: ReviewResult(pr_number="43",
-                                                    verdict=routing.Verdict.HOLD_REDISPATCH,
-                                                    this_pass=1, notes=[]))
+                        lambda ri, rr, *, worktree_name: ReviewResult(
+                            pr_number="43",
+                            verdict=routing.Verdict.HOLD_REDISPATCH,
+                            this_pass=1, notes=[]))
     _run()
     assert added == ["wt"], f"expected exactly one worktree, got {added}"
 

--- a/scripts/workflows/temporal/tests/unit/test_prompt_completeness.py
+++ b/scripts/workflows/temporal/tests/unit/test_prompt_completeness.py
@@ -283,4 +283,6 @@ def test_the_review_pr_dry_run_renders_the_real_prompt(monkeypatch, tmp_path) ->
         "headRefName": "build/x", "state": "OPEN", "title": "t"})
     monkeypatch.setattr(kickoff.act, "count_prior_passes", lambda *a, **k: 0)
 
-    assert kickoff._dry_run(ReviewInput(pr_number="31"), tmp_path) == 0
+    ctx = kickoff.RunContext.for_dry_run(repo_root=tmp_path,
+                                        workflow_key="review-pr", pr_number="31")
+    assert kickoff._dry_run(ReviewInput(pr_number="31"), tmp_path, ctx) == 0

--- a/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
@@ -174,7 +174,7 @@ def test_the_population_this_sweeps_MATCHES_THE_TREE() -> None:
     journal root, then update this number.
     """
     modules = _entrypoint_driving_modules()
-    assert len(modules) == 5, (
+    assert len(modules) == 6, (
         f"{len(modules)} test module(s) under {UNIT_DIR} drive an entrypoint "
         f"`main()`; it was 5 when this was pinned. Found: "
         f"{[m.name for m in modules]}.\n"


### PR DESCRIPTION
Implements [Workflow Decomposition Phase 4 — *Nothing a run relies on is invisible*](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/development/edge-assistant/workflow-decomposition/phase4_nothing_invisible.md), derived half.

## Summary

A wrong flag fails loudly at parse time. A wrong **derivation** produces a plausible wrong run — the workflow competently plans the wrong component, opens a real pull request, and nothing goes red. This closes that class, not by auditing derivations but by making the question smaller: a run has **one** place its derived values come from, that place is built once at the dispatch boundary, and the run says what it built before it spends anything.

- **`scripts/workflows/temporal/scripts/dispatch_context.py`** — a frozen `RunContext` extending `RunIdentity`, carrying the repo root, journal root, workflow key, worktree name, PR number and target alongside the three identity fields. Every field carries `field(metadata=derivation(marker=…, algorithm=…, override=…, scope=…))`, and `dataclasses.fields()` is the population that holds that honest.
- **The worktree name is derived once**, in `RunContext._worktree_name`, as `f"{workflow_key}-{int(clock())}"` — **one expression reached by both constructors**, which the refine pass made true (it was written twice). Eleven `worktree_add` call sites now receive the name instead of assembling it.
- **`run_build_minor` is renamed, deliberately.** Its `workflow_key` was `build-minor` while it named its trees `build-<ts>`, so its worktrees were indistinguishable on disk from the `build` parent's — which is exactly what `/cleanup-merged-worktrees` and the journal's `Journal-Worktree` field use to tell one run from another. Trees are now `build-minor-<ts>`.
- **`review_pr` is reconciled.** `run_review_pr.py` recorded `worktree_name=None` with the comment *"the ONE workflow that cuts no worktree"* while `review_pr_workflow` cut one through the same `worktree_add` whose docstring opens *"ISOLATION IS AN INVARIANT, NOT A PARAMETER"*. The bag now records the stem the tree is named from.
- **The journal root is resolved at the boundary** and passed into `open_run_bag`, which retains its own resolution for callers with no context (`validate_bag`, the tests).
- **`ctx.echo()`** states the context on stderr before the bag opens, the worktree is cut, `gh` runs or the model is invoked.

## Deviation summary — planned vs built

| Planned | Built | Note |
|---|---|---|
| r1 frozen context extending `RunIdentity`, ≥9 fields | ✅ as planned | 6 new + 3 inherited |
| Field **docstring** naming marker / algorithm / override / scope | ⚠️ **`field(metadata=derivation(...))` instead** | **Argued deviation, not silent.** Python has no field docstrings — the nearest convention is a `#:` comment the interpreter discards — so a check asserting *four named parts* would have to parse them back out of one prose blob, making the check's population the parser's guesses rather than the four parts. Metadata keeps the statement at the field where a reader meets it and makes each part separately addressable. The population (`dataclasses.fields()`) is unchanged. Reasoned in `derivation()`'s own docstring. |
| r2 check keyed on `worktree_add`'s call sites | ✅ as planned | Matched on the callee's **name**, so `_shared.worktree_add` is as visible as `act.worktree_add` |
| r3 echo gated on **constructed-here** | ⚠️ **gated on `is_the_run`, not on `minted`** | The plan named `minted` as the discriminator. `minted` is **False** for an operator retrying with `--run-id X` — a parent, constructing its own context, and the caller who most needs to see what the retry derived. `writer` is the field that answers *did I build this context or was I handed one*. Corrected with a test that names the reason. |
| r4 dry-run and live print the same object | ✅ as planned | One `render()`; an AST sweep holds every `--dry-run` branch to using it |
| r5 wrong derivation demonstrated | ✅ as planned | Live path, real repo, verbatim transcript |
| r6 field-documentation check over `dataclasses.fields()` | ✅ as planned | Plus a floor keeping `scope`/`algorithm` from degenerating into noun phrases |
| Worktree name from the workflow key at every `worktree_add` | ⚠️ **the per-pass review tree is NOT a context field** | A parent calls `run_review` once per loop-back, each pass cutting its own tree on the PR's branch. By the plan's own test (*run-scoped, derived once at the boundary*) that value is excluded, the same way `paper_currency` and `due_papers` are. `run_review` now **receives** the stem and appends `-review-<pr>-<pass>`; the check's property is *received, never assembled*, which covers both shapes without an exemption list. **Hardened in the refine pass** — as first built the property admitted a parameter *rebound* on the next line and a received stem plus a fresh clock; both were measured passing and both now fail. |

**Plan facts that did not survive verification** (reported, then built on what is true): the evidence table names `run_plan_verify.py:321`, which **does not exist** — the real site is `run_plan_refine.py:360` — and `run_plan_sprint.py` had moved from `:98` to `:137`. The **total of eleven is unchanged**; the membership had drifted again, inside a week, which is that section's own thesis landing on it for the third time. The `worktree_add` call-site count (eleven plus the definition) verified exactly, as did the `_shared.` alias claim and `test_isolation_invariants._classify`'s blindness to it.

## Review findings

### Draft pass — addressed at authoring time

- **[Critical] `run_plan.py`'s boundary block sat outside the handler.** `resolve_identity`'s refusal of a bad `--run-id` and `open_run_bag`'s refusal of a full journal — both `RuntimeError`s carrying operator-facing remedies — reached the operator as a traceback in this one file of eleven and as a one-line diagnostic in the other ten. Pre-existing on `main`; resolving the journal root at the boundary added a **third** raise to the unguarded region. **Fixed**, and the guard that should have caught it now checks placement rather than only presence.
- **[Warning] The review tree lost the PR number.** The stem is `<workflow-key>-<ts>`, so two `review-pr` dispatches aimed at different PRs starting in the same wall-clock second would have shared a directory on their first pass. **Fixed** — `f"{worktree_name}-review-{task.pr_number}-{this_pass}"`, with three collision tests that read the f-string out of the module rather than retyping it.
- **[Warning, standards] The transcript and checkboxes belong in the phase doc.** **Delivered** as helloskyy-io/skyynet-master-planning#4.

### Refine pass — six defects, each confirmed by mutation BEFORE it was fixed

**Rigour tier: safety control.** Six mutations to establish the defects, six negative controls after; predicted red counts stated first, **all twelve exact**.

- **[Critical — `code-reviewer` and `quality-control`, independently] The worktree name was derived TWICE, inside the object built to end exactly that.** `RunContext.build` and `.for_dry_run` each carried `f"{workflow_key}-{int(clock())}"`, and **every** worktree-name assertion in the suite drove the rehearsal — nothing in the tree called `RunContext.build` at all. **Measured: perturbing the LIVE copy alone left 3051 tests green** while a `--dry-run` previewed a name no run would use. That is requirement 4's own defect (a rule with two statements that agree until one is edited) reproduced one level inside requirement 4's fix, and the same shape as `run_build_minor` naming its trees `build-…` under `workflow_key="build-minor"`. **Fixed:** one `RunContext._worktree_name`, and `test_the_REHEARSAL_and_the_LIVE_run_render_THE_SAME_OBJECT` now drives `build` against `for_dry_run` on a pinned clock and compares **fields** as well as renderings — it previously constructed its comparison object from the rehearsal's own field values and could not fail. *Control: re-splitting the expression → predicted 5 red, observed 5.*
- **[Critical — `quality-control`] The `target` field named FOUR targetless workflows; `plan-revision` is a fifth.** A false statement in the one object whose stated purpose is that its fields state themselves — and it is exactly the failure its own guard admits it cannot catch (*"asserts each part is PRESENT, never that it is TRUE"*). **Fixed.**
- **[Warning — `code-reviewer`] The placement guard watched the OLD raise and not the one this PR added.** `_bag_open_outside_the_handler` keyed on `open_run_bag` only, while `run_plan.py`'s own comment says resolving the journal root at the boundary *"added a THIRD raise to the unguarded region"*. **Measured: hoisting `ctx = RunContext.build(...)` above the `try` while leaving `open_run_bag` inside it left the whole tier green** — a `JournalRootError` then reaches the operator as a traceback, which is the regression the guard was written after. **Fixed:** `_MUST_BE_GUARDED = (BAG_OPEN, "build")`, with two new control shapes. *Control: predicted 1 red, observed 1.*
- **[Warning — `code-reviewer`] Requirement 3's ordering was held on ONE entrypoint of eleven.** The entrypoint sweep collected call *names* anywhere in the file. **Measured green:** moving `ctx.echo()` below `open_run_bag`; and `if a.verbose: ctx.echo()`, which the requirement rules out in terms. Only `run_plan_draft` was protected, by the live demonstration. **Fixed:** `test_every_entrypoint_SAYS_IT_BEFORE_THE_BAG_OPENS_and_UNCONDITIONALLY`, with literal-driven controls including the one that must NOT fire — a `--dry-run` early return above the echo is not a gate on it. The `--dry-run` sweep likewise now requires the `for_dry_run` call to sit **inside** the rehearsal branch. *Controls: predicted 1 red each, observed 1 each.*
- **[Warning — `code-reviewer`, confirmed by probing the predicate] The r2 guard admitted two shapes its own property forbids.** A `worktree_name` **parameter rebound on the next line** passed — the half-migration shape (signature converted, body not), at the site the guard's docstring calls *"the one this guard most needs to see"*. And `f"{worktree_name}-{int(time.time())}"` passed — a re-scatter wearing a suffix, referencing a received parameter. **Fixed:** a name leaves `received` the moment anything in the function binds it, and a clock read at the call site is assembly whatever else the argument references. Four new controls. *Control: predicted 1 red, observed 1.*
- **[Warning — both] Prose that was false against the tree, swept as a class rather than at the site reported.**
  - `render()`'s header said *"before anything is created"* while `build()` had just `mkdir`'d the journal root at 0700. Reworded to *"before this run cuts, posts or spends"*, with the reason at the line.
  - Ten entrypoints carried *"BEFORE THE BAG OPENS, THE WORKTREE IS CUT OR ANY `gh` CALL RUNS"*. **Swept all eleven by AST, scoped to `main()`: the claim is false in three** — `run_plan_revision` (`base_ref`), `run_plan_refine` and `run_plan_sprint` (`unclosed_hold`, `pr_branch`). Those reads are **refusals** and correctly precede the bag, so the three comments now say what is true rather than the code being shuffled to match a comment.
  - `docs/file_structure.txt` said *"a local assignment is not received, which is what all eleven sites were"* — while the entry three rows below says the 11th was inline. Corrected; that belief is what shipped `base_ref`'s first guard green.
  - `docs/file_structure.txt` said *five* test modules drive an entrypoint `main()` in two places. **This PR made it six** and bumped the pin without sweeping its own blast radius.
- **[Warning — `code-reviewer`] Two vacuity floors sat below their real populations** — `>= 10` against eleven `worktree_add` calls, `>= 6` against nine context fields, the latter with a message insisting on nine. Both raised; the field count is now one named constant so message and assertion cannot disagree.
- **[Warning — `quality-control`] The census pin moved 33→35 / 22→24 with none of the narration every prior bump in that file carries.** Added.
- **[Info — `code-reviewer`] `context_field_documentation()` was dead code** arguing for a population nobody read. **Fixed by giving it its one caller** — the r6 guard now obtains the population through it, so the argument in its docstring is load-bearing. *Control: making it drop a field → predicted 1 red, observed 1.*
- **[Info — `code-reviewer`] `open_run_bag` silently voids `config_path`/`env` when `journal_root` is supplied.** No caller does this today. **Documented rather than guarded** — a guard for a combination nobody writes is speculation; a silent precedence nobody documented is how a redirected test asserts against the wrong root and passes.
- **[Info — `code-reviewer`] `env`/`clock` untyped, and `derivation()` lives in the identity module.** Types added (`Clock` is now named); a pointer added at the import site.
- **[Info — `code-reviewer`] `_review_tree_name` failed with a bare `ValueError` from `str.index`** if the call it scrapes were reformatted. Now a readable assertion naming the file and forbidding the obvious wrong fix (retyping the template).

**Rejected with reasoning:**

- **[High, structure — `code-reviewer`] Collapse the eleven hand-copied boundary blocks into `open_run_bag(ctx=ctx)`.** Real, and it is the *surfaced candidate below* rather than a rejection of the substance. Not done **here** because it changes all eleven entrypoints' control flow and the six-keyword forwarding is only the visible half — the sequence, the handler placement and the comment are the rest. That is a scope this phase names as out (*"it does not add a new derived value; this phase gives them one home and one voice"*). **What changed in this pass is that the drift is now caught**: the placement guard covers both boundary calls, and the ordering guard covers the echo.
- **[High, structure — `code-reviewer`] Reclassify `review_pr_workflow` as a parent in `test_isolation_invariants`.** Real and surfaced below as a defect. Not fixed here because reclassifying applies a **different set of parametrised invariants** to that module — a behaviour change to an existing guard, in a file this PR does not otherwise touch.
- **[Medium — `code-reviewer`] Extract `_per_pass_tree_name` into `review_pr_workflow` so the test need not scrape the f-string.** The brittleness was real and is fixed at its actual cost (a readable failure). Adding an indirection to production code purely so a test can import it moves the second statement of the rule rather than removing it — and the scraping is what makes the test *derived* rather than a copy, which is this phase's own thesis.
- **[Note] The bag records a stem, not the exact directory.** `Journal-Worktree` is `review-pr-<ts>` while the tree is `review-pr-<ts>-review-<pr>-<pass>`. Deliberate: the pass number is not knowable at bag-open (it costs a `gh` round trip) and the bag opens before the first side effect. **The refine pass carried out the disposition** — the stem-vs-path relationship is now stated in `open_run_bag`'s own docstring, where a consumer meets the field, rather than only at the two call sites.
- **[Low] `review-pr-<ts>-review-<pr>-<pass>` says "review" twice.** Cosmetic; for every other workflow the stem is the workflow key and the name reads correctly.

**Surfaced, not filed — for `review-pr` to route:**

> ### A dispatch boundary helper would close the drift class structurally — EXPANSION of `C-8tv8ewto`
>
> **This is an EXPANSION of an existing candidate, not a new one, and the draft pass surfaced it without that pointer.** [`tracked/candidates/C-8tv8ewto.md`](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/tracked/candidates/C-8tv8ewto.md) already covers the eleven runners' byte-identical `try/except RuntimeError → print(f"\n✗ {exc}") → return 1` block, with `parse_or_exit(parser, argv)` in `preflight.py` as its remedy; issue #149 is its open recurrence intake, measuring the population at ten as of 2026-08-28. **Verified:** `cat /opt/skyy-net/skyynet-master-planning/tracked/candidates/C-8tv8ewto.md` → `status: open`, `count: 1`, `component: workflow-decomposition`; `gh issue view 149` → OPEN.
>
> **What this PR adds to it:** the same eleven files now also hand-copy a *build context → echo → open bag* sequence **inside** that handler, and the two are one refactor rather than two — a `dispatch_boundary(argv, repo_root, workflow_key, …)` context manager subsumes `parse_or_exit`. **The population grew again in this PR**, which is the recurrence signal `C-8tv8ewto`'s own count exists to carry.
>
> **Harvest action:** append this to `C-8tv8ewto` as a recurrence with the widened remedy. **Do not open a second candidate.** `decision` stays blank — that is `triage-candidates`' output. **Component:** `workflow-decomposition`.

> ### The standards amendment this phase owes `workflow-scripts.md`
>
> **Consequence:** the rule this PR implements is now enforced only by per-value checks. Nothing states it, so the next run-scoped derived value scatters before anyone notices the pattern is already ruled on.
>
> **Remedy:** amend [`workflow-scripts.md`](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/standards/workflow-scripts.md) § *9. Repo Root Operation* — the section that today governs the one derivation this fleet already rules on — with: *a run-scoped derived value is a field on the run context, computed once at the dispatch boundary and passed down; it is not re-derived by a callee.* It also finishes a sentence [`guide/workflows.md`](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/guide/workflows.md) already starts — *"Isolation is established once by the parent and passed down"* — which is this rule stated for one value.
>
> **Store:** `tracked/standards/`. **Surfaced rather than filed** per [`finding-routing.md` §7](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/standards/finding-routing.md): a build dispatch is a producing run, and the phase doc says so in terms — *"Surface it, do not file it, and never edit the standard."*

> ### `test_isolation_invariants._classify` misclassifies `review_pr_workflow`
>
> **Consequence:** `_classify()` keys on the literal `"act.worktree_add("`, and `review_pr_workflow` reaches the function as `_shared.worktree_add`. It is classified a **child** while it cuts a worktree, so `test_child_does_not_create_its_own_worktree` asserts it cuts none — a green assertion that is actively false. The same literal is reused at `test_every_parent_opens_a_run_bag.py:636` and `:684` and at `test_isolation_invariants.py:134`, deliberately, so the miss is shared rather than isolated. *(Line numbers re-derived against this branch's HEAD; the draft pass's `470`/`513` were correct when written and moved when this pass extended the file.)*
>
> **Remedy:** key those predicates on the callee's AST name, the way this PR's two new guards do.
>
> **Store:** `tracked/issues/` — a **defect** in something already built. **Not fixed here** because reclassifying `review_pr_workflow` as a parent applies a different set of invariants to it, which is a behaviour change to an existing guard and outside this phase's scope. **Component:** `workflow-decomposition`.

## Test results

`./testing/run-all.sh` → **RESULT: PASSED** (`python/unit` PASS, `python/integration` PASS, `python/e2e` SKIP — no `tests/e2e` in the tree). Unit tier: **4256 passed, 8 skipped, 0 failed**; integration **95 passed**. The draft pass measured 3151 in the temporal component alone; the tier total moved because the corpus gates now collect against the sibling planning repo.

**The twelve mutations, predicted before each run and all twelve exact.** Six established the defects above; six are negative controls on what replaced them.

| # | Mutation | Predicted | Observed |
|---|---|---|---|
| 1 | Perturb `build()`'s worktree derivation only (the duplicated expression) | 0 — the defect | **0** |
| 2 | Hoist `RunContext.build` above the `try` in `run_plan.py` | 0 — the defect | **0** |
| 3 | Move `ctx.echo()` below `open_run_bag` in `run_plan.py` | 0 — the defect | **0** |
| 4 | Rebind `worktree_name` inside `run_review` (half-migration) | 0 — the defect | **0** |
| 5 | `f"{worktree_name}-{int(time.time())}"` at a call site | detector silent — the defect | **silent** |
| 6 | `if a.verbose: ctx.echo()` | 0 — the defect | **0** |
| 7 | Re-split the derivation after the fix | 5 | **5** |
| 8 | Hoist `RunContext.build` after the fix | 1 | **1** |
| 9 | Move `ctx.echo()` below bag-open after the fix | 1 | **1** |
| 10 | Rebind `worktree_name` after the fix | 1 | **1** |
| 11 | `context_field_documentation()` drops a field | 1 | **1** |
| 12 | `if a.verbose: ctx.echo()` after the fix | 1 | **1** |

**And the r5 demonstration was reproduced independently**, not read off the diff: a scratch repo with `RIGHT`/`WRONG` components, `run_plan_draft.main(["development/edge-assistant/WRONG", "--repo", …])` on the live path with `open_run_bag` replaced by a raise. The echo named `target : development/edge-assistant/WRONG` before the stand-in fired, and `.claude/worktrees/` did not exist afterwards.

**Coverage.** One new source artifact with logic — `dispatch_context.py` — with four corresponding test modules, all in `scripts/workflows/temporal/tests/unit/` per the Testing Standard's tier layout, all pytest:

| New / changed source | Test |
|---|---|
| `dispatch_context.py` (behaviour, both constructors) | `test_dispatch_context.py` — 31 tests |
| `dispatch_context.py` (field documentation, r6) | `test_every_context_FIELD_STATES_ITSELF.py` |
| The eleven call sites (r2) | `test_a_worktree_NAME_comes_from_the_RUN_CONTEXT.py` |
| The echo on the live path (r5) | `test_a_WRONG_TARGET_is_NAMED_before_the_run_costs_anything.py` |
| `run_plan.py`'s handler placement, and `RunContext.build`'s | `test_every_parent_opens_a_run_bag.py` (extended, with its own controls) |

**Three census guards went red on the new modules and were updated, not silenced** — `_PINNED` (33, 22) → (35, 24), now with the narration every prior bump in that file carries; the entrypoint-driving-module pin 5 → 6, **and its two stale restatements in `docs/file_structure.txt`**; and one prose figure reworded, because it stated a count the journal sweep reads as a claim about the *entrypoint* population.

## Success criteria

- [x] **r1** — A frozen run context exists, constructed once at the dispatch boundary, extending `RunIdentity`, carrying nine fields
- [x] **r2** — No entrypoint and no workflow module assembles a run-scoped derived value for itself, held by a check keyed on the call site, matched on the function name, and blind to neither a rebound parameter nor a clock
- [x] **r3** — A run states its context once, on the live path, before the first side effect, gated on constructed-here — **and the ordering and the gating are now held across all eleven entrypoints rather than one**
- [x] **r4** — The `--dry-run` preview and the live run print the same object, from **one** derivation, with the live constructor in the tested population
- [x] **r5** — A wrong derivation is demonstrated visible, verbatim, on the live path — reproduced independently in the refine pass
- [x] **r6** — Every field states its marker, algorithm, override and scope of effect, with `dataclasses.fields()` as the population, reached through the module's own accessor
- [x] The full suite passes and nothing that depended on the quiet path or on a worktree name's spelling broke
- [x] **The three departures from the requirements' wording are recorded where a planner reads them** — helloskyy-io/skyynet-master-planning#4
- [ ] **The standards amendment against `workflow-scripts.md` § 9** — surfaced above, not filed. The phase doc rules that a producing run surfaces and `review-pr` files, so this is deliberately open rather than met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
