### PR TITLE
build-draft: the content store, and a citation you can re-check with the network off

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -286,6 +286,10 @@ claude-dot-files/
 │               │                                    #   a corpus that is no longer in this repo, and a copy per
 │               │                                    #   module is 17 chances to point at a stale path
 │               ├── integration/                    # Runs against what the FLEET actually wrote, not against a constructed fixture
+│               │   ├── conftest.py                  # The `journal_root` fixture, at the package's own DIR_MODE rather than a bare 0o700
+│               │   │                                #   literal. tests/unit/conftest.py is not reachable from here — pytest resolves
+│               │   │                                #   conftest by directory — so this is the sibling copy, and it exists because the
+│               │   │                                #   same four lines had already been retyped three times in one file
 │               │   ├── test_a_real_bag_validates.py # Every journal bag on THIS machine still validates. Skips — distinctly from passing —
 │               │   │                                #   where no dispatch has run, because a clone has no journal and there is nothing
 │               │   │                                #   honest to assert about that. Does NOT substitute for the entrypoint sweep: a fleet

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -800,6 +800,14 @@ claude-dot-files/
 │   │                                                #   nobody has written yet. The coupling breaks at collection, which mutate.sh cannot read.
 │   │                                                #   TWO checks since PR #96: the import-statement one, and a second reading CALL ARGUMENTS,
 │   │                                                #   because a path LOAD emits no ast.Import node and slipped past the first one unseen
+│   │       ├── test_a_guard_RESOLVES_the_module_it_MATCHES.py # No AST guard recognises a module by its BARE NAME — repo-wide. A matcher
+│   │       │                                        #   keyed on `node.func.value.id == "re"` is evaded by `import re as _r`, and the
+│   │       │                                        #   evaded call is ABSENT from the guard's population rather than reported by it,
+│   │       │                                        #   which is the colour of a clean tree. RESOLVE the imports or REFUSE the aliased
+│   │       │                                        #   spelling; being neither is the finding. Keyed on the class after the identical
+│   │       │                                        #   defect hit four guards in four components — including one written to end the
+│   │       │                                        #   very class it then had (`test_journal_regex_anchors.py`, blind to an aliased
+│   │       │                                        #   `re`, with its own compensating honesty test blind the same way)
 │   │       ├── test_measurement_figures_are_cited.py # A figure with a denominator lives ONLY where the measurement is taken; every other
 │   │       │                                        #   mention cites it. Keyed on the class after fix-the-instances was MEASURED
 │   │       │                                        #   non-convergent over four passes on one PR — see tracked/candidates/ C-523klr8n

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -238,8 +238,7 @@ claude-dot-files/
 │           │                                        #   which are NOT kickoffs: they are what a run checks before, what an operator checks
 │           │                                        #   after (validate_bag asks whether a bag's bytes match its manifest; verify_citations
 │           │                                        #   asks whether the claims in it still stand against the sources they were made from),
-│           │                                        #   who
-│           │                                        #   NAMES the run, and what the run DERIVED. All four live here because they are
+│           │                                        #   who NAMES the run, and what the run DERIVED. All five live here because they are
 │           │                                        #   launch concerns rather than workflow concerns. None is named run_*.py, and that
 │           │                                        #   is load-bearing — the entrypoint sweeps glob that prefix, so a helper wearing it
 │           │                                        #   is swept as a runner and fails five guards at once (measured 2026-09-01)
@@ -630,6 +629,17 @@ claude-dot-files/
 │                   │                                #   declares why it cannot escape — so ADDING a join is what fails. The battery beside it
 │                   │                                #   catches the other half: reverting a guard leaves the declaration standing and true of
 │                   │                                #   nothing, which the sweep alone reads as covered
+│                   ├── test_journal_regex_anchors.py # The ANCHOR spelling of the same class-check shape: `$` matches before a TRAILING
+│                   │                                #   newline, so `re.compile(r"^…$")` is an anchored-LOOKING validator that admits one.
+│                   │                                #   Two instances — the digest gate that IS r7(b)'s path safety, then _LABEL_RE, still
+│                   │                                #   unconverted at the commit that published the sweep as exhaustive. Sweeps every
+│                   │                                #   re.compile in the package; a pattern it cannot READ fails separately, which is how
+│                   │                                #   the %-formatted digest gate was found invisible to the sweep's own first draft
+│                   ├── test_journal_operator_tools_separate_typo_from_finding.py # A target the operator MISTYPED must not be
+│                   │                                #   reported as a bag that failed. verify.main was fixed for this; validate.main did the
+│                   │                                #   mirror image and was left standing, printing result: FAIL with lifecycle, redacted
+│                   │                                #   and a payload size asserted about a bag that does not exist. Population DERIVED —
+│                   │                                #   every scripts/*.py importing validate or verify — so a third tool inherits the rule
 │                   ├── journal_entrypoint_facts.py  # WHAT THE ENTRYPOINT POPULATION IS, discovered once for the guards that ask — the
 │                   │                                #   bag-open sweep, the prose-figure guard and the run-id sweep. A helper and not a
 │                   │                                #   shared test module because test_test_tree_hygiene refuses test-imports-test; two

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -222,9 +222,23 @@ claude-dot-files/
 │           │                                        #   the activity every entrypoint invokes before its first side effect. Nothing writes
 │           │                                        #   a run's CONTENT here — that is Phase 3. Imports no workflow module, so a
 │           │                                        #   measurement helper can load it without dragging in temporalio
+│           │                                        #   PHASE 2 ADDS THE CONTENT STORE here rather than as a new modules/ child, which
+│           │                                        #   keeps the modules/<capability> precedent a single case for the operator to rule
+│           │                                        #   on: content_store.py files a source's bytes under their own sha256, at a path
+│           │                                        #   derived from the computed digest ALONE (r7(b) — a source-controlled string in the
+│           │                                        #   path would write outside a store that sits inside the bag); citations.py holds
+│           │                                        #   what was claimed and, per row, WHICH guarantee it carries; source_fetch.py is the
+│           │                                        #   fetch policy the tree had no existing fetcher to inherit; content_activities.py
+│           │                                        #   is capture and resolve; verify.py is the one read path run in bulk. r7(a) is
+│           │                                        #   ruled PER-RUN and the store lives under data/, so the bag's own manifest already
+│           │                                        #   covers the cited bytes — Phase 7 ships them with the bag by construction and
+│           │                                        #   Phase 5's reachability pass is a no-op
 │           ├── scripts/                             # Kickoff entrypoints, until an SDK path replaces them — plus preflight.py,
-│           │                                        #   validate_bag.py, dispatch_identity.py and dispatch_context.py, which are NOT
-│           │                                        #   kickoffs: they are what a run checks before, what an operator checks after, who
+│           │                                        #   validate_bag.py, verify_citations.py, dispatch_identity.py and dispatch_context.py,
+│           │                                        #   which are NOT kickoffs: they are what a run checks before, what an operator checks
+│           │                                        #   after (validate_bag asks whether a bag's bytes match its manifest; verify_citations
+│           │                                        #   asks whether the claims in it still stand against the sources they were made from),
+│           │                                        #   who
 │           │                                        #   NAMES the run, and what the run DERIVED. All four live here because they are
 │           │                                        #   launch concerns rather than workflow concerns. None is named run_*.py, and that
 │           │                                        #   is load-bearing — the entrypoint sweeps glob that prefix, so a helper wearing it
@@ -272,10 +286,18 @@ claude-dot-files/
 │               │                                    #   a corpus that is no longer in this repo, and a copy per
 │               │                                    #   module is 17 chances to point at a stale path
 │               ├── integration/                    # Runs against what the FLEET actually wrote, not against a constructed fixture
-│               │   └── test_a_real_bag_validates.py # Every journal bag on THIS machine still validates. Skips — distinctly from passing —
-│               │                                    #   where no dispatch has run, because a clone has no journal and there is nothing
-│               │                                    #   honest to assert about that. Does NOT substitute for the entrypoint sweep: a fleet
-│               │                                    #   where ten of eleven had stopped opening bags would still pass on the eleventh's output
+│               │   ├── test_a_real_bag_validates.py # Every journal bag on THIS machine still validates. Skips — distinctly from passing —
+│               │   │                                #   where no dispatch has run, because a clone has no journal and there is nothing
+│               │   │                                #   honest to assert about that. Does NOT substitute for the entrypoint sweep: a fleet
+│               │   │                                #   where ten of eleven had stopped opening bags would still pass on the eleventh's output
+│               │   └── test_citations_verify_offline.py # PMP Phase 2 r2 — the offline demonstration, and the network is DENIED rather
+│               │                                    #   than asserted absent: an LD_PRELOAD shim fails socket(), connect() and
+│               │                                    #   getaddrinfo() at the C library, below the code under test. A control fetch runs
+│               │                                    #   under the same shim FIRST and must fail, or the verify run proves only that
+│               │                                    #   nothing tried. unshare -rn is unavailable here — apparmor_restrict_unprivileged
+│               │                                    #   _userns is 1 — and that is recorded because "how the network was disabled" is a
+│               │                                    #   checklist item. Also walks one bag holding one of EACH outcome, and each outcome
+│               │                                    #   alone, so the mixed-run exit code cannot pass by accident
 │               ├── fixtures/                        # MEASURED inputs, not written ones
 │               │   └── schema_declared_run.jsonl    # A real CLI 2.1.224 run with --json-schema declared. Carries the finding that
 │               │                                    #   declaring a schema REPLACES .result with the structured output — the reason
@@ -687,6 +709,38 @@ claude-dot-files/
 │                                                    #   Placement covers RunContext.build as well as open_run_bag — both raise a
 │                                                    #   RuntimeError carrying an operator remedy, and a guard watching only the older of
 │                                                    #   the two was measured blind to the newer one
+│                   ├── test_content_store.py        # PMP Phase 2 r7(b)/r7(d) — the on-disk path is a function of the COMPUTED DIGEST and
+│                   │                                #   of nothing else (asserted on the signature, not only the output: a URL, a filename
+│                   │                                #   or a Content-Disposition header has nowhere to enter), and every read re-hashes and
+│                   │                                #   fails closed. Flips ONE byte of a stored object and requires the refusal to name
+│                   │                                #   what the bytes actually hash to. Names what it does not look at: no socket, no quote
+│                   ├── test_citations.py            # The citation record — refused at construction rather than coerced, because nothing
+│                   │                                #   rewrites a written row. r7(c)'s ruling is tested AS DATA: `capture` has no default
+│                   │                                #   anywhere, so a harvested row cannot start being reported as a read-time one. r6's
+│                   │                                #   git ref carries no page_content_hash, and an abbreviated sha is refused — a prefix
+│                   │                                #   stops being unique as a repository grows. The evidence-set hash is a SET, so ten
+│                   │                                #   claims on one page are one piece of evidence
+│                   ├── test_source_fetch.py         # PMP Phase 2 r7(c)'s policy, and the most adversarial file in the package: the URL is
+│                   │                                #   model-influenceable and the response is DURABLY STORED and re-servable offline, so
+│                   │                                #   the payload outlives the request. Every redirect hop re-enters every check (the
+│                   │                                #   metadata-range bypass is a test, not a comment), EVERY resolved address is checked
+│                   │                                #   rather than the first, the size cap is enforced on the READ because Content-Length
+│                   │                                #   is the server's claim, and an encoded response is refused rather than decoded.
+│                   │                                #   Runs entirely offline — opener and resolver are parameters, which is what makes a
+│                   │                                #   hostile DNS answer testable at all. Does NOT close DNS rebinding, and says so
+│                   ├── test_content_activities.py   # PMP Phase 2 r8 — capture and resolve as the store's two I/O boundaries. Carries the
+│                   │                                #   FIFTH instance of this package's containment class: the caller-supplied stage name
+│                   │                                #   was composed onto the payload path directly, by the pass that had just read the
+│                   │                                #   module documenting the other four, and test_journal_containment.py is what said so.
+│                   │                                #   Also pins that an activity boundary does not make the call happen — what breaks the
+│                   │                                #   silence is verify reporting `missing` for bytes nobody captured
+│                   └── test_verify_citations.py     # PMP Phase 2 r3/r4 — four outcomes, four exit codes, because each has a different
+│                                                    #   remedy. Resolve BEFORE span, so a corrupt store is never reported as a wrong
+│                                                    #   quotation. Offline is asserted over verify's own STATIC import closure, not over
+│                                                    #   sys.modules — the package __init__ imports every submodule eagerly, so the obvious
+│                                                    #   check reports the fetcher as reached on a tree with no defect in it. Its
+│                                                    #   discriminator starts the same walk at content_activities, which legitimately does
+│                                                    #   import the fetcher
 │
 ├── testing/                                         # TIER 1 + TIER 2 of the Testing Standard's three-tier hierarchy
 │   ├── README.md                                    # How to run the suite and how to add a test

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_activities.py
@@ -799,7 +799,12 @@ def checked_boxes(path: Path) -> Counter:
 #
 # CASE-INSENSITIVE ON BOTH HALVES: a legacy `PHASE3.MD` is a phase doc whoever
 # spelled it, and its disappearance is an offence just the same.
-_LOOKS_LIKE_A_PHASE = re.compile(r"^phase.*\.md$", re.I)
+# `\A…\Z` AND NOT `^…$`: `$` also matches immediately BEFORE a trailing
+# newline, which a POSIX filename may end with, so the anchor that refuses
+# `phase9_x.md.bak` above would have admitted `phase9_x.md\n`. Swept from
+# `modules/journal/`, where the same spelling let a digest carrying a newline
+# through the gate that derives an on-disk path.
+_LOOKS_LIKE_A_PHASE = re.compile(r"\Aphase.*\.md\Z", re.I)
 
 
 def phase_docs(component: Path) -> dict[str, str]:

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_draft/plan_draft_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_draft/plan_draft_activities.py
@@ -70,7 +70,10 @@ from ..plan_activities import plan_boxes, plan_docs  # noqa: F401
 # "Filename pattern (binding)" block: `phase{N}_{descriptor}.md` canonical, with
 # `phase{N}{a-z}_{descriptor}.md` as rule 6's narrow sub-letter carve-out.
 # Anchored at both ends because the whole point is that no OTHER form is valid.
-_PHASE_FILE = re.compile(r"^phase(\d+)([a-z]?)_[a-z0-9_-]+\.md$")
+# `\A…\Z` for the reason `_LOOKS_LIKE_A_PHASE` carries: `$` matches before a
+# trailing newline, and this pattern is what decides whether a NAME is a
+# conformant phase doc.
+_PHASE_FILE = re.compile(r"\Aphase(\d+)([a-z]?)_[a-z0-9_-]+\.md\Z")
 
 # PROMOTED TO THE SHARED SURFACE WHEN `plan-refine` BECAME A SECOND CONSUMER, per
 # §10.1 rule 3 — *consumer count decides, never taste*. Reached through `own.` so

--- a/scripts/workflows/temporal/modules/journal/__init__.py
+++ b/scripts/workflows/temporal/modules/journal/__init__.py
@@ -60,9 +60,16 @@ nothing here has to change to allow it.
   journal size as a requirement so the trigger fires on evidence rather than as
   a mid-build surprise.
 
-The full reasoning for every decision this package implements is in
-`/opt/skyy-net/skyynet-master-planning/development/edge-assistant/persistent-memory-protocol/phase1_the_run_bag.md`, which is the
-authority; the docstrings here carry the half a reader of the code needs.
+The full reasoning is in the phase docs under
+`/opt/skyy-net/skyynet-master-planning/development/edge-assistant/persistent-memory-protocol/`,
+which are the authority; the docstrings here carry the half a reader of the code
+needs. TWO of them apply, and naming only the first left half this package's
+decisions with no reachable authority:
+
+  `phase1_the_run_bag.md`      — the bag, its root, its states, its validator
+  `phase2_content_store.md`    — the store's shape (r7a), its path derivation
+                                 (r7b), its fetch policy (r7c), its single read
+                                 path (r7d), and the capture-provenance ruling
 """
 
 from __future__ import annotations

--- a/scripts/workflows/temporal/modules/journal/__init__.py
+++ b/scripts/workflows/temporal/modules/journal/__init__.py
@@ -12,6 +12,20 @@ rather than where it lands and how it is read, it is in the wrong phase.
   `validate.py`            — re-hash the payload; report integrity and all three states
   `journal_activities.py`  — the activity a run invokes before anything else
 
+PHASE 2 ADDS THE CONTENT STORE, and it is five more files under this same package
+rather than a new child of `modules/`. That placement is a deliberate answer to a
+question the roadmap flagged as this phase's trigger: whether `modules/<capability>/`
+is an admitted shape beside `modules/<edge>/`. Keeping the store here means the
+precedent stays a single case and the operator's ruling is not forced by a build.
+It also matches what the code IS — the store lives inside a bag's payload, so it
+is the journal's own storage rather than a capability sitting beside it.
+
+  `content_store.py`       — bytes filed under their own checksum; the one read path
+  `citations.py`           — what was claimed, against which bytes, under which guarantee
+  `source_fetch.py`        — the fetch policy: https only, every hop re-checked, capped
+  `content_activities.py`  — capture and resolve as the store's two I/O boundaries
+  `verify.py`              — the read-path invariant run in bulk, with four exit codes
+
 DEPENDENCY-FREE ON THE WORKFLOW TREE, on purpose. Nothing here imports
 `modules.assistant`, so the validator can be loaded by a measurement helper or a
 future CPI sweep without dragging in the workflow modules — the same discipline
@@ -55,14 +69,30 @@ from __future__ import annotations
 
 from .bag import (JOURNAL_SCHEMA_VERSION, Bag, BagError, open_bag,
                   read_tag_file, utc_now)
+from .citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME, Citation,
+                        CitationError, evidence_set_hash, new_citation,
+                        read_citations, record_citation,
+                        stage_evidence_hashes)
+from .content_activities import (capture_code_citation, capture_fetched_source,
+                                 capture_source, resolve_citation)
+from .content_store import (ContentStoreError, digest_of_bytes, load_object,
+                            object_relpath, store_bytes)
 from .journal_activities import (load_journal_config, mint_run_id,
                                  open_run_bag)
 from .root import JournalRootError, resolve_journal_root
+from .source_fetch import FetchPolicy, FetchRefused, fetch_source
 from .validate import BagReport, render_report, validate_bag
+from .verify import CitationResult, VerifyReport, verify_bag, verify_citation
 
 __all__ = [
-    "JOURNAL_SCHEMA_VERSION", "Bag", "BagError", "BagReport",
-    "JournalRootError", "load_journal_config", "mint_run_id", "open_bag",
-    "open_run_bag", "read_tag_file", "render_report", "resolve_journal_root",
-    "utc_now", "validate_bag",
+    "CAPTURE_HARVEST", "CAPTURE_READ_TIME", "JOURNAL_SCHEMA_VERSION", "Bag",
+    "BagError", "BagReport", "Citation", "CitationError", "CitationResult",
+    "ContentStoreError", "FetchPolicy", "FetchRefused", "JournalRootError",
+    "VerifyReport", "capture_code_citation", "capture_fetched_source",
+    "capture_source", "digest_of_bytes", "evidence_set_hash", "fetch_source",
+    "load_journal_config", "load_object", "mint_run_id", "new_citation",
+    "object_relpath", "open_bag", "open_run_bag", "read_citations",
+    "read_tag_file", "record_citation", "render_report", "resolve_citation",
+    "resolve_journal_root", "stage_evidence_hashes", "store_bytes", "utc_now",
+    "validate_bag", "verify_bag", "verify_citation",
 ]

--- a/scripts/workflows/temporal/modules/journal/bag.py
+++ b/scripts/workflows/temporal/modules/journal/bag.py
@@ -110,7 +110,15 @@ LABEL_INCOMPLETE = "Journal-Incomplete"            # zero or one; "true" => inco
 LABEL_GAP = "Journal-Gap"                          # zero or more; what was lost
 LABEL_SEALED_AT = "Journal-Sealed-At"              # exactly one, once sealed
 
-_LABEL_RE = re.compile(r"^([^:\s][^:]*):\s?(.*)$")
+# `\A…\Z` AND NOT `^…$`: `$` also matches immediately BEFORE a trailing
+# newline, so an anchored-looking validator silently accepts one. Both
+# callers here feed `splitlines()` output, so no newline reaches this
+# pattern today and the anchor is not load-bearing on them — it becomes
+# load-bearing the moment a caller hands it a raw line, which is exactly
+# the change nobody would notice. `test_journal_regex_anchors.py` fails on
+# any `^`/`$` added anywhere in this package, so this is a property of
+# `modules/journal/` rather than of this line.
+_LABEL_RE = re.compile(r"\A([^:\s][^:]*):\s?(.*)\Z")
 _SAFE_SEGMENT_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 

--- a/scripts/workflows/temporal/modules/journal/bag.py
+++ b/scripts/workflows/temporal/modules/journal/bag.py
@@ -475,7 +475,16 @@ def _append_tag_line(path: Path, label: str, value: str) -> None:
     and it makes the caller's mistake visible where it is made.
     """
     _refuse_folded_value(label, value)
-    with open(path, "a", encoding="utf-8") as handle:
+    # `O_NOFOLLOW` FOR THE SAME REASON `_write_tag_file` CARRIES IT — nothing
+    # this module writes is ever legitimately a symlink. This site appends to a
+    # file that function created, so the MODE is already right; only the follow
+    # was open. Found by a correction pass sweeping the class after
+    # `record_citation` was caught creating a file with neither rule, and fixed
+    # here rather than reported, because a sweep that names a second member and
+    # leaves it is not a sweep.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
+                 FILE_MODE)
+    with os.fdopen(fd, "a", encoding="utf-8") as handle:
         handle.write(f"{label}: {value}\n")
 
 

--- a/scripts/workflows/temporal/modules/journal/bag.py
+++ b/scripts/workflows/temporal/modules/journal/bag.py
@@ -65,6 +65,7 @@ __all__ = ["JOURNAL_SCHEMA_VERSION", "BAGIT_VERSION", "TAG_FILE_ENCODING",
            "open_bag", "read_tag_file", "utc_now", "payload_files",
            "payload_symlinks", "sha256_of", "contained_relpath",
            "RUN_ID_PERMITTED", "RUN_ID_PERMITTED_DESCRIPTION",
+           "safe_payload_segment",
            "RUN_ID_MAX_LENGTH", "validated_run_id", "folds_a_tag_line",
            "LABEL_SCHEMA_VERSION", "LABEL_REDACTION", "LABEL_INCOMPLETE",
            "LABEL_GAP", "LABEL_SEALED_AT", "BagState", "bag_state",
@@ -210,6 +211,33 @@ RUN_ID_MAX_LENGTH = 128
 # down, and a reader tightening this regex later needs to know why it is spelled
 # this way.
 _RUN_ID_RE = re.compile(r"\A[A-Za-z0-9._-]+\Z")
+
+
+def safe_payload_segment(name: str) -> str:
+    """A caller-supplied name reduced to ONE payload directory segment.
+
+    EXTRACTED FROM `Bag.writer_dir` WHEN THE CONTENT STORE NEEDED THE SAME RULE.
+    It is the same shape `contained_relpath` was extracted for: a rule this
+    package would otherwise hold two hand-written copies of, which is how the
+    four containment escapes already found here were produced. Every character
+    outside `[A-Za-z0-9._-]` maps to `-`, so no separator survives and no
+    segment can be a bare `..` that `mkdir` would follow; an input that reduces
+    to nothing yields `writer` rather than an empty component.
+
+    ⚠ THE DOTS-ONLY CASE IS EXPLICIT BECAUSE THE ALLOWLIST ADMITS `.`, AND THAT
+    HOLE WAS LIVE. `[A-Za-z0-9._-]` permits a dot, so `writer_dir("..")` slugged
+    to a bare `..` and joined onto the payload directory — the containment
+    declaration for that join said "no segment can be a bare `..`", and it was
+    describing a rule the code did not have. Nothing escaped in practice only
+    because `os.mkdir` fails on a directory that already exists and the caller
+    took the next ordinal; that is luck, not the rule. A dots-only name is not a
+    usable directory name in any case, so it takes the same fallback an empty
+    one does.
+    """
+    slug = _SAFE_SEGMENT_RE.sub("-", name).strip("-")
+    if not slug or set(slug) == {"."}:
+        return "writer"
+    return slug
 
 
 def validated_run_id(run_id: str) -> str:
@@ -712,7 +740,7 @@ class Bag:
         to one store is the day this needs a sequence number. Cheap to add now,
         unrecoverable in old data.
         """
-        slug = _SAFE_SEGMENT_RE.sub("-", name).strip("-") or "writer"
+        slug = safe_payload_segment(name)
         for ordinal in range(1, 10_000):
             candidate = self.payload_dir / (slug if ordinal == 1 else f"{slug}-{ordinal}")
             try:

--- a/scripts/workflows/temporal/modules/journal/citations.py
+++ b/scripts/workflows/temporal/modules/journal/citations.py
@@ -1,0 +1,370 @@
+"""What a run CLAIMED, and which bytes it claimed it against.
+
+PHASE 2 REQUIREMENTS 1, 5 AND 6. `content_store.py` holds the bytes; this module
+holds the record that points at them. They are separate because they fail
+separately: a store defect is corruption of something the fleet wrote, and a
+citation defect is a claim that was wrong when it was made.
+
+THE RECORD IS `claim_id`, `quote`, `source_ref` AND `page_content_hash`, which is
+the phase's first checklist item, plus three fields the build could not do
+without and which a v1 record cannot gain later:
+
+  * `stage` — requirement 5 computes an evidence-set hash PER STAGE, so the stage
+    has to be on the record. Deriving it from the writer directory afterwards
+    would work today and would silently stop working the moment one writer runs
+    two stages.
+  * `capture` — WHICH GUARANTEE THIS ROW CARRIES, and it is r7(c)'s ruling
+    expressed as data. See § below.
+  * `recorded_at` — when the row was written. A record whose bytes are dated only
+    by a filesystem timestamp loses its date the first time it is copied.
+
+r7(c) IS RULED: POST-EXIT HARVEST, AND THE GUARANTEE IS PER-CITATION RATHER THAN
+GLOBAL. The phase doc names two arms and calls both legitimate. The routed-fetcher
+arm changes how the research workflow reads its sources, and the doc says
+plainly that this is "not a decision this phase can take alone" — so this phase
+takes the arm that stays inside it, which is also the shape the model-issued
+harvest already uses for writes.
+
+  **What that arm costs is a weaker guarantee, and the doc's own remedy was to
+  amend requirement 2's sentence.** This build does something narrower and more
+  useful instead: rather than downgrading one global claim, it records the
+  provenance ON EACH ROW.
+
+    `capture: "read-time"`  the bytes were captured as the source was read, so
+                            the hash proves the claim was made against them.
+    `capture: "harvest"`    the bytes were fetched after the run ended, so the
+                            hash proves they matched AT HARVEST and nothing more.
+
+  Two things follow. A `verify` result can never over-claim, because it reports
+  the provenance it read rather than a guarantee the mechanism asserts. And the
+  routed-fetcher arm stays reachable at no cost: the day a fleet-side read path
+  exists it calls the same capture activity with `capture="read-time"`, and no
+  stored record has to be rewritten.
+
+REQUIREMENT 6 — A CODE DIFF IS A COMMIT SHA AND IS NEVER COPIED IN. `source_ref`
+carries `git:<sha>[:<path>]` for code, and such a row has NO `page_content_hash`:
+git is already content-addressed, so storing a second copy under a second
+checksum would be two names for one guarantee, and the copy is the one that can
+drift. `store_a_code_diff_instead` is the refusal that makes this mechanical
+rather than a convention.
+
+WHY JSON LINES AND NOT ONE DOCUMENT. A run appends citations as it goes and may
+die mid-write; a partially-written array is unparseable and loses every row
+before the break, while a partially-written final line loses one. Each writer
+appends to its OWN file for the reason `Bag.writer_dir` exists — concurrent
+writers in this fleet are real, and the cheapest correct answer to two writers is
+two files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from .bag import PAYLOAD_DIR, BagError, contained_relpath, utc_now
+
+__all__ = ["CITATIONS_FILE", "CITATION_SCHEMA_VERSION", "CAPTURE_READ_TIME",
+           "CAPTURE_HARVEST", "CAPTURE_KINDS", "GIT_REF_RE", "CitationError",
+           "Citation", "is_git_ref", "parse_git_ref", "record_citation",
+           "read_citations", "citations_by_stage", "evidence_set_hash",
+           "stage_evidence_hashes", "converged_stages", "new_citation"]
+
+CITATIONS_FILE = "citations.jsonl"
+
+# Its own version, separate from the bag's `Event-Schema-Version`, because a
+# citation row travels: Phase 7 ships it to object storage where the bag's
+# summary version does not follow it.
+CITATION_SCHEMA_VERSION = 1
+
+CAPTURE_READ_TIME = "read-time"
+CAPTURE_HARVEST = "harvest"
+CAPTURE_KINDS = (CAPTURE_READ_TIME, CAPTURE_HARVEST)
+
+# `git:<40-hex-sha>` with an optional `:<path>`. Abbreviated SHAs are refused:
+# an abbreviation is a prefix search whose answer can change as a repository
+# grows objects, and a citation is meant to name one object forever.
+GIT_REF_RE = re.compile(r"^git:([0-9a-f]{40})(?::(.+))?$")
+
+_CLAIM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CitationError(BagError):
+    """A citation record could not be built, written or read as asked."""
+
+
+def is_git_ref(source_ref: str) -> bool:
+    return bool(GIT_REF_RE.match(source_ref or ""))
+
+
+def parse_git_ref(source_ref: str) -> tuple[str, str | None]:
+    """`(sha, path)` out of a `git:` ref, or a refusal.
+
+    The path is returned unvalidated on purpose — it is handed to `git`, which
+    resolves it inside the object database rather than on the filesystem, so it
+    is not a path this process composes onto anything. `content_store` is where
+    path composition happens and it accepts a digest and nothing else.
+    """
+    match = GIT_REF_RE.match(source_ref or "")
+    if not match:
+        raise CitationError(
+            f"not a git source ref: {source_ref!r}. Expected "
+            f"`git:<40-hex-sha>` with an optional `:<path>`; an abbreviated sha "
+            f"is refused because a prefix can stop being unique as a repository "
+            f"grows, and a citation must name one object permanently.")
+    return match.group(1), match.group(2)
+
+
+@dataclass(frozen=True)
+class Citation:
+    """One claim, the words it quoted, and the evidence it quoted them from.
+
+    Frozen because a written record is not edited — the same rule the bag keeps
+    one directory up, applied to the row rather than to the folder.
+    """
+
+    claim_id: str
+    stage: str
+    quote: str
+    source_ref: str
+    capture: str
+    page_content_hash: str | None = None
+    media_type: str | None = None
+    recorded_at: str = ""
+    schema_version: int = CITATION_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Every field is checked HERE, so no other module has to trust a caller.
+
+        The record is the durable artifact: a malformed row written today is a
+        row every later reader has to cope with, and there is no pass that
+        rewrites it. Validating at construction means the refusal lands on the
+        run that made the mistake rather than on whoever reads the journal next.
+        """
+        if not _CLAIM_ID_RE.match(self.claim_id or ""):
+            raise CitationError(
+                f"claim_id {self.claim_id!r} is not a usable identifier. "
+                f"Expected up to 128 characters of letters, digits, dot, dash "
+                f"or underscore, starting with a letter or digit — it is used "
+                f"to name one claim across a whole journal.")
+        if not (self.stage or "").strip():
+            raise CitationError(
+                "stage is empty. Requirement 5 computes an evidence-set hash "
+                "per stage, so a row with no stage cannot be counted into one.")
+        if not (self.quote or "").strip():
+            raise CitationError(
+                f"claim {self.claim_id}: quote is empty. A citation with no "
+                f"quoted span has nothing for `verify` to re-check, which is "
+                f"the whole reason the bytes were stored.")
+        if self.capture not in CAPTURE_KINDS:
+            raise CitationError(
+                f"claim {self.claim_id}: capture {self.capture!r} is not one of "
+                f"{', '.join(CAPTURE_KINDS)}. It records WHICH guarantee this "
+                f"row carries — whether the hash proves the claim was made "
+                f"against these bytes, or only that they matched at harvest — "
+                f"so it has no default.")
+
+        if is_git_ref(self.source_ref):
+            parse_git_ref(self.source_ref)
+            if self.page_content_hash is not None:
+                raise CitationError(
+                    f"claim {self.claim_id}: a git source ref carries no "
+                    f"page_content_hash. Requirement 6 resolves code from git "
+                    f"rather than copying it into the store, and a second "
+                    f"checksum over a copy is a second thing that can drift.")
+            return
+
+        if not (self.source_ref or "").startswith("https://"):
+            raise CitationError(
+                f"claim {self.claim_id}: source_ref {self.source_ref!r} is "
+                f"neither an https URL nor a `git:<sha>` ref. Those are the two "
+                f"kinds of evidence this record describes, and a third would "
+                f"have no defined way to be re-checked offline.")
+        if not _HEX_DIGEST_RE.match(self.page_content_hash or ""):
+            raise CitationError(
+                f"claim {self.claim_id}: page_content_hash "
+                f"{self.page_content_hash!r} is not a sha256 digest. A web "
+                f"citation with no digest names no bytes, so it would verify "
+                f"clean by having nothing to check.")
+
+    @property
+    def evidence_id(self) -> str:
+        """What this row counts AS, in an evidence set. Never the claim, never the quote.
+
+        Two claims quoting different spans of one page saw ONE piece of evidence,
+        so the identity is the source's bytes: the digest for a stored page, and
+        the git ref for code, which git has already made content-addressed.
+        """
+        return self.source_ref if self.page_content_hash is None else self.page_content_hash
+
+    def to_json(self) -> str:
+        """One JSON Lines row: sorted keys, no newline, nulls dropped.
+
+        Keys are sorted so two rows with the same content are the same bytes —
+        a record that re-serialised differently on each write would make a diff
+        over the journal unreadable. Nulls are dropped rather than written
+        because an absent `page_content_hash` on a git row is a property of the
+        kind of citation, not a value that happens to be empty.
+        """
+        payload = {k: v for k, v in asdict(self).items() if v is not None}
+        return json.dumps(payload, sort_keys=True, ensure_ascii=False)
+
+    @classmethod
+    def from_json(cls, line: str) -> "Citation":
+        """One row back into a record, re-validated on the way in.
+
+        RE-VALIDATED, because `citations.jsonl` is a file on disk that this
+        module did not necessarily write — the same reasoning that made
+        `validate._parse_manifest` contain its paths. A reader that trusted the
+        row would let a hand-edited file name whatever it liked.
+        """
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CitationError(f"citation row is not JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise CitationError(
+                f"citation row is a {type(data).__name__}, not an object")
+        known = {f for f in cls.__dataclass_fields__}
+        unknown = sorted(set(data) - known)
+        if unknown:
+            raise CitationError(
+                f"citation row carries unknown field(s) {unknown}. A field this "
+                f"reader does not know is either a newer schema than it can "
+                f"read or a hand edit, and guessing between those is how a "
+                f"record silently loses meaning.")
+        return cls(**data)
+
+
+def record_citation(directory: Path, citation: Citation) -> Path:
+    """Append one citation row to `<directory>/citations.jsonl`. Returns the file.
+
+    `directory` IS A WRITER DIRECTORY, allocated by `Bag.writer_dir`, and that is
+    what makes the append safe without a lock: no two writers share this file.
+    A single `write` of a line under `O_APPEND` is what the fleet relies on, and
+    it is correct precisely because the contention it would otherwise face has
+    been removed one layer up rather than handled here.
+    """
+    if not directory.is_dir():
+        raise CitationError(
+            f"cannot record a citation: {directory} is not a directory. "
+            f"Citations are written into a writer directory allocated by "
+            f"`Bag.writer_dir`, which is what makes concurrent writers safe.")
+    target = directory / CITATIONS_FILE
+    with open(target, "a", encoding="utf-8") as handle:
+        handle.write(citation.to_json() + "\n")
+    return target
+
+
+def read_citations(bag_path: Path) -> list[Citation]:
+    """Every citation in one bag, from every writer, in a stable order.
+
+    ⚠ THE DISCOVERED PATHS ARE CONTAINED BEFORE THEY ARE READ, for the reason
+    `validate._parse_manifest` contains its manifest entries: a symlink under
+    `data/` pointing outside the bag would otherwise let a file that never
+    travelled with the bag supply its citations. A symlinked citations file is
+    skipped rather than followed, and the bag validator reports the symlink
+    itself as a structural finding.
+
+    Rows are returned in `(stage, claim_id, source_ref)` order rather than in
+    file order, so a set of citations has one spelling regardless of which
+    writer wrote which part of it — which is what lets the evidence-set hash be
+    a function of the evidence rather than of the scheduling.
+    """
+    payload = bag_path / PAYLOAD_DIR
+    if not payload.is_dir():
+        return []
+
+    found: list[Citation] = []
+    for path in sorted(payload.rglob(CITATIONS_FILE)):
+        if path.is_symlink() or not path.is_file():
+            continue
+        relpath = path.relative_to(bag_path).as_posix()
+        try:
+            contained_relpath(relpath)
+        except BagError as exc:
+            raise CitationError(
+                f"{path} is not contained by {bag_path}: {exc}") from exc
+        for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if not raw.strip():
+                continue
+            try:
+                found.append(Citation.from_json(raw))
+            except CitationError as exc:
+                raise CitationError(f"{path}:{lineno}: {exc}") from exc
+    return sorted(found, key=lambda c: (c.stage, c.claim_id, c.source_ref))
+
+
+def citations_by_stage(citations: list[Citation]) -> dict[str, list[Citation]]:
+    """Group rows by the stage that recorded them, stages in sorted order."""
+    grouped: dict[str, list[Citation]] = {}
+    for citation in citations:
+        grouped.setdefault(citation.stage, []).append(citation)
+    return {stage: grouped[stage] for stage in sorted(grouped)}
+
+
+def evidence_set_hash(citations: list[Citation]) -> str:
+    """One hash over the SET of evidence a group of citations rests on.
+
+    REQUIREMENT 5, AND WHAT IT IS FOR: two stages with equal hashes saw exactly
+    the same evidence, which is a stop condition computed from bytes rather than
+    asserted by a model. This fleet has already replaced one model-asserted
+    convergence flag with a computed signal for that reason.
+
+    A SET, DEDUPLICATED AND SORTED. Ten claims quoting one page are one piece of
+    evidence, so counting them ten times would make the hash a function of how
+    much a stage wrote rather than of what it read. An empty set hashes to the
+    hash of the empty string, which is a real value and not a sentinel — and
+    `stage_evidence_hashes` is where "no evidence" is kept distinguishable from
+    "the same evidence", because two empty stages genuinely did see the same
+    nothing.
+    """
+    identities = sorted({c.evidence_id for c in citations})
+    return hashlib.sha256("\n".join(identities).encode("utf-8")).hexdigest()
+
+
+def stage_evidence_hashes(citations: list[Citation]) -> dict[str, str]:
+    """`{stage: evidence_set_hash}` for every stage present. Requirement 5's output."""
+    return {stage: evidence_set_hash(rows)
+            for stage, rows in citations_by_stage(citations).items()}
+
+
+def converged_stages(citations: list[Citation]) -> list[tuple[str, str]]:
+    """`(stage, prior_stage)` for every stage whose evidence equals its predecessor's.
+
+    REQUIREMENT 5 STOPS HERE, AND SO DOES THIS FUNCTION. It is COMPUTED AND
+    EXPOSED; nothing in this fleet routes on it and nothing should until somebody
+    produces firing-rate evidence for it. The precedent is this fleet's own
+    convergence signal, which was built, shadowed beside the incumbent and gated
+    nothing — because two positive observations are not a rate, and a stopping
+    rule that fires early ends productive work silently with no failing test.
+
+    "Predecessor" is the previous stage in sorted order, which is a property of
+    the NAMES rather than of execution. That is honest about what the record
+    holds: nothing in a v1 citation row orders the stages, so an ordering
+    inferred from anything else here would be a guess wearing a computation's
+    clothes. A caller that knows its own stage order passes its own list.
+    """
+    hashes = stage_evidence_hashes(citations)
+    names = list(hashes)
+    return [(names[i], names[i - 1]) for i in range(1, len(names))
+            if hashes[names[i]] == hashes[names[i - 1]]]
+
+
+def new_citation(*, claim_id: str, stage: str, quote: str, source_ref: str,
+                 capture: str, page_content_hash: str | None = None,
+                 media_type: str | None = None) -> Citation:
+    """A citation stamped with the current time. The one constructor callers use.
+
+    `recorded_at` is defaulted here rather than in the dataclass because a
+    frozen record read back off disk must keep the timestamp it was written
+    with, and a field defaulting to "now" inside `__init__` would silently
+    restamp every row `from_json` rebuilt.
+    """
+    return Citation(claim_id=claim_id, stage=stage, quote=quote,
+                    source_ref=source_ref, capture=capture,
+                    page_content_hash=page_content_hash, media_type=media_type,
+                    recorded_at=utc_now())

--- a/scripts/workflows/temporal/modules/journal/citations.py
+++ b/scripts/workflows/temporal/modules/journal/citations.py
@@ -60,11 +60,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from .bag import PAYLOAD_DIR, BagError, contained_relpath, utc_now
+from .bag import (FILE_MODE, PAYLOAD_DIR, BagError, contained_relpath,
+                  folds_a_tag_line, utc_now)
+from .content_store import ContentStoreError, validated_digest
 
 __all__ = ["CITATIONS_FILE", "CITATION_SCHEMA_VERSION", "CAPTURE_READ_TIME",
            "CAPTURE_HARVEST", "CAPTURE_KINDS", "GIT_REF_RE", "CitationError",
@@ -86,10 +89,15 @@ CAPTURE_KINDS = (CAPTURE_READ_TIME, CAPTURE_HARVEST)
 # `git:<40-hex-sha>` with an optional `:<path>`. Abbreviated SHAs are refused:
 # an abbreviation is a prefix search whose answer can change as a repository
 # grows objects, and a citation is meant to name one object forever.
-GIT_REF_RE = re.compile(r"^git:([0-9a-f]{40})(?::(.+))?$")
+#
+# ⚠ `\A` AND `\Z`, NEVER `^` AND `$` — the rule `bag._RUN_ID_RE` states and
+# this module did not reach for. `$` also matches BEFORE a trailing newline, so
+# `claim_id = "c1\n"` and `page_content_hash = "a"*64 + "\n"` were both
+# ACCEPTED, and both are rendered raw into the operator's verify report. A
+# trailing newline is not a near-miss here; it is a forged report line.
+GIT_REF_RE = re.compile(r"\Agit:([0-9a-f]{40})(?::(.+))?\Z")
 
-_CLAIM_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_CLAIM_ID_RE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 
 
 class CitationError(BagError):
@@ -144,6 +152,19 @@ class Citation:
         rewrites it. Validating at construction means the refusal lands on the
         run that made the mistake rather than on whoever reads the journal next.
         """
+        for field_name in ("claim_id", "stage", "quote", "source_ref",
+                           "capture", "page_content_hash", "media_type",
+                           "recorded_at"):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, str):
+                raise CitationError(
+                    f"citation field {field_name} is a "
+                    f"{type(value).__name__}, not a string. A row read back off "
+                    f"disk was not necessarily written by this module, and a "
+                    f"non-string reaching the regex below raises `TypeError` — "
+                    f"which is not the `CitationError` every caller of "
+                    f"`from_json` is told to catch.")
+
         if not _CLAIM_ID_RE.match(self.claim_id or ""):
             raise CitationError(
                 f"claim_id {self.claim_id!r} is not a usable identifier. "
@@ -154,6 +175,23 @@ class Citation:
             raise CitationError(
                 "stage is empty. Requirement 5 computes an evidence-set hash "
                 "per stage, so a row with no stage cannot be counted into one.")
+
+        # ⚠ `stage` AND `source_ref` ARE RENDERED RAW INTO THE OPERATOR'S VERIFY
+        # REPORT, so they are the fifth and sixth consumers of the rule
+        # `validated_run_id` enumerates by name: a string that folds across
+        # lines lets a record rewrite the report about itself. A row with
+        # `stage = "draft\n  evidence_set_hash[draft]: 0000…"` prints a line the
+        # checker never composed. Asked of `str.splitlines()` rather than of an
+        # author's list of terminators, for the reason `folds_a_tag_line` was
+        # extracted: eight spellings survived the hand-written version.
+        for field_name in ("stage", "source_ref"):
+            value = getattr(self, field_name) or ""
+            if folds_a_tag_line(value):
+                raise CitationError(
+                    f"claim {self.claim_id}: {field_name} {value!r} folds "
+                    f"across lines or carries surrounding whitespace. It is "
+                    f"rendered into the operator's verify report, so a value "
+                    f"that folds would forge a line the checker never wrote.")
         if not (self.quote or "").strip():
             raise CitationError(
                 f"claim {self.claim_id}: quote is empty. A citation with no "
@@ -183,12 +221,19 @@ class Citation:
                 f"neither an https URL nor a `git:<sha>` ref. Those are the two "
                 f"kinds of evidence this record describes, and a third would "
                 f"have no defined way to be re-checked offline.")
-        if not _HEX_DIGEST_RE.match(self.page_content_hash or ""):
+        # THE DIGEST SHAPE IS THE STORE'S RULE AND IS ASKED OF THE STORE. This
+        # module held a second hand-written copy of the same regex, and the two
+        # copies carried the same `^…$` defect — which is the shape this package
+        # extracted `contained_relpath` and `safe_payload_segment` for. One
+        # statement of one fact, so tightening it reaches both readers.
+        try:
+            validated_digest(self.page_content_hash or "")
+        except ContentStoreError as exc:
             raise CitationError(
                 f"claim {self.claim_id}: page_content_hash "
-                f"{self.page_content_hash!r} is not a sha256 digest. A web "
-                f"citation with no digest names no bytes, so it would verify "
-                f"clean by having nothing to check.")
+                f"{self.page_content_hash!r} is not a sha256 digest ({exc}). A "
+                f"web citation with no digest names no bytes, so it would "
+                f"verify clean by having nothing to check.") from None
 
     @property
     def evidence_id(self) -> str:
@@ -236,7 +281,18 @@ class Citation:
                 f"reader does not know is either a newer schema than it can "
                 f"read or a hand edit, and guessing between those is how a "
                 f"record silently loses meaning.")
-        return cls(**data)
+        try:
+            return cls(**data)
+        except TypeError as exc:
+            # ⚠ A ROW MISSING A REQUIRED FIELD RAISED `TypeError` STRAIGHT PAST
+            # THIS CLASS'S OWN "re-validated on the way in" GUARANTEE — and a
+            # truncated append is the single most likely corruption of a JSON
+            # Lines file, which is the format this module chose BECAUSE a
+            # partial write loses one row. `verify_bag` catches `CitationError`
+            # to turn a bad record into a structural finding; a `TypeError`
+            # went past it and killed the sweep.
+            raise CitationError(
+                f"citation row is missing a required field: {exc}") from exc
 
 
 def record_citation(directory: Path, citation: Citation) -> Path:
@@ -254,7 +310,19 @@ def record_citation(directory: Path, citation: Citation) -> Path:
             f"Citations are written into a writer directory allocated by "
             f"`Bag.writer_dir`, which is what makes concurrent writers safe.")
     target = directory / CITATIONS_FILE
-    with open(target, "a", encoding="utf-8") as handle:
+
+    # ⚠ MODE AT CREATION AND `O_NOFOLLOW`, THE SAME TWO RULES `_write_tag_file`
+    # KEEPS AND THIS FUNCTION DID NOT. Builtin `open(..., "a")` creates at
+    # `0o666 & ~umask` — 0644 on this host — so the quotes and claim text were
+    # the only file in a bag not at `FILE_MODE`, on a root the package's own
+    # docstrings call as sensitive as the transcripts beside it. And it follows
+    # a symlink, so a planted `citations.jsonl` link diverted appended rows out
+    # of the bag entirely: `read_citations` already refuses to FOLLOW such a
+    # link, which made the read side closed and the write side open.
+    fd = os.open(str(target),
+                 os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
+                 FILE_MODE)
+    with os.fdopen(fd, "a", encoding="utf-8") as handle:
         handle.write(citation.to_json() + "\n")
     return target
 

--- a/scripts/workflows/temporal/modules/journal/content_activities.py
+++ b/scripts/workflows/temporal/modules/journal/content_activities.py
@@ -1,0 +1,177 @@
+"""Capture and resolve — the content store's two I/O boundaries.
+
+REQUIREMENT 8, AND IT IS PHASE 1 REQUIREMENT 11's ARGUMENT APPLIED TO THIS
+STORE'S TWO I/O BOUNDARIES. A source read through a path that does not capture is
+a citation nobody can re-check offline, and it fails silently — there is no
+error, no missing file, and nothing to notice until somebody tries to verify a
+claim and finds no bytes behind it. Temporal Standard §3 puts I/O in the
+activities layer, which is why these live here and not in `content_store.py`:
+that module is layout and hashing, and it does no network and makes no decisions
+about a run.
+
+⚠ AND AN ACTIVITY BOUNDARY DOES NOT MAKE THE CALL HAPPEN — the same caveat
+`journal_activities` states about bag-open, and it is more acute here. Nothing
+forces a workflow to capture before it cites. What supplies the guarantee is
+`verify` FAILING CLOSED: a citation naming a digest with no stored bytes is
+reported `missing` with a non-zero exit, so a read path that skipped capture
+shows up as a finding rather than as silence.
+
+WHAT IS BUILDABLE TODAY AND WHAT IS PORT-TIME, so neither half is claimed
+falsely. Layer placement, invocation, fail-stop and idempotency are here.
+Orchestrator-driven retry and recorded execution belong to a worker that does not
+exist yet, and the port carries them. Idempotency is free rather than designed:
+capturing the same bytes twice computes the same digest and writes the same
+path, which is §7.1 satisfied by content addressing.
+
+⚠ THE READ-SIDE BOUNDARY IS THE HONEST GAP, AND IT IS RULED RATHER THAN HIDDEN.
+In this fleet a research citation is read by a model inside a `claude -p` child,
+through the model's own tooling. Adding a fetcher here does not reach that read,
+because nothing routes the model's reads through fleet code — the same structural
+problem the emit rule found for writes, applied to reads. Of the two arms the
+phase names, this build takes the one that stays inside the component:
+
+  * `capture_fetched_source` — bytes already in hand are stored. The caller
+    states its own provenance, so the day a fleet-side read path exists it
+    passes `capture="read-time"` and the guarantee is the strong one with no
+    stored record rewritten.
+  * `capture_source` — this module fetches under `source_fetch`'s policy and
+    stores. Used post-exit to harvest what a run cited, which is the shape the
+    model-issued harvest already uses for writes, and it defaults to
+    `capture="harvest"` because that is what it is.
+
+The weaker guarantee is recorded on each row rather than amended into a global
+sentence, so a `verify` result reports the provenance it read instead of
+asserting one. See `citations.py` § r7(c).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .bag import PAYLOAD_DIR, Bag, contained_relpath, safe_payload_segment
+from .citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME, CAPTURE_KINDS,
+                        Citation, CitationError, is_git_ref, new_citation,
+                        record_citation)
+from .content_store import load_object, store_bytes
+from .source_fetch import FetchPolicy, fetch_source
+
+__all__ = ["capture_source", "capture_fetched_source", "capture_code_citation",
+           "resolve_citation"]
+
+
+def _writer_directory(bag: Bag, stage: str) -> Path:
+    """The directory this stage's citation rows are appended to.
+
+    ADOPTED WHEN IT ALREADY EXISTS, ALLOCATED WHEN IT DOES NOT, and the
+    difference from `Bag.writer_dir` matters. That method allocates a name no
+    other writer can be handed, which is right for a writer claiming a workspace
+    and wrong here: a stage capturing its second source must append to the file
+    its first source created, not to `<stage>-2`. So the exact directory is used
+    when it is already there.
+
+    ⚠ AND THE STAGE IS A CALLER-SUPPLIED STRING, WHICH THIS COMPOSED ONTO THE
+    PAYLOAD PATH DIRECTLY UNTIL `test_journal_containment` SAID SO. That is the
+    fifth instance of this package's own escape class, written by the pass that
+    had just read the module documenting the other four. It goes through
+    `safe_payload_segment` (no separator survives, no bare `..`) and then through
+    `contained_relpath` (proven to stay under `data/`) — the same two rules
+    `Bag.writer_dir` keeps, reached by name rather than re-implemented.
+    """
+    candidate = bag.path / contained_relpath(
+        f"{PAYLOAD_DIR}/{safe_payload_segment(stage)}")
+    if candidate.is_dir():
+        return candidate
+    return bag.writer_dir(stage)
+
+
+def capture_fetched_source(*, bag: Bag, stage: str, claim_id: str, quote: str,
+                           source_ref: str, data: bytes,
+                           capture: str = CAPTURE_READ_TIME,
+                           media_type: str | None = None) -> Citation:
+    """Store bytes already in hand and record the citation naming them.
+
+    THE ENTRY POINT A ROUTED READ PATH USES, and it is why r7(c)'s expensive arm
+    stays reachable at no cost: a caller that obtained the bytes AS THE SOURCE
+    WAS READ passes them here with the default provenance, and the citation
+    carries the strong guarantee. Nothing about the store changes between the
+    two arms — only who calls, when, and what they say about it.
+    """
+    if capture not in CAPTURE_KINDS:
+        raise CitationError(
+            f"capture {capture!r} is not one of {', '.join(CAPTURE_KINDS)}. It "
+            f"records which guarantee the row carries and has no default here.")
+    digest = store_bytes(bag.path, data)
+    citation = new_citation(claim_id=claim_id, stage=stage, quote=quote,
+                            source_ref=source_ref, capture=capture,
+                            page_content_hash=digest, media_type=media_type)
+    record_citation(_writer_directory(bag, stage), citation)
+    return citation
+
+
+def capture_source(*, bag: Bag, stage: str, claim_id: str, quote: str, url: str,
+                   capture: str = CAPTURE_HARVEST,
+                   policy: FetchPolicy | None = None) -> Citation:
+    """Fetch one source under the policy, store its bytes, record the citation.
+
+    THE ONLY PLACE THIS PACKAGE REACHES THE NETWORK, and it is deliberately not
+    on `verify`'s import path: the checker resolves from the store alone, which
+    is requirement 2, and keeping the fetcher out of that graph is what makes
+    the property structural rather than a promise.
+
+    ⚠ THE SPAN IS NOT CHECKED HERE, AND THAT IS NOT AN OVERSIGHT. Refusing to
+    record a citation whose quote is absent from the fetched bytes would move a
+    finding out of `verify` and into the capture path, where it becomes an error
+    a run has to handle mid-flight rather than a reported outcome an operator
+    reads. `span-missing` exists as a distinct exit code precisely so that a
+    wrong quotation is a FINDING about the record, not a failure of capture.
+    """
+    fetched = fetch_source(url, policy=policy)
+    return capture_fetched_source(bag=bag, stage=stage, claim_id=claim_id,
+                                  quote=quote, source_ref=fetched.final_url,
+                                  data=fetched.data, capture=capture,
+                                  media_type=fetched.media_type)
+
+
+def capture_code_citation(*, bag: Bag, stage: str, claim_id: str, quote: str,
+                          commit_sha: str, path: str | None = None) -> Citation:
+    """Record a code citation as a commit sha. Stores nothing. Requirement 6.
+
+    NO BYTES ARE WRITTEN, WHICH IS THE REQUIREMENT AND NOT A SHORTCUT. Git is
+    already content-addressed, so copying a diff into the store would be a second
+    name for one guarantee and the copy is the one that can drift from the
+    repository it came from. `verify` resolves these through `git cat-file`.
+    """
+    source_ref = f"git:{commit_sha}" + (f":{path}" if path else "")
+    if not is_git_ref(source_ref):
+        raise CitationError(
+            f"{commit_sha!r} is not a full 40-character commit sha. An "
+            f"abbreviated sha is a prefix search whose answer can change as a "
+            f"repository grows objects, and a citation must name one object "
+            f"permanently.")
+    citation = new_citation(claim_id=claim_id, stage=stage, quote=quote,
+                            source_ref=source_ref, capture=CAPTURE_READ_TIME)
+    record_citation(_writer_directory(bag, stage), citation)
+    return citation
+
+
+def resolve_citation(*, bag: Bag, citation: Citation) -> bytes:
+    """The stored bytes behind one citation, re-hashed on the way out.
+
+    r7(d) — THIS IS `content_store.load_object` AND NOT A SECOND RESOLVER. It
+    exists as an activity so a workflow reaching into the store crosses a
+    declared I/O boundary rather than importing a layout module, and it adds no
+    behaviour of its own: adding any would create the second read path r7(d)
+    exists to prevent.
+
+    A git citation is refused rather than silently resolved from a repository
+    this function was not given, because guessing which checkout a sha belongs to
+    is exactly the wrong answer. `verify.verify_citation` takes an explicit
+    `repo_root` and is where that resolution belongs.
+    """
+    if is_git_ref(citation.source_ref):
+        raise CitationError(
+            f"claim {citation.claim_id} cites code ({citation.source_ref}), "
+            f"which resolves from a git object database rather than from the "
+            f"content store. Use `verify.git_blob` with the repository it "
+            f"belongs to — this function will not guess which checkout that is.")
+    return load_object(bag.path, citation.page_content_hash)

--- a/scripts/workflows/temporal/modules/journal/content_activities.py
+++ b/scripts/workflows/temporal/modules/journal/content_activities.py
@@ -114,9 +114,25 @@ def capture_source(*, bag: Bag, stage: str, claim_id: str, quote: str, url: str,
     """Fetch one source under the policy, store its bytes, record the citation.
 
     THE ONLY PLACE THIS PACKAGE REACHES THE NETWORK, and it is deliberately not
-    on `verify`'s import path: the checker resolves from the store alone, which
-    is requirement 2, and keeping the fetcher out of that graph is what makes
-    the property structural rather than a promise.
+    on `verify`'s INTRA-PACKAGE import closure: the checker resolves from the
+    store alone, which is requirement 2, and keeping the fetcher out of that
+    graph is what makes the property structural rather than a promise.
+
+    ⚠ THE QUALIFIER IS LOAD-BEARING AND WAS MISSING. `modules/journal/__init__`
+    imports this module eagerly, so a process entering through the PACKAGE — and
+    `scripts/verify_citations.py` does — has `urllib` loaded whether or not
+    `verify` reaches it. The closure is what the guard asserts and what a
+    reviewer can check; process-level absence is NOT claimed, and is not what
+    requirement 2 asks for. The demonstration that settles it is the run with the
+    network denied at the C library, where the fetcher IS imported and the
+    verifier returns every verdict regardless.
+
+    ⚠ THE REDIRECT CHAIN IS NOT DURABLE, DELIBERATELY. `FetchedSource.hops`
+    records every URL visited and only `final_url` reaches the citation row, so
+    a source that arrived via a redirect reads on disk as though it had been
+    fetched directly. Carrying `hops` would be a v1 schema field with no reader,
+    and this record refuses fields nothing consumes; the operator-facing place
+    for the chain is the refusal message when a hop is rejected, which names it.
 
     ⚠ THE SPAN IS NOT CHECKED HERE, AND THAT IS NOT AN OVERSIGHT. Refusing to
     record a citation whose quote is absent from the fetched bytes would move a

--- a/scripts/workflows/temporal/modules/journal/content_store.py
+++ b/scripts/workflows/temporal/modules/journal/content_store.py
@@ -1,0 +1,296 @@
+"""The byte cache: sources filed under their own checksum, and read back by it.
+
+PHASE 2 REQUIREMENTS 1, 7(a), 7(b) AND 7(d). What a citation points AT lives
+here; what a citation SAYS lives in `citations.py`; how bytes are obtained lives
+in `source_fetch.py`. Three files because they fail differently: a store defect
+is corruption, a citation defect is a wrong claim, and a fetch defect is a
+network policy hole.
+
+r7(a) IS RULED PER-RUN, AND THE STORE SITS INSIDE THE BAG'S PAYLOAD. The draft
+implied both shapes and they are not compatible without an answer, so here is the
+answer and its cost.
+
+  * **What per-run buys.** A bag stays self-contained. Because the store is under
+    `data/`, every stored object is covered by the bag's own
+    `manifest-sha256.txt` — so `validate_bag` already re-hashes the cited bytes,
+    and Phase 7's requirement 2 ("the content-store objects the bag references
+    ship with it") is satisfied by construction rather than by a second sync
+    mechanism nobody has written. Phase 5's retention deletes whole run folders,
+    which reclaims the cited bytes with them, so its conditional reachability
+    pass is a **no-op** and the reason is recorded rather than discovered later.
+  * **What per-run costs, stated rather than glossed.** One source cited by many
+    runs is stored once per run. That is real duplication and it is the reason
+    the shared shape was tempting. It is the cheaper trade here because the
+    journal has a size budget measured over the whole root and a reclamation pass
+    for a shared store is unbuilt work in a phase that has not started, whereas
+    duplicated text sources are bounded by `MAX_SOURCE_BYTES` per object and are
+    reclaimed by a deletion that already exists.
+
+  The revisit trigger is a measurement, not a preference: **cited bytes becoming
+  a material fraction of the journal budget.** Phase 5's pass reports what it
+  could not reclaim, so the evidence arrives on its own.
+
+r7(b) — THE PATH COMES FROM THE COMPUTED DIGEST AND FROM NOTHING ELSE. Not from
+the URL, not from a filename, not from a `Content-Disposition` header, not from a
+content type. Those are source-controlled strings and the store sits under the
+journal root beside the bags, so a crafted URL or a redirect that reached the
+path would write outside the store. `object_relpath` takes a digest and only a
+digest, and it re-validates the digest's shape before composing — a function that
+cannot be handed a name cannot be tricked into one. Human-facing names travel in
+the citation record, which is data and never a path component.
+
+THE ALGORITHM IS A PATH PREFIX FOR A REASON. `sha256/` sits above the fan-out so
+a future second algorithm gets its own namespace instead of colliding with this
+one. Two digests of different algorithms that happen to share a prefix would
+otherwise land in the same directory and the store would have no way to say which
+function produced a name.
+
+r7(d) — EVERY READ RE-HASHES, AND THERE IS ONE READ. `load_object` is the only
+way bytes leave this store, and it fails closed: bytes whose digest is not the
+name they are filed under raise rather than return. A store checked only when
+somebody remembers to invoke a checker is checked never, so `verify` is this
+function run over everything rather than a separate implementation of the same
+idea — which is also why there is no second code path for it to drift from.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+from .bag import (DIR_MODE, FILE_MODE, PAYLOAD_DIR, BagError,
+                  contained_relpath)
+
+__all__ = ["CONTENT_STORE_DIR", "DIGEST_ALGORITHM", "DIGEST_HEX_LENGTH",
+           "FANOUT", "ContentStoreError", "digest_of_bytes", "validated_digest",
+           "object_relpath", "store_dir", "object_path", "store_bytes",
+           "load_object", "has_object", "stored_digests"]
+
+# Under `data/`, so the bag's own payload manifest covers every stored object.
+# The name is hyphenated because it is a directory in a payload, not a Python
+# module — `bag.payload_files` walks it like any other payload subtree.
+CONTENT_STORE_DIR = "content-store"
+
+DIGEST_ALGORITHM = "sha256"
+DIGEST_HEX_LENGTH = 64
+
+# Two hex characters of fan-out. A single flat directory of objects is the shape
+# that degrades once a journal accumulates, and one level is enough at this
+# scale: a second level buys nothing until an edge holds far more objects than
+# the journal's size budget permits.
+FANOUT = 2
+
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{%d}$" % DIGEST_HEX_LENGTH)
+
+
+class ContentStoreError(BagError):
+    """A stored object could not be written, found, or trusted.
+
+    A `BagError` — and therefore a `RuntimeError` — for the reason every other
+    error in this package is one: entrypoints already print these and the
+    message is the diagnostic. A distinct type so a caller can tell a store
+    problem from a bag problem without parsing prose.
+    """
+
+
+def digest_of_bytes(data: bytes) -> str:
+    """The lowercase hex sha256 of `data`. The store's naming function, in one place."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def validated_digest(digest: str) -> str:
+    """`digest` proven to be a lowercase hex sha256, or a refusal.
+
+    THE GATE THAT MAKES r7(b) MECHANICAL RATHER THAN ASPIRATIONAL. Path
+    derivation is safe because the only input to it is a value with this shape,
+    and this is where the shape is proven. Uppercase is refused rather than
+    normalised: a digest arriving in the wrong case came from somewhere that is
+    not this module's `digest_of_bytes`, and silently folding it would hide that
+    the store has two naming conventions.
+    """
+    if not isinstance(digest, str) or not _HEX_DIGEST_RE.match(digest):
+        raise ContentStoreError(
+            f"not a {DIGEST_ALGORITHM} digest: {digest!r}. The content store "
+            f"derives every path from the digest it computed and from nothing "
+            f"else, so a value that is not {DIGEST_HEX_LENGTH} lowercase hex "
+            f"characters is refused here rather than composed onto a path.")
+    return digest
+
+
+def object_relpath(digest: str) -> str:
+    """The bag-relative path for `digest`: `data/content-store/sha256/ab/cdef…`.
+
+    A PURE FUNCTION OF THE DIGEST. It takes no name, no URL and no content type,
+    which is what makes "a source-controlled string cannot enter the path" a
+    property of the code rather than a rule someone has to remember. The return
+    is composed from validated hex and from module constants only, so it has no
+    traversal to contain.
+    """
+    safe = validated_digest(digest)
+    return "/".join((PAYLOAD_DIR, CONTENT_STORE_DIR, DIGEST_ALGORITHM,
+                     safe[:FANOUT], safe[FANOUT:]))
+
+
+def store_dir(bag_path: Path) -> Path:
+    """`<bag>/data/content-store/` — the root of one run's store."""
+    return bag_path / PAYLOAD_DIR / CONTENT_STORE_DIR
+
+
+def object_path(bag_path: Path, digest: str) -> Path:
+    """Where `digest`'s bytes live in this bag's store.
+
+    THE JOIN GOES THROUGH `contained_relpath` EVEN THOUGH `object_relpath` IS
+    ALREADY A PURE FUNCTION OF VALIDATED HEX. Belt and braces is not the reason —
+    uniformity is. This package has produced four containment escapes, each in a
+    join whose author could explain why it was safe, and the remedy it settled on
+    was one rule applied everywhere rather than a per-site argument. A join that
+    opts out on the grounds of being obviously fine is how the next one gets
+    written.
+    """
+    return bag_path / contained_relpath(object_relpath(digest))
+
+
+def has_object(bag_path: Path, digest: str) -> bool:
+    """Whether an object file exists for `digest`. Says nothing about its bytes.
+
+    Deliberately separate from `load_object`, and callers must not read it as a
+    verdict: `verify` distinguishes *missing* from *tampered* precisely because
+    a file being present is not the same as its bytes being right, and a
+    convenience that conflated them would collapse two exit codes into one.
+    """
+    return object_path(bag_path, digest).is_file()
+
+
+def store_bytes(bag_path: Path, data: bytes) -> str:
+    """Write `data` into this bag's store under its own digest. Returns the digest.
+
+    IDEMPOTENT, AND THE SECOND WRITE IS SKIPPED RATHER THAN REDONE. Two captures
+    of the same source inside one run produce the same digest and therefore the
+    same path; re-writing identical bytes would be harmless but would also
+    rewrite a file the bag may already have sealed over. Content addressing is
+    what makes "already there" mean "already correct", and `load_object` is what
+    checks that claim on the way out.
+
+    MODES ARE SET AT CREATION for the reason `root._create_with_mode` gives: a
+    `mkdir` followed by a `chmod` leaves a readable window on a multi-user host,
+    and stored sources are as sensitive as the transcripts beside them.
+    """
+    if not isinstance(data, (bytes, bytearray)):
+        raise ContentStoreError(
+            f"the content store holds bytes, not {type(data).__name__}. Encode "
+            f"text at the boundary that knows its encoding — the store must "
+            f"hash exactly what was received, and choosing an encoding here "
+            f"would change the digest the citation was made against.")
+
+    payload = bytes(data)
+    digest = digest_of_bytes(payload)
+    target = object_path(bag_path, digest)
+    if target.is_file():
+        return digest
+
+    parent = target.parent
+    missing = []
+    probe = parent
+    while not probe.exists():
+        missing.append(probe)
+        probe = probe.parent
+    for directory in reversed(missing):
+        try:
+            os.mkdir(directory, DIR_MODE)
+        except FileExistsError:
+            # Another writer in this run won the race; the directory is the one
+            # we wanted either way. Same reasoning as `Bag.writer_dir`.
+            continue
+        except OSError as exc:
+            raise ContentStoreError(
+                f"cannot create {directory} for the content store "
+                f"({exc.strerror}). The store lives inside the bag's payload, "
+                f"so this is the same failure as being unable to write the run's "
+                f"record at all.") from exc
+
+    # Written to a temporary name in the same directory and renamed, so a reader
+    # never sees a partial object under a digest that promises complete bytes.
+    # `os.replace` is atomic within a filesystem, and the temp name carries the
+    # pid so two writers in one run cannot collide on it.
+    staging = parent / f".{digest}.{os.getpid()}.part"
+    try:
+        handle = os.open(str(staging), os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
+        try:
+            os.write(handle, payload)
+        finally:
+            os.close(handle)
+        os.replace(str(staging), str(target))
+    except OSError as exc:
+        try:
+            staging.unlink()
+        except OSError:
+            # The staging file could not be removed. Named rather than passed
+            # over: it is leftover bytes under a dot-name, not a correctness
+            # problem, and the write failure below is the finding.
+            pass
+        raise ContentStoreError(
+            f"cannot write content-store object {digest} into {parent} "
+            f"({exc.strerror}).") from exc
+    return digest
+
+
+def load_object(bag_path: Path, digest: str) -> bytes:
+    """The bytes filed under `digest`, re-hashed on the way out. Fails closed.
+
+    THE ONLY READ PATH, WHICH IS r7(d). Every consumer — `verify`, a resolve
+    activity, anything Phase 6 later adds — comes through here, so re-hashing is
+    not a mode that can be switched off and there is no second implementation to
+    drift from. The cost is one hash per read of an object bounded by
+    `MAX_SOURCE_BYTES`; the alternative is a store whose integrity is asserted.
+
+    THE TWO FAILURES ARE DIFFERENT TYPES OF EVENT AND CARRY DIFFERENT WORDS,
+    because `verify`'s exit codes are built on the distinction: an absent object
+    means the check could not be made, and a mismatched one means the store
+    itself is not to be trusted.
+    """
+    target = object_path(bag_path, digest)
+    try:
+        data = target.read_bytes()
+    except FileNotFoundError:
+        raise ContentStoreError(
+            f"content-store object {digest} is MISSING from {store_dir(bag_path)}. "
+            f"Nothing was stored under that digest in this bag, so the citation "
+            f"naming it cannot be checked at all.") from None
+    except OSError as exc:
+        raise ContentStoreError(
+            f"content-store object {digest} could not be read from {target} "
+            f"({exc.strerror}).") from exc
+
+    actual = digest_of_bytes(data)
+    if actual != digest:
+        raise ContentStoreError(
+            f"content-store object {digest} is TAMPERED: its bytes hash to "
+            f"{actual}. An object is named by its own checksum, so a mismatch "
+            f"means the stored bytes were changed after they were filed — the "
+            f"store, not the citation, is the thing that failed.")
+    return data
+
+
+def stored_digests(bag_path: Path) -> list[str]:
+    """Every digest this bag's store holds, sorted. Names only; nothing is read.
+
+    Derived by walking the store rather than by reading an index, because an
+    index is a second statement of the same fact and this package's whole thesis
+    is that two statements of one fact diverge. A file whose name is not a valid
+    digest is skipped: it did not come from `store_bytes`, and reporting it as an
+    object would let a stray file impersonate one.
+    """
+    root = store_dir(bag_path) / DIGEST_ALGORITHM
+    if not root.is_dir():
+        return []
+    found = []
+    for path in root.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        prefix = path.parent.name
+        candidate = f"{prefix}{path.name}"
+        if _HEX_DIGEST_RE.match(candidate):
+            found.append(candidate)
+    return sorted(found)

--- a/scripts/workflows/temporal/modules/journal/content_store.py
+++ b/scripts/workflows/temporal/modules/journal/content_store.py
@@ -58,13 +58,15 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import uuid
 from pathlib import Path
 
 from .bag import (DIR_MODE, FILE_MODE, PAYLOAD_DIR, BagError,
                   contained_relpath)
 
 __all__ = ["CONTENT_STORE_DIR", "DIGEST_ALGORITHM", "DIGEST_HEX_LENGTH",
-           "FANOUT", "ContentStoreError", "digest_of_bytes", "validated_digest",
+           "FANOUT", "ContentStoreError", "ObjectMissing", "ObjectCorrupt",
+           "ObjectUnreadable", "digest_of_bytes", "validated_digest",
            "object_relpath", "store_dir", "object_path", "store_bytes",
            "load_object", "has_object", "stored_digests"]
 
@@ -82,7 +84,13 @@ DIGEST_HEX_LENGTH = 64
 # the journal's size budget permits.
 FANOUT = 2
 
-_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{%d}$" % DIGEST_HEX_LENGTH)
+# `\A` and `\Z`, NEVER `^` and `$`, for the reason `bag._RUN_ID_RE` states
+# twelve lines above the function this module reuses: `$` also matches BEFORE a
+# trailing newline, so `"a"*64 + "\n"` satisfied `^[0-9a-f]{64}$` and was
+# composed onto a path by the very function whose docstring says a value that is
+# not 64 lowercase hex characters is refused rather than composed. The rule was
+# already written down in this package and this module did not reach for it.
+_HEX_DIGEST_RE = re.compile(r"\A[0-9a-f]{%d}\Z" % DIGEST_HEX_LENGTH)
 
 
 class ContentStoreError(BagError):
@@ -92,6 +100,42 @@ class ContentStoreError(BagError):
     error in this package is one: entrypoints already print these and the
     message is the diagnostic. A distinct type so a caller can tell a store
     problem from a bag problem without parsing prose.
+    """
+
+
+class ObjectMissing(ContentStoreError):
+    """Nothing is stored under that digest. The check could not be MADE.
+
+    ⚠ A SUBCLASS BECAUSE `verify` HAS TO TELL THESE APART, AND IT WAS TELLING
+    THEM APART BY READING THE MESSAGE. `verify_citation` classified an outcome
+    with `"TAMPERED" in str(exc)` — over prose that embeds the store's own path,
+    which embeds the run id, which `RUN_ID_PERMITTED` allows to contain the
+    letters `TAMPERED`. A run named `TAMPERED-2026` therefore reported every
+    genuinely absent object as a corrupted one: exit 4, and a verdict this
+    module documents as "nothing else in the journal should be trusted".
+
+    The outcome class is a fact about WHAT FAILED, so it is carried by the type
+    of the failure rather than recovered from the sentence describing it.
+    """
+
+
+class ObjectCorrupt(ContentStoreError):
+    """Bytes are stored under that digest and they hash to something else.
+
+    The STORE failed. The citation naming it may be perfectly good.
+    """
+
+
+class ObjectUnreadable(ContentStoreError):
+    """The object file is there and this process could not read it.
+
+    ⚠ NOT `ObjectMissing`, AND THE REMEDY IS WHY. "Nothing was stored under that
+    digest, re-capture the source" is false and actively misleading for an
+    `EACCES`, an `EIO` or a path that has become a directory — the bytes may be
+    perfectly intact behind a permission or a failing disk, and re-capturing
+    would overwrite a record rather than repair it. `verify` reports this in the
+    `tampered` class, which is the class that means "the store is not currently
+    to be trusted" — the true statement here — with the errno in the detail.
     """
 
 
@@ -195,6 +239,13 @@ def store_bytes(bag_path: Path, data: bytes) -> str:
     probe = parent
     while not probe.exists():
         missing.append(probe)
+        # The filesystem-root terminator `root._create_with_mode` carries. This
+        # loop was retyped from it and dropped the line; unreachable on a real
+        # tree because `/` exists, and restored rather than argued about,
+        # because "the copy that diverged is the one nobody re-checked" is this
+        # package's own repeated finding.
+        if probe.parent == probe:
+            break
         probe = probe.parent
     for directory in reversed(missing):
         try:
@@ -212,9 +263,17 @@ def store_bytes(bag_path: Path, data: bytes) -> str:
 
     # Written to a temporary name in the same directory and renamed, so a reader
     # never sees a partial object under a digest that promises complete bytes.
-    # `os.replace` is atomic within a filesystem, and the temp name carries the
-    # pid so two writers in one run cannot collide on it.
-    staging = parent / f".{digest}.{os.getpid()}.part"
+    # `os.replace` is atomic within a filesystem.
+    #
+    # ⚠ THE UNIQUIFIER IS PER-CALL, NOT PER-PROCESS. It carried only the pid,
+    # which is unique across processes and NOT across threads — and a Temporal
+    # worker runs sync activities on a thread pool, which is the shape this
+    # package says the port carries. Two threads capturing the same bytes
+    # collided on one staging name: the loser's `O_EXCL` raised, and its
+    # handler then unlinked the file the WINNER was still writing, so
+    # `os.replace` failed for both and neither capture landed. A per-call name
+    # makes the cleanup unambiguously this call's own file.
+    staging = parent / f".{digest}.{os.getpid()}.{uuid.uuid4().hex}.part"
     try:
         handle = os.open(str(staging), os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
         try:
@@ -254,18 +313,18 @@ def load_object(bag_path: Path, digest: str) -> bytes:
     try:
         data = target.read_bytes()
     except FileNotFoundError:
-        raise ContentStoreError(
+        raise ObjectMissing(
             f"content-store object {digest} is MISSING from {store_dir(bag_path)}. "
             f"Nothing was stored under that digest in this bag, so the citation "
             f"naming it cannot be checked at all.") from None
     except OSError as exc:
-        raise ContentStoreError(
+        raise ObjectUnreadable(
             f"content-store object {digest} could not be read from {target} "
             f"({exc.strerror}).") from exc
 
     actual = digest_of_bytes(data)
     if actual != digest:
-        raise ContentStoreError(
+        raise ObjectCorrupt(
             f"content-store object {digest} is TAMPERED: its bytes hash to "
             f"{actual}. An object is named by its own checksum, so a mismatch "
             f"means the stored bytes were changed after they were filed — the "

--- a/scripts/workflows/temporal/modules/journal/source_fetch.py
+++ b/scripts/workflows/temporal/modules/journal/source_fetch.py
@@ -1,0 +1,296 @@
+"""Getting a source's bytes over the network, under a policy stated in one place.
+
+REQUIREMENT 7(c)'s FETCH POLICY. The phase doc offered a cheap arm — tee an
+existing tool's byte stream and inherit its policy — and a check of this tree
+closed it: `grep -rlE "urllib|requests\\.|httpx|urlopen" --include=*.py scripts/`
+returns nothing, because every citation this fleet reads is fetched by the model
+through its own tooling inside a `claude -p` child. There is no stream to tee, so
+this module is the policy and it is written out rather than inherited.
+
+WHY A POLICY AT ALL, STATED AS THE THREAT AND NOT AS HYGIENE. The URL is
+model-influenceable and may itself have come out of a previously-fetched
+document. Without the rules below this is a server-side request forgery
+primitive whose responses are DURABLY STORED and RE-SERVABLE OFFLINE — which is
+strictly worse than the usual shape, because the attacker's payload outlives the
+request and gets read back by a checker that trusts the store.
+
+THE RULES, EACH WITH THE CASE IT CLOSES:
+
+  * **`https` only.** `http` is unauthenticated in transit, and `file:`, `ftp:`
+    and `data:` reach things that are not a remote source at all. A scheme
+    allowlist rather than a denylist: the schemes `urllib` supports grow.
+  * **Every redirect hop is re-validated.** A permitted URL that redirects to
+    `http://169.254.169.254/` is the standard bypass, so automatic redirect
+    following is switched OFF and each hop re-enters the same checks. A redirect
+    to a non-`https` scheme, or to a refused address, ends the fetch.
+  * **Private, loopback, link-local and unspecified addresses are refused**, for
+    every address the host resolves to rather than for the first. A name with one
+    public and one loopback record must not be reachable by luck of ordering.
+  * **A timeout**, so a hung server cannot hold a run open indefinitely.
+  * **A size cap**, enforced while reading rather than from `Content-Length`,
+    because that header is a claim by the server. The declared length is checked
+    too, as a cheap early refusal, but it is never what stops the read.
+  * **Bytes are stored AS RECEIVED**, and a response carrying a content encoding
+    is REFUSED rather than decoded. The phase doc allows either that or a decoded
+    size cap; refusing is the smaller mechanism, it keeps "the hash is over what
+    the server sent" literally true, and it removes the decompression-bomb case
+    instead of bounding it. `Accept-Encoding: identity` asks for this, and the
+    refusal is what happens when a server ignores the ask.
+
+WHAT THIS DOES NOT CLOSE, SAID PLAINLY SO IT IS NOT OVER-READ. The addresses are
+resolved and checked, and then `urllib` resolves the name again to connect. A
+name that changes its answer between those two moments — DNS rebinding — is not
+caught here. Closing it means connecting to a validated address directly and
+carrying the original host through TLS verification, which is a custom
+connection layer rather than a rule. It is named as a residual rather than
+implied away, and the store's other protection is that a rebound response still
+has to survive `verify` being run by a human who knows what was cited.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlsplit
+
+from .bag import BagError
+
+__all__ = ["ALLOWED_SCHEMES", "DEFAULT_TIMEOUT_SECONDS", "MAX_SOURCE_BYTES",
+           "MAX_REDIRECTS", "USER_AGENT", "FetchRefused", "FetchPolicy",
+           "FetchedSource", "refused_address_reason", "check_url",
+           "resolved_addresses", "fetch_source"]
+
+ALLOWED_SCHEMES = ("https",)
+
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+# One object's ceiling. Generous for a document and far below anything that
+# would matter against the journal's size budget; a source larger than this is
+# a refusal naming the number rather than a silent truncation, because half a
+# page hashed as though it were the page is a citation that verifies against
+# bytes nobody read.
+MAX_SOURCE_BYTES = 8 * 1024 * 1024
+
+MAX_REDIRECTS = 5
+
+# Identifies the fetcher to the operator of the site being read. A request that
+# does not say who it is invites being treated as abuse, and this one is made on
+# behalf of a record that claims to be checkable.
+USER_AGENT = "skyynet-journal-content-store/1 (+persistent-memory-protocol)"
+
+
+class FetchRefused(BagError):
+    """A source was not fetched, and the message says which rule refused it.
+
+    A refusal is the normal outcome for a URL that should not be reached, so it
+    carries the rule's name: an operator reading it needs to know whether the
+    policy worked or the source is simply unreachable.
+    """
+
+
+@dataclass(frozen=True)
+class FetchPolicy:
+    """The numbers the rules above are enforced with. One object, passed down.
+
+    A dataclass rather than module constants read directly, so a test can tighten
+    a bound without monkeypatching the module — and so the values a fetch ran
+    under can be recorded beside what it fetched.
+    """
+
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    max_bytes: int = MAX_SOURCE_BYTES
+    max_redirects: int = MAX_REDIRECTS
+    allowed_schemes: tuple[str, ...] = ALLOWED_SCHEMES
+
+
+@dataclass(frozen=True)
+class FetchedSource:
+    """The bytes, and the trail that produced them."""
+
+    url: str                      # the URL asked for
+    final_url: str                # the URL that answered, after any redirects
+    data: bytes
+    media_type: str | None
+    hops: tuple[str, ...]         # every URL visited, in order, including the first
+
+
+class _NoRedirects(urllib.request.HTTPRedirectHandler):
+    """Turns `urllib`'s automatic redirect following OFF.
+
+    THE POINT IS THE HOP, NOT THE COUNT. `urllib` follows redirects itself and
+    would deliver the final response with the intermediate URLs never having
+    passed a check — so a permitted URL redirecting to a link-local address would
+    be fetched and stored. Returning `None` from every redirect method makes
+    `urllib` raise `HTTPError` on a 3xx instead, which hands the hop back to
+    `fetch_source` to re-validate before it is followed.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: D102
+        return None
+
+
+def refused_address_reason(address: str) -> str | None:
+    """Why this IP may not be fetched from, or `None` if it may.
+
+    Every category is refused by the `ipaddress` module's own classification
+    rather than by a hand-written range table: the ranges are the standard's and
+    a table here would be a second, staler copy of them. `is_global` is not used
+    as the single test because it answers a slightly different question for IPv6
+    and the categories below are what the threat model actually names.
+    """
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return f"{address!r} is not an IP address"
+    for flag, why in (("is_loopback", "a loopback address"),
+                      ("is_link_local", "a link-local address (the cloud metadata range)"),
+                      ("is_private", "a private address"),
+                      ("is_reserved", "a reserved address"),
+                      ("is_multicast", "a multicast address"),
+                      ("is_unspecified", "the unspecified address")):
+        if getattr(ip, flag):
+            return (f"{address} is {why}. The content store fetches sources the "
+                    f"model named, so a URL resolving inside this network would "
+                    f"make the fetcher a way to reach it.")
+    return None
+
+
+def resolved_addresses(host: str, port: int,
+                       resolve=socket.getaddrinfo) -> list[str]:
+    """Every address `host` resolves to, as strings. Injectable for testing.
+
+    `resolve` IS A PARAMETER BECAUSE THE ALTERNATIVE IS AN UNTESTED RULE. The
+    address checks are the security half of this module and the only way to
+    exercise them against a name with a hostile answer, offline and
+    deterministically, is to supply the answer. A default argument keeps every
+    real caller honest without a fixture.
+    """
+    try:
+        infos = resolve(host, port, 0, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise FetchRefused(f"cannot resolve {host!r}: {exc}") from exc
+    addresses = []
+    for info in infos:
+        address = info[4][0]
+        if address not in addresses:
+            addresses.append(address)
+    if not addresses:
+        raise FetchRefused(f"{host!r} resolved to no addresses")
+    return addresses
+
+
+def check_url(url: str, policy: FetchPolicy, resolve=socket.getaddrinfo) -> str:
+    """Prove one URL may be fetched. Returns its host. Refuses otherwise.
+
+    CALLED ON THE ORIGINAL URL AND ON EVERY REDIRECT TARGET, which is the whole
+    reason it is a function rather than a block at the top of `fetch_source`. A
+    check that ran once would be exactly the bypass this policy exists to close.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in policy.allowed_schemes:
+        raise FetchRefused(
+            f"refusing {url!r}: scheme {parts.scheme!r} is not permitted "
+            f"(allowed: {', '.join(policy.allowed_schemes)}). The allowlist is "
+            f"positive rather than a denylist because the set of schemes the "
+            f"URL library supports grows without this module being edited.")
+    if not parts.hostname:
+        raise FetchRefused(f"refusing {url!r}: it names no host")
+
+    port = parts.port or 443
+    for address in resolved_addresses(parts.hostname, port, resolve=resolve):
+        reason = refused_address_reason(address)
+        if reason:
+            raise FetchRefused(f"refusing {url!r}: {reason}")
+    return parts.hostname
+
+
+def _read_capped(response, max_bytes: int, url: str) -> bytes:
+    """Read the body, refusing at `max_bytes` rather than truncating to it.
+
+    THE CAP IS ENFORCED ON THE READ, and the declared length is only a cheap
+    early exit. `Content-Length` is the server's claim about its own body; a
+    fetcher that trusted it would store however many bytes actually arrived.
+    """
+    declared = response.headers.get("Content-Length")
+    if declared and declared.isdigit() and int(declared) > max_bytes:
+        raise FetchRefused(
+            f"refusing {url!r}: it declares {int(declared)} bytes, over the "
+            f"{max_bytes}-byte cap for one stored source.")
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = response.read(64 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise FetchRefused(
+                f"refusing {url!r}: its body exceeds the {max_bytes}-byte cap "
+                f"for one stored source. The read stops here rather than "
+                f"storing a truncation — half a page hashed as though it were "
+                f"the page is a citation that verifies against bytes nobody read.")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def fetch_source(url: str, *, policy: FetchPolicy | None = None,
+                 opener=None, resolve=socket.getaddrinfo) -> FetchedSource:
+    """Fetch one source under the policy. Every hop re-checked; bytes as received.
+
+    `opener` AND `resolve` ARE INJECTABLE FOR THE SAME REASON. The rules this
+    function enforces are the ones that matter, and a test that had to reach a
+    real host to exercise them would be a test that does not run offline — which
+    is the property this whole phase is about.
+    """
+    policy = policy or FetchPolicy()
+    opener = opener or urllib.request.build_opener(_NoRedirects)
+
+    hops: list[str] = []
+    current = url
+    for _ in range(policy.max_redirects + 1):
+        check_url(current, policy, resolve=resolve)
+        hops.append(current)
+
+        request = urllib.request.Request(current, headers={
+            "User-Agent": USER_AGENT,
+            # Asks for no content coding. A server that ignores this is refused
+            # below rather than decoded, which is what keeps "the digest is over
+            # the bytes the server sent" literally true.
+            "Accept-Encoding": "identity",
+        })
+        try:
+            response = opener.open(request, timeout=policy.timeout_seconds)
+        except urllib.error.HTTPError as exc:
+            location = exc.headers.get("Location") if exc.headers else None
+            if exc.code in (301, 302, 303, 307, 308) and location:
+                current = urljoin(current, location)
+                continue
+            raise FetchRefused(
+                f"fetching {current!r} failed: HTTP {exc.code} {exc.reason}") from exc
+        except urllib.error.URLError as exc:
+            raise FetchRefused(f"fetching {current!r} failed: {exc.reason}") from exc
+
+        with response:
+            encoding = (response.headers.get("Content-Encoding") or "").strip().lower()
+            if encoding and encoding != "identity":
+                raise FetchRefused(
+                    f"refusing {current!r}: the response is {encoding}-encoded "
+                    f"and this fetcher stores bytes as received. Decoding here "
+                    f"would mean the stored digest was over something the "
+                    f"server never sent, and would reopen the decompression "
+                    f"case that not decoding closes outright.")
+            data = _read_capped(response, policy.max_bytes, current)
+            media_type = (response.headers.get_content_type()
+                          if hasattr(response.headers, "get_content_type") else None)
+
+        return FetchedSource(url=url, final_url=current, data=data,
+                             media_type=media_type, hops=tuple(hops))
+
+    raise FetchRefused(
+        f"refusing {url!r}: more than {policy.max_redirects} redirects. A chain "
+        f"this long is either a loop or an attempt to tire out the checks each "
+        f"hop re-runs.")

--- a/scripts/workflows/temporal/modules/journal/source_fetch.py
+++ b/scripts/workflows/temporal/modules/journal/source_fetch.py
@@ -81,7 +81,6 @@ MAX_REDIRECTS = 5
 # behalf of a record that claims to be checkable.
 USER_AGENT = "skyynet-journal-content-store/1 (+persistent-memory-protocol)"
 
-
 class FetchRefused(BagError):
     """A source was not fetched, and the message says which rule refused it.
 
@@ -189,7 +188,18 @@ def check_url(url: str, policy: FetchPolicy, resolve=socket.getaddrinfo) -> str:
     reason it is a function rather than a block at the top of `fetch_source`. A
     check that ran once would be exactly the bypass this policy exists to close.
     """
-    parts = urlsplit(url)
+    # ⚠ `urlsplit` AND `.port` BOTH RAISE `ValueError`, AND THIS FUNCTION
+    # PROMISES `FetchRefused`. `https://[::1` is an "Invalid IPv6 URL" and
+    # `https://host:99999/` is a port out of range; both escaped past every
+    # caller catching the documented refusal type, so a malformed URL crashed
+    # the capture activity instead of being recorded as a policy refusal. A
+    # boundary that validates input must return its own refusal for every bad
+    # input, including the ones the parser rejects before the rules run.
+    try:
+        parts = urlsplit(url)
+        port = parts.port or 443
+    except ValueError as exc:
+        raise FetchRefused(f"refusing {url!r}: it is not a parseable URL ({exc})") from exc
     if parts.scheme not in policy.allowed_schemes:
         raise FetchRefused(
             f"refusing {url!r}: scheme {parts.scheme!r} is not permitted "
@@ -199,7 +209,6 @@ def check_url(url: str, policy: FetchPolicy, resolve=socket.getaddrinfo) -> str:
     if not parts.hostname:
         raise FetchRefused(f"refusing {url!r}: it names no host")
 
-    port = parts.port or 443
     for address in resolved_addresses(parts.hostname, port, resolve=resolve):
         reason = refused_address_reason(address)
         if reason:

--- a/scripts/workflows/temporal/modules/journal/validate.py
+++ b/scripts/workflows/temporal/modules/journal/validate.py
@@ -323,6 +323,11 @@ def main(argv: list[str] | None = None) -> int:
     Exit 0 only if every bag validated. A flag is NOT a failure — a redacted or
     incomplete bag whose bytes match its manifest exits 0, because those flags
     describe the run and `ok` describes the bytes.
+
+    EXIT CODES: 0 every bag valid · 1 a bag failed validation · 2 usage (no
+    argument, a target that is not a directory, or a directory holding no bags).
+    1 and 2 are kept apart deliberately: an operator typo and a corrupt journal
+    need opposite remedies, so they must not share a number.
     """
     args = list(sys.argv[1:] if argv is None else argv)
     if not args:
@@ -332,7 +337,20 @@ def main(argv: list[str] | None = None) -> int:
     reports: list[BagReport] = []
     for raw in args:
         target = Path(raw).expanduser()
-        if (target / BAGIT_FILE).is_file() or not target.is_dir():
+        # A PATH THE OPERATOR NAMED THAT IS NOT THERE IS USAGE, NOT A FAILED BAG.
+        # Routing it into `validate_bag` printed a full `result: FAIL` report —
+        # asserting `lifecycle`, `redacted`, `incomplete` and a payload size about
+        # a bag that does not exist — and exited 1, the code that means a bag's
+        # bytes did not match its manifest. On the tool an operator reaches for
+        # BECAUSE the journal is what has gone wrong, that answers a typo with
+        # "your journal is broken". Same rule `verify.main` applies, and the two
+        # deliberately agree here even though they deliberately disagree about
+        # what `validate_bag`/`verify_bag` return for the same path: the
+        # programmatic structural result below is for callers, not for operators.
+        if not target.is_dir():
+            print(f"not a directory: {target}", file=sys.stderr)
+            return 2
+        if (target / BAGIT_FILE).is_file():
             reports.append(validate_bag(target))
             continue
         children = sorted(p for p in target.iterdir() if p.is_dir())

--- a/scripts/workflows/temporal/modules/journal/verify.py
+++ b/scripts/workflows/temporal/modules/journal/verify.py
@@ -41,9 +41,14 @@ what gets over-read.
 
 OFFLINE IS A PROPERTY OF THE CODE, NOT A PROMISE IN A DOCSTRING. Nothing in this
 module's import graph opens a socket: it reads files and, for a `git:` citation,
-runs `git cat-file` against a local object database. `test_verify_is_offline.py`
-asserts the import graph, and the phase's demonstration runs the whole thing with
-the process's network denied at the C library boundary.
+runs `git cat-file` against a local object database.
+`tests/unit/test_verify_citations.py::test_the_verifier_reaches_no_fetcher`
+asserts that intra-package import closure — with a discriminator beside it that
+starts the same walk at `content_activities`, which legitimately does reach the
+fetcher — and the phase's demonstration runs the whole thing with the process's
+network denied at the C library boundary. (The named test is the real guard; the
+file `test_verify_is_offline.py` this line used to cite has never existed, which
+is a claim about a property nobody could go and check.)
 """
 
 from __future__ import annotations
@@ -53,16 +58,17 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .bag import BAGIT_FILE
+from .bag import BAGIT_FILE, BagError
 from .citations import (Citation, CitationError, is_git_ref, parse_git_ref,
                         read_citations, stage_evidence_hashes)
-from .content_store import ContentStoreError, load_object
+from .content_store import ContentStoreError, ObjectMissing, load_object
 
 __all__ = ["VERIFIED", "MISSING", "TAMPERED", "SPAN_MISSING", "OUTCOMES",
            "EXIT_OK", "EXIT_MISSING", "EXIT_TAMPERED", "EXIT_SPAN_MISSING",
-           "EXIT_USAGE", "SEVERITY", "GIT_TIMEOUT_SECONDS", "CitationResult",
-           "VerifyReport", "span_occurs_in", "git_blob", "verify_citation",
-           "verify_bag", "render_report", "exit_code_for", "split_args", "main"]
+           "EXIT_STRUCTURAL", "EXIT_USAGE", "SEVERITY", "GIT_TIMEOUT_SECONDS",
+           "GitResolveError", "CitationResult", "VerifyReport",
+           "span_occurs_in", "git_blob", "verify_citation", "verify_bag",
+           "render_report", "exit_code_for", "split_args", "main"]
 
 VERIFIED = "verified"
 MISSING = "missing"
@@ -71,24 +77,56 @@ SPAN_MISSING = "span-missing"
 OUTCOMES = (VERIFIED, MISSING, TAMPERED, SPAN_MISSING)
 
 EXIT_OK = 0
-# 2 is left to usage, matching `validate_bag.py`, so a wrong invocation and a
-# real finding are never the same number.
+# 2 is left to usage ALONE, matching `validate_bag.py`, so a wrong invocation and
+# a real finding are never the same number. That sentence was false when it was
+# written — `exit_code_for` returned this for a structural finding — and
+# `EXIT_STRUCTURAL` below is what makes it true.
 EXIT_USAGE = 2
 EXIT_MISSING = 3
 EXIT_TAMPERED = 4
 EXIT_SPAN_MISSING = 5
+# ⚠ ITS OWN CODE, BECAUSE IT USED TO BE 2 AND THAT MADE THE COMMENT ABOVE FALSE.
+# A bag whose `citations.jsonl` cannot be parsed is a REAL FINDING — the record
+# of what was claimed is unreadable — and it exited with the number reserved for
+# "you invoked me wrong". Automation reading 2 as a usage error discards it, and
+# the report says FAIL while the code says try-again-with-better-arguments.
+# Ranked ABOVE `tampered`: a tampered object invalidates one verdict, an
+# unreadable record means the verdicts were never enumerable at all.
+EXIT_STRUCTURAL = 6
+
+# The name of the structural class inside `SEVERITY`. Not an outcome a citation
+# can carry — no citation was reached — so it is not in `OUTCOMES` and never
+# appears in `counts()`.
+STRUCTURAL = "structural"
 
 # WHICH CODE A MIXED RUN EXITS WITH, ordered by how much of the report the
 # outcome invalidates rather than by how bad it sounds. A tampered object means
 # the store itself is untrustworthy, so every other verdict in the same run is
 # provisional; a missing object means one check could not be made; a
-# span-missing is a complete, trustworthy check with a negative answer. Stated
-# as data because a caller reading the exit code needs the same ordering the
-# report used.
-SEVERITY = {TAMPERED: 3, MISSING: 2, SPAN_MISSING: 1, VERIFIED: 0}
+# span-missing is a complete, trustworthy check with a negative answer; and a
+# structural finding outranks all of them because it means the citations were
+# never enumerated at all. Stated as data because a caller reading the exit code
+# needs the same ordering the report used.
+SEVERITY = {STRUCTURAL: 4, TAMPERED: 3, MISSING: 2, SPAN_MISSING: 1,
+            VERIFIED: 0}
 
 _EXIT_FOR = {VERIFIED: EXIT_OK, MISSING: EXIT_MISSING,
-             TAMPERED: EXIT_TAMPERED, SPAN_MISSING: EXIT_SPAN_MISSING}
+             TAMPERED: EXIT_TAMPERED, SPAN_MISSING: EXIT_SPAN_MISSING,
+             STRUCTURAL: EXIT_STRUCTURAL}
+
+
+class GitResolveError(BagError):
+    """A `git:` citation could not be produced from a git object database.
+
+    ⚠ NOT A `ContentStoreError`, WHICH IS WHAT IT WAS. `verify_citation` now
+    branches on exception TYPE to choose an outcome, and `ContentStoreError`
+    means "the content store failed" — so git-not-installed and a git timeout
+    were arriving in the branch that classifies store failures. The two
+    resolvers fail for unrelated reasons and a caller must be able to tell them
+    apart without reading prose, which is the defect this whole file just paid
+    for once.
+    """
+
 
 # `git cat-file` against a local object database answers in milliseconds. The
 # bound exists because an unbounded subprocess in a checker is how a verify run
@@ -136,7 +174,17 @@ class VerifyReport:
 
     @property
     def worst(self) -> str:
-        """The outcome this report exits on. `verified` when there is nothing worse."""
+        """The class this report exits on. `verified` when there is nothing worse.
+
+        ⚠ STRUCTURAL IS RANKED HERE AND NOT ONLY IN `exit_code_for`. This
+        property returned `verified` for a report whose `ok` was False, because
+        it ranked `results` and ignored `structural` — so the obviously-named
+        property said "nothing wrong" for the one report class that means the
+        citations were never enumerated. Two derivations of one severity is the
+        shape that produced the exit-code defect one field up.
+        """
+        if self.structural:
+            return STRUCTURAL
         return max((r.outcome for r in self.results),
                    key=lambda o: SEVERITY[o], default=VERIFIED)
 
@@ -176,19 +224,27 @@ def git_blob(repo_root: Path, sha: str, path: str | None) -> bytes:
     """
     target = f"{sha}:{path}" if path else sha
     try:
+        # `timeout=` directly rather than `assistant_activities.run_bounded`:
+        # `modules/journal/` does not import upward into the workflow modules,
+        # which is the dependency rule this package's `__init__` states. The
+        # bound is the property the fleet-wide guard checks, and it is here.
         probe = subprocess.run(["git", "cat-file", "-p", target],
                                cwd=str(repo_root), capture_output=True,
                                timeout=GIT_TIMEOUT_SECONDS)
     except FileNotFoundError as exc:
-        raise ContentStoreError(
+        raise GitResolveError(
             f"cannot resolve {target}: git is not installed or not on PATH in "
             f"this environment.") from exc
     except subprocess.TimeoutExpired as exc:
-        raise ContentStoreError(
+        raise GitResolveError(
             f"cannot resolve {target}: `git cat-file` did not answer within "
             f"{GIT_TIMEOUT_SECONDS:.0f}s in {repo_root}.") from exc
+    except OSError as exc:
+        raise GitResolveError(
+            f"cannot resolve {target}: `git cat-file` could not be launched in "
+            f"{repo_root} ({exc.strerror}).") from exc
     if probe.returncode != 0:
-        raise ContentStoreError(
+        raise GitResolveError(
             f"{target} is MISSING from the git object database at {repo_root}: "
             f"{probe.stderr.decode('utf-8', errors='replace').strip()[:200]}")
     return probe.stdout
@@ -216,14 +272,28 @@ def verify_citation(bag_path: Path, citation: Citation, *,
         sha, path = parse_git_ref(citation.source_ref)
         try:
             data = git_blob(repo_root, sha, path)
-        except ContentStoreError as exc:
+        except GitResolveError as exc:
             return result(MISSING, str(exc))
     else:
+        # ⚠ THE OUTCOME COMES FROM THE EXCEPTION TYPE, NOT FROM ITS MESSAGE.
+        # This asked `"TAMPERED" in str(exc)` — of prose that embeds the store
+        # directory, which embeds the run id, which `RUN_ID_PERMITTED` allows to
+        # contain those letters. A run named `TAMPERED-2026` reported every
+        # ABSENT object as a corrupted one. The outcome class is a fact about
+        # what failed and is carried by the failure.
+        #
+        # Everything that is not `ObjectMissing` lands in `tampered`, which is
+        # the class that means "the store is not currently to be trusted" — the
+        # true statement for a corrupt object AND for one that is present and
+        # unreadable. `missing` is reserved for "nothing was stored", because
+        # its remedy is "re-capture the source" and that is destructive advice
+        # for bytes that are merely behind a failing disk.
         try:
             data = load_object(bag_path, citation.page_content_hash)
+        except ObjectMissing as exc:
+            return result(MISSING, str(exc))
         except ContentStoreError as exc:
-            message = str(exc)
-            return result(TAMPERED if "TAMPERED" in message else MISSING, message)
+            return result(TAMPERED, str(exc))
 
     if not span_occurs_in(citation.quote, data):
         return result(
@@ -247,11 +317,20 @@ def verify_bag(bag_path: Path, *, repo_root: Path | None = None) -> VerifyReport
                             structural=(f"{bag_path} is not a directory",))
     try:
         citations = read_citations(bag_path)
-    except CitationError as exc:
+    except (CitationError, OSError, ValueError) as exc:
         # A citation FILE that cannot be parsed is structural: it is not one
         # claim failing, it is the record of what was claimed being unreadable,
         # and reporting it as a per-citation outcome would understate it.
-        return VerifyReport(path=bag_path, structural=(str(exc),))
+        #
+        # ⚠ AND THAT INCLUDES A FILESYSTEM OR DECODE ERROR — the half
+        # `validate_bag` already paid for and documented, and this function did
+        # not carry across. Only `CitationError` was caught, so a
+        # `citations.jsonl` holding non-UTF-8 bytes raised `UnicodeDecodeError`
+        # (a `ValueError`) straight out of the sweep, and a permission failure
+        # or a file that vanished mid-`rglob` raised `OSError`. One such bag
+        # killed a whole-journal run and reported nothing about the other 47 —
+        # verbatim the regression `validate.py` records against itself.
+        return VerifyReport(path=bag_path, structural=(f"{type(exc).__name__}: {exc}",))
 
     results = tuple(verify_citation(bag_path, c, repo_root=repo_root)
                     for c in citations)
@@ -260,9 +339,14 @@ def verify_bag(bag_path: Path, *, repo_root: Path | None = None) -> VerifyReport
 
 
 def exit_code_for(reports: list[VerifyReport]) -> int:
-    """The code the run exits with: the most severe outcome anywhere in it."""
-    if any(r.structural for r in reports):
-        return EXIT_USAGE
+    """The code the run exits with: the most severe class anywhere in it.
+
+    ONE RANKING, APPLIED ONCE. This short-circuited on `structural` and returned
+    `EXIT_USAGE` before the ranking ran, so a sweep containing one unparseable
+    record and one tampered object exited 2 — the number the entrypoint
+    documents as "usage" — and the integrity finding was reported to a caller
+    that had been told it had merely typed the command wrong.
+    """
     worst = max((r.worst for r in reports), key=lambda o: SEVERITY[o],
                 default=VERIFIED)
     return _EXIT_FOR[worst]
@@ -331,6 +415,9 @@ def main(argv: list[str] | None = None) -> int:
     `--repo` supplies the repository `git:` citations resolve against. Without
     it those citations report `missing` and say why, which is honest: this run
     could not make the check, rather than the check having failed.
+
+    EXIT CODES: 0 verified · 2 usage · 3 missing · 4 tampered · 5 span-missing ·
+    6 structural (a bag exists and its citation record cannot be read).
     """
     args = list(sys.argv[1:] if argv is None else argv)
     try:
@@ -347,7 +434,14 @@ def main(argv: list[str] | None = None) -> int:
     reports: list[VerifyReport] = []
     for raw in targets:
         target = Path(raw).expanduser()
-        if (target / BAGIT_FILE).is_file() or not target.is_dir():
+        # A PATH THE OPERATOR NAMED THAT IS NOT THERE IS USAGE, and it is
+        # separated here so that `EXIT_STRUCTURAL` means one thing only: a bag
+        # that exists and whose record cannot be read. Collapsing the two is
+        # what put a real finding behind the usage code.
+        if not target.is_dir():
+            print(f"not a directory: {target}", file=sys.stderr)
+            return EXIT_USAGE
+        if (target / BAGIT_FILE).is_file():
             reports.append(verify_bag(target, repo_root=repo_root))
             continue
         children = sorted(p for p in target.iterdir() if p.is_dir())

--- a/scripts/workflows/temporal/modules/journal/verify.py
+++ b/scripts/workflows/temporal/modules/journal/verify.py
@@ -1,0 +1,345 @@
+"""Re-check every citation in a bag from the stored bytes alone. No network.
+
+REQUIREMENTS 2, 3, 4 AND 7(d). This module is `content_store.load_object` run
+over everything — not a second implementation of resolving, which is what r7(d)
+rules and what keeps the bulk check and the single read from ever disagreeing.
+
+FOUR OUTCOMES, FOUR EXIT CODES, AND COLLAPSING THEM IS THE FAILURE THIS EXISTS
+TO PREVENT. Requirement 3 names three and requirement 4 splits a fourth out of
+them, and each has a different remedy, which is the test for whether a
+distinction is worth an exit code:
+
+  `verified`      the stored bytes hash to the digest the citation names, and the
+                  quoted span still occurs in them. Nothing to do.
+  `missing`       nothing is stored under that digest, or git cannot produce that
+                  object. The check could not be MADE — re-capture the source.
+  `tampered`      bytes are stored under that digest and they hash to something
+                  else. The STORE failed; the citation may be perfectly good.
+                  Nothing else in the journal should be trusted until this is
+                  understood.
+  `span-missing`  the bytes are intact and the quote is not in them. The STORE is
+                  fine and the CITATION was wrong when it was made. This is the
+                  one outcome that is an epistemic finding rather than an
+                  integrity one, which is exactly why requirement 4 refuses to
+                  let it share an exit code with a changed hash.
+
+WHAT A CLEAN RUN PROVES, AND THE THREE THINGS IT DOES NOT. It proves the bytes
+this claim was made against are the bytes still on disk and the quoted span is
+still in them. It does NOT prove the claim is true — a correct quotation from a
+wrong source verifies clean. It does NOT prove the live source still says this;
+the store is a snapshot, and an upstream page that changed after capture is a
+currency question this phase does not own. It does NOT prove the record is
+authentic: a digest computed by the party that can write the store is
+regenerable by that party, so this detects accident and transport corruption and
+not a party with write access.
+
+AND IT REPORTS THE CAPTURE PROVENANCE PER CITATION rather than asserting a
+guarantee. A `harvest` row's hash proves its bytes matched at harvest, not that
+the claim was made against them; a `read-time` row's does. The verifier says
+which, per row, because a single global sentence about the guarantee is exactly
+what gets over-read.
+
+OFFLINE IS A PROPERTY OF THE CODE, NOT A PROMISE IN A DOCSTRING. Nothing in this
+module's import graph opens a socket: it reads files and, for a `git:` citation,
+runs `git cat-file` against a local object database. `test_verify_is_offline.py`
+asserts the import graph, and the phase's demonstration runs the whole thing with
+the process's network denied at the C library boundary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .bag import BAGIT_FILE
+from .citations import (Citation, CitationError, is_git_ref, parse_git_ref,
+                        read_citations, stage_evidence_hashes)
+from .content_store import ContentStoreError, load_object
+
+__all__ = ["VERIFIED", "MISSING", "TAMPERED", "SPAN_MISSING", "OUTCOMES",
+           "EXIT_OK", "EXIT_MISSING", "EXIT_TAMPERED", "EXIT_SPAN_MISSING",
+           "EXIT_USAGE", "SEVERITY", "GIT_TIMEOUT_SECONDS", "CitationResult",
+           "VerifyReport", "span_occurs_in", "git_blob", "verify_citation",
+           "verify_bag", "render_report", "exit_code_for", "main"]
+
+VERIFIED = "verified"
+MISSING = "missing"
+TAMPERED = "tampered"
+SPAN_MISSING = "span-missing"
+OUTCOMES = (VERIFIED, MISSING, TAMPERED, SPAN_MISSING)
+
+EXIT_OK = 0
+# 2 is left to usage, matching `validate_bag.py`, so a wrong invocation and a
+# real finding are never the same number.
+EXIT_USAGE = 2
+EXIT_MISSING = 3
+EXIT_TAMPERED = 4
+EXIT_SPAN_MISSING = 5
+
+# WHICH CODE A MIXED RUN EXITS WITH, ordered by how much of the report the
+# outcome invalidates rather than by how bad it sounds. A tampered object means
+# the store itself is untrustworthy, so every other verdict in the same run is
+# provisional; a missing object means one check could not be made; a
+# span-missing is a complete, trustworthy check with a negative answer. Stated
+# as data because a caller reading the exit code needs the same ordering the
+# report used.
+SEVERITY = {TAMPERED: 3, MISSING: 2, SPAN_MISSING: 1, VERIFIED: 0}
+
+_EXIT_FOR = {VERIFIED: EXIT_OK, MISSING: EXIT_MISSING,
+             TAMPERED: EXIT_TAMPERED, SPAN_MISSING: EXIT_SPAN_MISSING}
+
+# `git cat-file` against a local object database answers in milliseconds. The
+# bound exists because an unbounded subprocess in a checker is how a verify run
+# hangs a machine, and this fleet bounds every subprocess it launches.
+GIT_TIMEOUT_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class CitationResult:
+    """One citation's verdict, and enough context to act on it."""
+
+    claim_id: str
+    stage: str
+    outcome: str
+    capture: str
+    source_ref: str
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome == VERIFIED
+
+
+@dataclass(frozen=True)
+class VerifyReport:
+    """Every citation in one bag, plus requirement 5's per-stage evidence hashes."""
+
+    path: Path
+    results: tuple[CitationResult, ...] = ()
+    evidence_hashes: dict[str, str] = field(default_factory=dict)
+    structural: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        """DERIVED, NEVER STORED — same rule `BagReport.ok` keeps one module over.
+
+        A `PASS` printed above a tampered object is the single worst thing a
+        checker can emit, and a stored field is what makes one constructible.
+        """
+        return not self.structural and all(r.ok for r in self.results)
+
+    def counts(self) -> dict[str, int]:
+        return {outcome: sum(1 for r in self.results if r.outcome == outcome)
+                for outcome in OUTCOMES}
+
+    @property
+    def worst(self) -> str:
+        """The outcome this report exits on. `verified` when there is nothing worse."""
+        return max((r.outcome for r in self.results),
+                   key=lambda o: SEVERITY[o], default=VERIFIED)
+
+
+def span_occurs_in(quote: str, data: bytes) -> bool:
+    """Whether the quoted span still occurs in these bytes.
+
+    DECODED PERMISSIVELY AND COMPARED ON WHITESPACE-NORMALISED TEXT, and both
+    halves are deliberate. `errors="replace"` means a page that is not valid
+    UTF-8 produces a span answer rather than an exception — a decode failure
+    would be reported as an integrity problem when the integrity is fine.
+    Normalising runs of whitespace is what makes a quote survive the source
+    being re-wrapped, which is the overwhelmingly common shape of a quote a
+    human or a model copied out of rendered text.
+
+    WHAT IT DOES NOT DO: it does not strip markup, so a quote taken from
+    rendered HTML may not occur in the HTML bytes. That is a real limit, it
+    produces a `span-missing` rather than a wrong `verified`, and closing it
+    means storing a rendered form beside the raw one — a bigger mechanism than
+    this phase is scoped to, and one that would put a DERIVED artifact in a
+    store whose whole guarantee is that it holds what was received.
+    """
+    text = data.decode("utf-8", errors="replace")
+    return " ".join(quote.split()) in " ".join(text.split())
+
+
+def git_blob(repo_root: Path, sha: str, path: str | None) -> bytes:
+    """The bytes of a code citation, out of the local git object database.
+
+    REQUIREMENT 6 — CODE IS RESOLVED FROM GIT AND NEVER COPIED INTO THE STORE.
+    Git is already content-addressed, so a second copy under a second checksum
+    would be two names for one guarantee and the copy is the one that can drift.
+
+    NO TAMPERED OUTCOME IS POSSIBLE HERE and that is a property of git rather
+    than an omission: git verifies an object against its own name on read, so a
+    corrupt object fails to be produced at all and arrives here as `missing`.
+    """
+    target = f"{sha}:{path}" if path else sha
+    try:
+        probe = subprocess.run(["git", "cat-file", "-p", target],
+                               cwd=str(repo_root), capture_output=True,
+                               timeout=GIT_TIMEOUT_SECONDS)
+    except FileNotFoundError as exc:
+        raise ContentStoreError(
+            f"cannot resolve {target}: git is not installed or not on PATH in "
+            f"this environment.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ContentStoreError(
+            f"cannot resolve {target}: `git cat-file` did not answer within "
+            f"{GIT_TIMEOUT_SECONDS:.0f}s in {repo_root}.") from exc
+    if probe.returncode != 0:
+        raise ContentStoreError(
+            f"{target} is MISSING from the git object database at {repo_root}: "
+            f"{probe.stderr.decode('utf-8', errors='replace').strip()[:200]}")
+    return probe.stdout
+
+
+def verify_citation(bag_path: Path, citation: Citation, *,
+                    repo_root: Path | None = None) -> CitationResult:
+    """One citation, resolved from the store alone and re-checked. Never fetches.
+
+    THE ORDER OF THE TWO CHECKS IS THE DIAGNOSIS. Resolve first — which
+    re-hashes, and separates `missing` from `tampered` — and only then look for
+    the span. A span check run against bytes that failed their own hash would
+    report a wrong quote when the real finding is a corrupt store.
+    """
+    def result(outcome: str, detail: str = "") -> CitationResult:
+        return CitationResult(claim_id=citation.claim_id, stage=citation.stage,
+                              outcome=outcome, capture=citation.capture,
+                              source_ref=citation.source_ref, detail=detail)
+
+    if is_git_ref(citation.source_ref):
+        if repo_root is None:
+            return result(MISSING,
+                          "a git citation needs a repository to resolve against; "
+                          "none was given to this run")
+        sha, path = parse_git_ref(citation.source_ref)
+        try:
+            data = git_blob(repo_root, sha, path)
+        except ContentStoreError as exc:
+            return result(MISSING, str(exc))
+    else:
+        try:
+            data = load_object(bag_path, citation.page_content_hash)
+        except ContentStoreError as exc:
+            message = str(exc)
+            return result(TAMPERED if "TAMPERED" in message else MISSING, message)
+
+    if not span_occurs_in(citation.quote, data):
+        return result(
+            SPAN_MISSING,
+            f"the stored bytes are intact and the quoted span does not occur in "
+            f"them. The store is fine; this citation was wrong when it was made. "
+            f"Quote: {citation.quote[:120]!r}")
+    return result(VERIFIED)
+
+
+def verify_bag(bag_path: Path, *, repo_root: Path | None = None) -> VerifyReport:
+    """Every citation in one bag, plus the per-stage evidence hashes.
+
+    A BAG WITH NO CITATIONS IS NOT A FAILURE, for the reason an open bag is not
+    a failed bag one module over: most runs cite nothing, and a checker that
+    called them broken would make its own output unreadable. It is reported as
+    zero citations, which is a fact rather than a verdict.
+    """
+    if not bag_path.is_dir():
+        return VerifyReport(path=bag_path,
+                            structural=(f"{bag_path} is not a directory",))
+    try:
+        citations = read_citations(bag_path)
+    except CitationError as exc:
+        # A citation FILE that cannot be parsed is structural: it is not one
+        # claim failing, it is the record of what was claimed being unreadable,
+        # and reporting it as a per-citation outcome would understate it.
+        return VerifyReport(path=bag_path, structural=(str(exc),))
+
+    results = tuple(verify_citation(bag_path, c, repo_root=repo_root)
+                    for c in citations)
+    return VerifyReport(path=bag_path, results=results,
+                        evidence_hashes=stage_evidence_hashes(citations))
+
+
+def exit_code_for(reports: list[VerifyReport]) -> int:
+    """The code the run exits with: the most severe outcome anywhere in it."""
+    if any(r.structural for r in reports):
+        return EXIT_USAGE
+    worst = max((r.worst for r in reports), key=lambda o: SEVERITY[o],
+                default=VERIFIED)
+    return _EXIT_FOR[worst]
+
+
+def render_report(report: VerifyReport) -> str:
+    """Human-readable, and every outcome class is printed even at zero.
+
+    The always is the contract, same as `validate.render_report`: a reader who
+    sees `tampered: 0` learns something, and a reader of a report that simply
+    omits the line cannot tell zero from not-looked-for.
+    """
+    counts = report.counts()
+    lines = [
+        f"bag        : {report.path}",
+        f"result     : {'PASS' if report.ok else 'FAIL'}",
+        f"citations  : {len(report.results)}",
+        "  " + "  ".join(f"{outcome}: {counts[outcome]}" for outcome in OUTCOMES),
+    ]
+    for item in report.structural:
+        lines.append(f"  structural: {item}")
+    for result in report.results:
+        if result.ok:
+            continue
+        lines.append(f"  {result.outcome}: [{result.stage}] {result.claim_id} "
+                     f"({result.capture}) {result.source_ref}")
+        if result.detail:
+            lines.append(f"      {result.detail}")
+    for stage, digest in report.evidence_hashes.items():
+        lines.append(f"  evidence_set_hash[{stage}]: {digest}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Verify one bag or every bag directly under one journal root.
+
+    `--repo` supplies the repository `git:` citations resolve against. Without
+    it those citations report `missing` and say why, which is honest: this run
+    could not make the check, rather than the check having failed.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    repo_root: Path | None = None
+    targets: list[str] = []
+    index = 0
+    while index < len(args):
+        if args[index] == "--repo":
+            if index + 1 >= len(args):
+                print("--repo needs a path", file=sys.stderr)
+                return EXIT_USAGE
+            repo_root = Path(args[index + 1]).expanduser()
+            index += 2
+            continue
+        targets.append(args[index])
+        index += 1
+
+    if not targets:
+        print("usage: verify_citations.py [--repo <path>] <bag-dir-or-journal-root> [...]",
+              file=sys.stderr)
+        return EXIT_USAGE
+
+    reports: list[VerifyReport] = []
+    for raw in targets:
+        target = Path(raw).expanduser()
+        if (target / BAGIT_FILE).is_file() or not target.is_dir():
+            reports.append(verify_bag(target, repo_root=repo_root))
+            continue
+        children = sorted(p for p in target.iterdir() if p.is_dir())
+        if not children:
+            print(f"no bags under {target}", file=sys.stderr)
+            return EXIT_USAGE
+        reports.extend(verify_bag(child, repo_root=repo_root) for child in children)
+
+    for report in reports:
+        print(render_report(report))
+        print()
+
+    total = sum(len(r.results) for r in reports)
+    failed = sum(1 for r in reports for result in r.results if not result.ok)
+    print(f"{total - failed}/{total} citations verified across {len(reports)} bag(s)")
+    return exit_code_for(reports)

--- a/scripts/workflows/temporal/modules/journal/verify.py
+++ b/scripts/workflows/temporal/modules/journal/verify.py
@@ -62,7 +62,7 @@ __all__ = ["VERIFIED", "MISSING", "TAMPERED", "SPAN_MISSING", "OUTCOMES",
            "EXIT_OK", "EXIT_MISSING", "EXIT_TAMPERED", "EXIT_SPAN_MISSING",
            "EXIT_USAGE", "SEVERITY", "GIT_TIMEOUT_SECONDS", "CitationResult",
            "VerifyReport", "span_occurs_in", "git_blob", "verify_citation",
-           "verify_bag", "render_report", "exit_code_for", "main"]
+           "verify_bag", "render_report", "exit_code_for", "split_args", "main"]
 
 VERIFIED = "verified"
 MISSING = "missing"
@@ -268,6 +268,35 @@ def exit_code_for(reports: list[VerifyReport]) -> int:
     return _EXIT_FOR[worst]
 
 
+def split_args(args: list[str]) -> tuple[Path | None, list[str]]:
+    """`(repo_root, targets)` out of an argument list. One parse, two callers.
+
+    EXTRACTED BECAUSE THE SECOND COPY WAS ALREADY WRONG. `verify_citations.py`
+    needs to know whether any TARGET was given, so it can fall back to the
+    configured journal root — and it asked that question with a filter over the
+    raw arguments, which counted `--repo`'s own VALUE as a target. The result
+    was that `verify_citations.py --repo <path>`, with no bag named, printed a
+    usage message instead of verifying the configured root. Two hand-written
+    parses of one grammar is the shape this package keeps finding in itself.
+
+    Raises `ValueError` when `--repo` is given without a path, so the caller
+    owns the exit code and the message reaches whichever stream it writes to.
+    """
+    repo_root: Path | None = None
+    targets: list[str] = []
+    index = 0
+    while index < len(args):
+        if args[index] == "--repo":
+            if index + 1 >= len(args):
+                raise ValueError("--repo needs a path")
+            repo_root = Path(args[index + 1]).expanduser()
+            index += 2
+            continue
+        targets.append(args[index])
+        index += 1
+    return repo_root, targets
+
+
 def render_report(report: VerifyReport) -> str:
     """Human-readable, and every outcome class is printed even at zero.
 
@@ -304,19 +333,11 @@ def main(argv: list[str] | None = None) -> int:
     could not make the check, rather than the check having failed.
     """
     args = list(sys.argv[1:] if argv is None else argv)
-    repo_root: Path | None = None
-    targets: list[str] = []
-    index = 0
-    while index < len(args):
-        if args[index] == "--repo":
-            if index + 1 >= len(args):
-                print("--repo needs a path", file=sys.stderr)
-                return EXIT_USAGE
-            repo_root = Path(args[index + 1]).expanduser()
-            index += 2
-            continue
-        targets.append(args[index])
-        index += 1
+    try:
+        repo_root, targets = split_args(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return EXIT_USAGE
 
     if not targets:
         print("usage: verify_citations.py [--repo <path>] <bag-dir-or-journal-root> [...]",

--- a/scripts/workflows/temporal/scripts/verify_citations.py
+++ b/scripts/workflows/temporal/scripts/verify_citations.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Re-check every citation in a bag, from the stored bytes alone. No network.
+
+    verify_citations.py <bag-dir>                     # one run
+    verify_citations.py <journal-root>                # every bag directly under it
+    verify_citations.py                               # the configured root, read-only
+    verify_citations.py --repo <path> <bag-dir>       # also resolve `git:` citations
+
+THE OPERATOR-FACING HALF OF REQUIREMENTS 2, 3 AND 4, and the sibling of
+`validate_bag.py` beside it: that tool answers *do the bag's bytes match its
+manifest*, this one answers *do the claims in it still stand against the sources
+they were made from*. Two questions, two tools, because a bag can be perfectly
+intact and hold a citation whose quote was never in its source.
+
+EXIT CODE NAMES THE OUTCOME CLASS, WHICH IS WHY THERE ARE FOUR AND NOT A BOOLEAN:
+
+    0  every citation verified
+    2  usage, or a citation record that could not be parsed at all
+    3  missing    — nothing stored under that digest; the check could not be MADE
+    4  tampered   — stored bytes do not hash to their own name; the STORE failed
+    5  span-miss  — bytes intact, quote absent; the CITATION was wrong when made
+
+A run with several classes exits on the most severe, ordered by how much of the
+report it invalidates: tampered, then missing, then span-missing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.journal import verify  # noqa: E402
+from modules.journal.journal_activities import load_journal_config  # noqa: E402
+from modules.journal.root import resolve_journal_root  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    # `create=False` for the reason `validate_bag.py` gives: a diagnostic must
+    # not bring the thing it is diagnosing into existence. An operator whose
+    # root is missing needs to be told so, not handed a fresh empty directory.
+    if not [a for a in args if a != "--repo" and not a.startswith("-")]:
+        try:
+            root = resolve_journal_root(config=load_journal_config(), create=False)
+        except RuntimeError as exc:
+            print(f"\n✗ {exc}", file=sys.stderr)
+            return verify.EXIT_USAGE
+        args = args + [str(root)]
+    return verify.main(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflows/temporal/scripts/verify_citations.py
+++ b/scripts/workflows/temporal/scripts/verify_citations.py
@@ -38,10 +38,22 @@ from modules.journal.root import resolve_journal_root  # noqa: E402
 
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
+
+    # WHETHER A TARGET WAS NAMED IS ASKED OF THE PARSER, NOT OF THE RAW ARGV.
+    # This filtered the argument list itself and counted `--repo`'s own VALUE as
+    # a target, so `verify_citations.py --repo <path>` printed a usage message
+    # instead of verifying the configured root. `verify.split_args` is the one
+    # parse both this file and `verify.main` now use.
+    try:
+        _, targets = verify.split_args(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return verify.EXIT_USAGE
+
     # `create=False` for the reason `validate_bag.py` gives: a diagnostic must
     # not bring the thing it is diagnosing into existence. An operator whose
     # root is missing needs to be told so, not handed a fresh empty directory.
-    if not [a for a in args if a != "--repo" and not a.startswith("-")]:
+    if not targets:
         try:
             root = resolve_journal_root(config=load_journal_config(), create=False)
         except RuntimeError as exc:

--- a/scripts/workflows/temporal/tests/conftest.py
+++ b/scripts/workflows/temporal/tests/conftest.py
@@ -82,7 +82,29 @@ import pytest  # noqa: E402
 
 @pytest.fixture(autouse=True, scope="session")
 def _journal_root_is_never_the_operators(tmp_path_factory):
-    """Point every bag this suite opens at a temporary root, for the whole session."""
+    """Point every bag this suite opens at a temporary root, for the whole session.
+
+    ⚠ AUTOUSE AND SESSION-SCOPED, WHICH MAKES *WHEN* YOU RESOLVE THE ROOT PART OF
+    THE TEST'S MEANING. A test body runs INSIDE this fixture, so resolving the
+    journal root there yields the sandbox above — never the operator's root. An
+    integration test that means to read the REAL journal must resolve it at
+    MODULE scope, which runs at collection time and therefore before any fixture.
+
+    THE FAILURE IS A SKIP, WHICH IS WHY IT NEEDS SAYING HERE. The sandbox root
+    does not exist until a bag is opened in it, so an in-body resolution raises
+    `JournalRootError`; a tier that turns that into `pytest.skip` then reports an
+    environment-sounding reason — "no journal on this machine" — on a machine
+    holding a journal full of bags. A skip that is really a scoping bug and a
+    skip that is really a fresh clone are indistinguishable in a summary table,
+    and `run-all.sh` prints the same word for both.
+
+    MEASURED TWICE. `tests/integration/test_a_real_bag_validates.py` resolves at
+    module scope and carried no comment saying why, so the constraint survived as
+    one file's habit. `tests/integration/test_citations_verify_offline.py` then
+    shipped a tier that passed vacuously via skip on a machine holding bags, and
+    was corrected the same way. Both depend on this fixture's scope; stating it
+    at the fixture reaches the next such file, which neither of them can.
+    """
     from modules.journal import journal_activities
 
     sandbox = tmp_path_factory.mktemp("journal-sandbox")

--- a/scripts/workflows/temporal/tests/integration/conftest.py
+++ b/scripts/workflows/temporal/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures for the integration tier.
+
+ONE `journal` FIXTURE, BECAUSE THE FOURTH COPY IS THE ONE THAT DRIFTS. This is
+`tests/unit/conftest.py`'s argument at the tier below it, and that file records
+what it cost there: the same four lines were pasted into three test modules and a
+fourth copy had already drifted to a bare `0o700` literal, so a mode change would
+have reached three files and silently missed one.
+
+`tests/unit/conftest.py` is not reachable from here — pytest resolves conftest by
+directory, and `tests/integration/` is a sibling — which is why this file exists
+rather than the import that would obviously be cheaper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import DIR_MODE
+
+
+@pytest.fixture
+def journal_root(tmp_path: Path) -> Path:
+    """A journal root at the package's own directory mode, never a bare literal.
+
+    `DIR_MODE` rather than `0o700` written out: the mode is the package's to
+    state, and a test that hard-codes it stops testing the package's choice the
+    moment the package changes it.
+    """
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    return root

--- a/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
+++ b/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
@@ -138,11 +138,8 @@ def _demo_bag(root: Path):
     return bag, (good, absent, altered, wrong)
 
 
-def test_a_bag_holding_one_of_each_outcome_reports_all_four(tmp_path: Path) -> None:
-    from modules.journal.bag import DIR_MODE
-    root = tmp_path / "journal"
-    root.mkdir(mode=DIR_MODE)
-    bag, _ = _demo_bag(root)
+def test_a_bag_holding_one_of_each_outcome_reports_all_four(journal_root: Path) -> None:
+    bag, _ = _demo_bag(journal_root)
     counts = verify_bag(bag.path).counts()
     assert counts == {VERIFIED: 1, MISSING: 1, TAMPERED: 1, SPAN_MISSING: 1}
 
@@ -204,7 +201,8 @@ def _network_denier(tmp_path: Path) -> Path | None:
     return library
 
 
-def test_verify_runs_with_THE_NETWORK_ACTUALLY_DENIED(tmp_path: Path) -> None:
+def test_verify_runs_with_THE_NETWORK_ACTUALLY_DENIED(tmp_path: Path,
+                                                      journal_root: Path) -> None:
     """REQUIREMENT 2, DEMONSTRATED RATHER THAN ASSERTED.
 
     The checker runs as a subprocess whose `socket`, `connect` and `getaddrinfo`
@@ -216,10 +214,7 @@ def test_verify_runs_with_THE_NETWORK_ACTUALLY_DENIED(tmp_path: Path) -> None:
     if library is None:
         pytest.skip("no C compiler here — the denial shim cannot be built")
 
-    from modules.journal.bag import DIR_MODE
-    root = tmp_path / "journal"
-    root.mkdir(mode=DIR_MODE)
-    bag, _ = _demo_bag(root)
+    bag, _ = _demo_bag(journal_root)
 
     env = dict(os.environ, LD_PRELOAD=str(library))
 
@@ -249,7 +244,7 @@ def test_verify_runs_with_THE_NETWORK_ACTUALLY_DENIED(tmp_path: Path) -> None:
 
 def test_the_exit_code_tracks_the_worst_outcome_present(tmp_path: Path) -> None:
     """Each class on its own, so the mixed-run test above cannot pass by accident."""
-    from modules.journal.bag import DIR_MODE
+    from modules.journal.bag import DIR_MODE  # one root PER outcome, not the fixture's one
 
     def bag_with(mutate) -> int:
         root = tmp_path / f"journal-{mutate.__name__}"

--- a/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
+++ b/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
@@ -1,0 +1,266 @@
+"""A verify pass over a real journal on THIS machine, and it must not need a network.
+
+TWO TIERS, TWO QUESTIONS. The unit tier proves each rule in isolation against
+fixtures it built; this tier asks whether the whole thing works against whatever
+the operator's journal actually holds — the same split `test_a_real_bag_validates`
+keeps for the bag validator one question over.
+
+⚠ REQUIREMENT 2 IS ONLY PARTIALLY MET BY THIS FILE AND THE GAP IS NAMED RATHER
+THAN PAPERED OVER. The requirement asks for a demonstration "on a run captured at
+read time", and no run in this fleet captures at read time yet: a research
+citation is read by a model inside a `claude -p` child through the model's own
+tooling, and nothing routes that read through fleet code. Phase 2 rules that
+boundary onto post-exit harvest, so what exists today to verify is a bag this
+tier writes through the real capture activity. That IS a read-time capture for
+everything that goes through the boundary — and it is NOT the same as a research
+run's own sources having gone through it. The phase's PR says so plainly.
+
+SKIPPED, DISTINCTLY FROM PASSING, WHERE THERE IS NO JOURNAL. A clone has no
+journal and there is nothing for this tier to read; a skip and a pass must never
+look alike.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import BAGIT_FILE, open_bag
+from modules.journal.content_activities import capture_fetched_source
+from modules.journal.content_store import object_path
+from modules.journal.journal_activities import load_journal_config
+from modules.journal.root import JournalRootError, resolve_journal_root
+from modules.journal.verify import (EXIT_MISSING, EXIT_OK, EXIT_SPAN_MISSING,
+                                    EXIT_TAMPERED, MISSING, SPAN_MISSING,
+                                    TAMPERED, VERIFIED, verify_bag)
+
+# `parents[2]`, not `[1]`: this file sits at `tests/integration/`, so the
+# component root is two levels up. The component conftest resolves `[1]` because
+# it sits one level shallower, and copying its expression here pointed the
+# entrypoint at `tests/scripts/` — which python reported as an exit code with no
+# output, a failure that names nothing.
+COMPONENT_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = COMPONENT_ROOT / "scripts" / "verify_citations.py"
+
+assert ENTRYPOINT.is_file(), f"the entrypoint under test is not at {ENTRYPOINT}"
+
+PAGE = (b"<html><body><p>Every mature system draws this line, and each drew it "
+        b"after being hurt.</p></body></html>\n")
+QUOTE = "Every mature system draws this line, and each drew it after being hurt."
+
+
+def _operator_root() -> Path | None:
+    try:
+        return resolve_journal_root(config=load_journal_config(), create=False)
+    except (JournalRootError, RuntimeError):
+        return None
+
+
+def test_every_bag_on_this_machine_verifies_its_citations() -> None:
+    """The real corpus, whatever it holds. Today most bags cite nothing.
+
+    A bag with no citations is reported as zero and not as a failure, so a green
+    run here is compatible with the fleet not yet capturing anything — which is
+    honest, and is exactly why the offline demonstration below builds its own
+    corpus rather than asserting over this one.
+    """
+    root = _operator_root()
+    if root is None or not root.is_dir():
+        pytest.skip("no journal root on this machine — a clone has none")
+    bags = [p for p in sorted(root.iterdir())
+            if p.is_dir() and (p / BAGIT_FILE).is_file()]
+    if not bags:
+        pytest.skip(f"journal root {root} holds no bags yet")
+
+    bad = []
+    for path in bags:
+        report = verify_bag(path)
+        if not report.ok:
+            bad.append((path.name, report.counts(), report.structural))
+    assert not bad, f"citations failed to verify in the operator's journal: {bad}"
+
+
+def _demo_bag(root: Path):
+    """A bag holding one of each outcome, built through the real capture activity."""
+    bag = open_bag(root, "verify-offline-demo")
+    good = capture_fetched_source(bag=bag, stage="draft", claim_id="good",
+                                  quote=QUOTE, source_ref="https://example.org/a",
+                                  data=PAGE)
+    absent = capture_fetched_source(bag=bag, stage="draft", claim_id="absent",
+                                    quote=QUOTE, source_ref="https://example.org/b",
+                                    data=PAGE + b"<!-- second source -->")
+    altered = capture_fetched_source(bag=bag, stage="draft", claim_id="altered",
+                                     quote=QUOTE, source_ref="https://example.org/c",
+                                     data=PAGE + b"<!-- third source -->")
+    wrong = capture_fetched_source(bag=bag, stage="critic", claim_id="wrongquote",
+                                   quote="a sentence that was never on that page",
+                                   source_ref="https://example.org/d",
+                                   data=PAGE + b"<!-- fourth source -->")
+
+    object_path(bag.path, absent.page_content_hash).unlink()
+
+    target = object_path(bag.path, altered.page_content_hash)
+    data = bytearray(target.read_bytes())
+    data[0] ^= 0x01
+    target.write_bytes(bytes(data))
+    return bag, (good, absent, altered, wrong)
+
+
+def test_a_bag_holding_one_of_each_outcome_reports_all_four(tmp_path: Path) -> None:
+    from modules.journal.bag import DIR_MODE
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    bag, _ = _demo_bag(root)
+    counts = verify_bag(bag.path).counts()
+    assert counts == {VERIFIED: 1, MISSING: 1, TAMPERED: 1, SPAN_MISSING: 1}
+
+
+# --- the network-off demonstration ----------------------------------------------
+
+_DENY_SOCKET_C = r"""
+#define _GNU_SOURCE
+#include <errno.h>
+#include <netdb.h>
+#include <sys/socket.h>
+
+/* Denies the process the ability to reach a network, below the language the
+ * code under test is written in. Not a mock: the C library entry points
+ * themselves refuse, so nothing importable can route around them. */
+int socket(int domain, int type, int protocol) {
+    (void)domain; (void)type; (void)protocol;
+    errno = EACCES;
+    return -1;
+}
+
+int connect(int fd, const struct sockaddr *addr, socklen_t len) {
+    (void)fd; (void)addr; (void)len;
+    errno = EACCES;
+    return -1;
+}
+
+int getaddrinfo(const char *node, const char *service,
+                const struct addrinfo *hints, struct addrinfo **res) {
+    (void)node; (void)service; (void)hints; (void)res;
+    return EAI_FAIL;
+}
+"""
+
+
+def _network_denier(tmp_path: Path) -> Path | None:
+    """Compile the denial shim, or `None` if this machine has no compiler.
+
+    ⚠ WHY THIS AND NOT A NETWORK NAMESPACE. `unshare -rn` is the obvious tool and
+    it is unavailable to an unprivileged process here:
+    `/proc/sys/kernel/apparmor_restrict_unprivileged_userns` is 1 on this host,
+    so writing `/proc/self/uid_map` is refused and every `unshare` variant exits
+    non-zero without root. `LD_PRELOAD` denies the same capability at the C
+    library boundary, which is below the code under test and outside its control
+    — the property requirement 2 asks for. It is recorded here rather than in a
+    commit message because "how the network was disabled" is a checklist item.
+    """
+    source = tmp_path / "deny_socket.c"
+    source.write_text(_DENY_SOCKET_C)
+    library = tmp_path / "deny_socket.so"
+    try:
+        probe = subprocess.run(
+            ["cc", "-shared", "-fPIC", "-o", str(library), str(source)],
+            capture_output=True, timeout=120)
+    except FileNotFoundError:
+        return None
+    if probe.returncode != 0:
+        return None
+    return library
+
+
+def test_verify_runs_with_THE_NETWORK_ACTUALLY_DENIED(tmp_path: Path) -> None:
+    """REQUIREMENT 2, DEMONSTRATED RATHER THAN ASSERTED.
+
+    The checker runs as a subprocess whose `socket`, `connect` and `getaddrinfo`
+    are denied by the C library, and it must still return every verdict. The
+    control is the second half: the SAME denial must make a fetch impossible, or
+    the run proves only that nothing tried.
+    """
+    library = _network_denier(tmp_path)
+    if library is None:
+        pytest.skip("no C compiler here — the denial shim cannot be built")
+
+    from modules.journal.bag import DIR_MODE
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    bag, _ = _demo_bag(root)
+
+    env = dict(os.environ, LD_PRELOAD=str(library))
+
+    # THE CONTROL FIRST. If this does not fail, the denial is not in force and
+    # the verify run below would prove nothing at all.
+    control = subprocess.run(
+        [sys.executable, "-c",
+         "import urllib.request;"
+         "urllib.request.urlopen('https://example.com', timeout=5).read(16)"],
+        env=env, capture_output=True, timeout=120)
+    assert control.returncode != 0, (
+        "the denial shim did not take effect — a fetch SUCCEEDED under it, so "
+        "the verify run below would be evidence of nothing")
+
+    verified = subprocess.run(
+        [sys.executable, str(ENTRYPOINT), str(bag.path)],
+        env=env, capture_output=True, text=True, timeout=120)
+
+    assert verified.returncode == EXIT_TAMPERED, (
+        f"expected the most severe outcome to decide the exit code.\n"
+        f"stdout:\n{verified.stdout}\nstderr:\n{verified.stderr}")
+    for outcome in (VERIFIED, MISSING, TAMPERED, SPAN_MISSING):
+        assert f"{outcome}: 1" in verified.stdout, (
+            f"{outcome} not reported offline:\n{verified.stdout}")
+    assert "evidence_set_hash[draft]" in verified.stdout
+
+
+def test_the_exit_code_tracks_the_worst_outcome_present(tmp_path: Path) -> None:
+    """Each class on its own, so the mixed-run test above cannot pass by accident."""
+    from modules.journal.bag import DIR_MODE
+
+    def bag_with(mutate) -> int:
+        root = tmp_path / f"journal-{mutate.__name__}"
+        root.mkdir(mode=DIR_MODE)
+        bag = open_bag(root, "one-outcome")
+        citation = capture_fetched_source(
+            bag=bag, stage="draft", claim_id="c1", quote=QUOTE,
+            source_ref="https://example.org/a", data=PAGE)
+        mutate(bag, citation)
+        probe = subprocess.run([sys.executable, str(ENTRYPOINT), str(bag.path)],
+                               capture_output=True, text=True, timeout=120)
+        return probe.returncode
+
+    def untouched(bag, citation):
+        return None
+
+    def removed(bag, citation):
+        object_path(bag.path, citation.page_content_hash).unlink()
+
+    def flipped(bag, citation):
+        target = object_path(bag.path, citation.page_content_hash)
+        data = bytearray(target.read_bytes())
+        data[-1] ^= 0x01
+        target.write_bytes(bytes(data))
+
+    def rewritten(bag, citation):
+        object_path(bag.path, citation.page_content_hash).write_bytes(
+            b"intact bytes that simply do not contain the quote")
+        # Re-file under the new digest so the object is INTACT and only the span
+        # is gone — otherwise this reproduces `flipped` and proves nothing new.
+        from modules.journal.content_store import store_bytes
+        digest = store_bytes(bag.path, b"intact bytes without the quote")
+        writer = bag.payload_dir / "draft"
+        rows = (writer / "citations.jsonl").read_text()
+        (writer / "citations.jsonl").write_text(
+            rows.replace(citation.page_content_hash, digest))
+        object_path(bag.path, citation.page_content_hash).unlink()
+
+    assert bag_with(untouched) == EXIT_OK
+    assert bag_with(removed) == EXIT_MISSING
+    assert bag_with(flipped) == EXIT_TAMPERED
+    assert bag_with(rewritten) == EXIT_SPAN_MISSING

--- a/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
+++ b/scripts/workflows/temporal/tests/integration/test_citations_verify_offline.py
@@ -53,35 +53,63 @@ PAGE = (b"<html><body><p>Every mature system draws this line, and each drew it "
 QUOTE = "Every mature system draws this line, and each drew it after being hurt."
 
 
-def _operator_root() -> Path | None:
+def _operator_bags() -> list[Path]:
+    """Bags under the root THIS machine's config resolves to, or an empty list.
+
+    ⚠ RESOLVED AT MODULE SCOPE, AND THAT IS LOAD-BEARING RATHER THAN STYLE.
+    `tests/conftest.py` installs a session-wide autouse fixture that repoints
+    `journal_activities.CONFIG_PATH` at a sandbox, so that the suite can never
+    write into the operator's journal. Asking for the root INSIDE a test body
+    therefore returns the sandbox, and this tier would skip with "no journal on
+    this machine" on a machine holding forty-eight bags — a vacuous pass wearing
+    a skip's clothes. Module scope runs at collection, before the fixture, which
+    is exactly how `test_a_real_bag_validates.py` beside this file does it.
+    (Measured: this file shipped the inside-the-body version first and skipped
+    silently while `verify_citations.py` found 48 bags from the command line.)
+    """
     try:
-        return resolve_journal_root(config=load_journal_config(), create=False)
+        root = resolve_journal_root(config=load_journal_config(), create=False)
     except (JournalRootError, RuntimeError):
-        return None
+        return []
+    if not root.is_dir():
+        return []
+    return sorted(p for p in root.iterdir()
+                  if p.is_dir() and (p / BAGIT_FILE).is_file())
 
 
+BAGS = _operator_bags()
+
+
+@pytest.mark.skipif(not BAGS, reason="no journal on this machine — no dispatch has run here")
 def test_every_bag_on_this_machine_verifies_its_citations() -> None:
     """The real corpus, whatever it holds. Today most bags cite nothing.
 
     A bag with no citations is reported as zero and not as a failure, so a green
     run here is compatible with the fleet not yet capturing anything — which is
     honest, and is exactly why the offline demonstration below builds its own
-    corpus rather than asserting over this one.
+    corpus rather than asserting over this one. What this tier does prove today
+    is that the reader survives every real bag on disk: a malformed or
+    unreadable citation file anywhere under the root is a structural finding.
     """
-    root = _operator_root()
-    if root is None or not root.is_dir():
-        pytest.skip("no journal root on this machine — a clone has none")
-    bags = [p for p in sorted(root.iterdir())
-            if p.is_dir() and (p / BAGIT_FILE).is_file()]
-    if not bags:
-        pytest.skip(f"journal root {root} holds no bags yet")
-
     bad = []
-    for path in bags:
+    for path in BAGS:
         report = verify_bag(path)
         if not report.ok:
             bad.append((path.name, report.counts(), report.structural))
     assert not bad, f"citations failed to verify in the operator's journal: {bad}"
+
+
+@pytest.mark.skipif(not BAGS, reason="no journal on this machine — no dispatch has run here")
+def test_this_tier_actually_READ_the_operators_journal() -> None:
+    """VACUITY CONTROL. A sweep over an empty list passes exactly like a clean one.
+
+    The test above asserts an ABSENCE across a collection, which is the shape
+    that reports success when its scoping is wrong — and that is not
+    hypothetical here, it is what this file shipped. Naming a non-zero count is
+    what makes the absence mean something.
+    """
+    assert len(BAGS) > 0
+    assert all((path / BAGIT_FILE).is_file() for path in BAGS)
 
 
 def _demo_bag(root: Path):

--- a/scripts/workflows/temporal/tests/unit/journal_entrypoint_facts.py
+++ b/scripts/workflows/temporal/tests/unit/journal_entrypoint_facts.py
@@ -120,9 +120,15 @@ NON_STARTING_FILES = {
         "the journal root; it starts nothing, cuts nothing and opens no bag — "
         "the entrypoint that built it does all three.",
     "validate_bag.py":
-        "an operator tool that READS a finished bag and prints a report. It is "
-        "the one file here that addresses the journal without being a run, and "
-        "opening a bag to validate one would be the tool recording itself.",
+        "an operator tool that READS a finished bag and prints a report. It "
+        "addresses the journal without being a run, and opening a bag to "
+        "validate one would be the tool recording itself.",
+    "verify_citations.py":
+        "the same shape as `validate_bag.py` beside it, asking the other "
+        "question: it READS a finished bag's citations and re-checks them "
+        "against the stored bytes. It starts no run and opens no bag — a "
+        "checker that recorded itself would grow the journal every time an "
+        "operator inspected it.",
 }
 
 # A shim is `<workflow>.sh` beside its runner: thin by design, it resolves the

--- a/scripts/workflows/temporal/tests/unit/test_a_bounded_reply_is_CHECKED_not_only_read.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_bounded_reply_is_CHECKED_not_only_read.py
@@ -60,9 +60,11 @@ as broader than it is does more harm than a narrow one:
     is that a new spelling escapes rather than that a good one is blocked.
 
 THE POPULATION FIGURE IS DERIVED, NOT ASSERTED. `test_the_census_matches_the_
-tree` fails when the number of launch bindings changes, so the sentence "seven
-sites route through `run_bounded`" cannot go stale the way the docstring this
-guard replaces did. That is the discipline this file exists to demonstrate: a
+tree` fails when the number of launch bindings changes, so the sentence "eight
+launch bindings live in the tree" cannot go stale the way the docstring this
+guard replaces did. It went from seven to eight when the content store's
+`verify.git_blob` landed, which is the census doing its job: the author of that
+function was told, by this assertion, that they had joined this population. That is the discipline this file exists to demonstrate: a
 coverage claim is either an assertion that goes red, or it is a hedge.
 """
 
@@ -296,8 +298,8 @@ def test_the_census_matches_the_tree() -> None:
     next person to add one is told, here, that they are now in this population.
     """
     _, total = _scan_tree()
-    assert total == 7, (
-        f"the walk found {total} launch-reply binding(s), not the 7 recorded when "
+    assert total == 8, (
+        f"the walk found {total} launch-reply binding(s), not the 8 recorded when "
         f"this was written. That is not a failure — it is the census telling you "
         f"the population moved. Confirm the new site reads its outcome, then "
         f"update this number and the docstring's count together."

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -190,7 +190,16 @@ _HERE = Path(__file__).resolve().parent
 # `verify`'s graph, and the discriminator beside it starts the same walk at
 # `content_activities`, which legitimately does import the fetcher. An absence
 # with no demonstrated presence is the vacuity this file exists to refuse.
-_PINNED = (36, 25)
+# 36 -> 38 and 25 -> 27 when a `build-refine` correction pass added the two
+# class-checks this PR's findings were instances of:
+# `test_journal_regex_anchors.py` (a `^…$` anywhere in `modules/journal/`) and
+# `test_journal_operator_tools_separate_typo_from_finding.py` (an operator-named
+# target that is not there must be USAGE on every bag-inspection tool). BOTH
+# numbers moved because each ships its own literal control rather than being
+# grandfathered — and the anchor guard's control is not decoration: exercising
+# it is how its recogniser was found blind to `re.compile(r"…" % N)`, which is
+# the spelling of the digest gate that IS r7(b)'s path safety.
+_PINNED = (38, 27)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -184,7 +184,13 @@ _HERE = Path(__file__).resolve().parent
 # spellings and six negative ones driven on literals, the second controls its
 # build/echo, ordering, gating and dry-run predicates the same way. Verified
 # rather than assumed — `_walks_the_tree` returns True for both files.
-_PINNED = (35, 24)
+# 35 -> 36 when PMP Phase 2 added `test_verify_citations.py`, and the second
+# number moved with it because that guard ships its control rather than being
+# grandfathered: its import-closure walk asserts `source_fetch` is ABSENT from
+# `verify`'s graph, and the discriminator beside it starts the same walk at
+# `content_activities`, which legitimately does import the fetcher. An absence
+# with no demonstrated presence is the vacuity this file exists to refuse.
+_PINNED = (36, 25)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_a_gh_reply_is_checked_for_SHAPE_not_only_parsed.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_gh_reply_is_checked_for_SHAPE_not_only_parsed.py
@@ -33,6 +33,15 @@ WHAT THIS GUARD DOES NOT LOOK AT:
   * **`json.load`, `yaml.safe_load`, or a parse behind a helper.** It matches
     `json.loads` applied to something that is visibly a subprocess reply. A
     fourth spelling is invisible here.
+
+    `json` ITSELF IS NOW RESOLVED THROUGH ITS IMPORT BINDINGS, so `import json
+    as _j` / `_j.loads(...)` and `from json import loads` are in the census
+    rather than absent from it. That was NOT true until a class sweep reached
+    this site: the recogniser required the bare name, exactly as the journal
+    package's anchor sweep did, and a decode reached through an alias was not
+    reported unguarded — it was not seen, which reads as a clean tree. See
+    `_json_bindings`, and `test_a_guard_RESOLVES_the_module_it_MATCHES.py` for
+    the class.
   * **Replies that are never indexed.** A site that decodes and only ever passes
     the value onward is flagged anyway; that is the safe direction and it costs
     one `isinstance`.
@@ -100,9 +109,42 @@ def _is_reply(node: ast.AST) -> bool:
     return _is_gh_call(node)
 
 
+def _json_bindings(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """`({names bound to `json`}, {names bound to `json.loads`})`.
+
+    `json` IS RESOLVED THROUGH ITS IMPORTS RATHER THAN HARD-CODED, and it was
+    hard-coded until a sweep for that class found this site. A recogniser keyed
+    on the bare module name is evaded by `import json as _j` / `_j.loads(...)`
+    and by `from json import loads`, so a `gh` reply decoded through either
+    spelling was not in the census AT ALL — not reported as unguarded, simply
+    absent, which is the direction that reads as a clean tree. The tree does not
+    alias `json` today; the habit is live elsewhere in it, and the closure this
+    guard publishes is population-wide.
+
+    `from json import *` binds `loads` under its own name and is expanded here
+    rather than declared as a hole; nothing in the tree uses it.
+
+    The class check is `test_a_guard_RESOLVES_the_module_it_MATCHES.py`.
+    """
+    modules = {"json"}
+    functions: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules |= {a.asname or a.name for a in node.names if a.name == "json"}
+        elif isinstance(node, ast.ImportFrom) and node.module == "json":
+            functions |= {a.asname or a.name for a in node.names
+                          if a.name == "loads"}
+            functions |= {"loads"} if any(a.name == "*" for a in node.names) else set()
+    return modules, functions
+
+
 class _Parses(ast.NodeVisitor):
     def __init__(self, rel: str) -> None:
         self.rel = rel
+        # Seeded so a snippet with no import statement still reads `json.loads`,
+        # and replaced per-module by `visit_Module`.
+        self._json_modules: set[str] = {"json"}
+        self._json_functions: set[str] = set()
         self.stack: list[ast.FunctionDef] = []
         # (file, enclosing FunctionDef NODE, line, bound name). The node and not
         # its name: `_run` and `_git` are closure names this tree reuses, and a
@@ -112,6 +154,13 @@ class _Parses(ast.NodeVisitor):
         # Decode calls already claimed by a named position, so the
         # catch-all `visit_Call` below does not report them a second time.
         self._handled: set[int] = set()
+
+    def visit_Module(self, node: ast.Module):  # noqa: N802
+        # RESOLVED UP FRONT, NOT AS THE WALK PASSES THE IMPORT. A function-local
+        # `import json as _j` is visited AFTER the calls in every function above
+        # it, so binding on arrival would leave the earlier ones unresolved.
+        self._json_modules, self._json_functions = _json_bindings(node)
+        self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef):  # noqa: N802
         self.stack.append(node)
@@ -152,11 +201,16 @@ class _Parses(ast.NodeVisitor):
     def _maybe(self, value, targets) -> None:
         if isinstance(value, ast.Call):
             self._handled.add(id(value))
-        if not (isinstance(value, ast.Call)
-                and isinstance(value.func, ast.Attribute)
-                and value.func.attr == "loads"
-                and isinstance(value.func.value, ast.Name)
-                and value.func.value.id == "json"):
+        if not isinstance(value, ast.Call):
+            return
+        func = value.func
+        decodes = (
+            (isinstance(func, ast.Attribute) and func.attr == "loads"
+             and isinstance(func.value, ast.Name)
+             and func.value.id in self._json_modules)
+            or (isinstance(func, ast.Name) and func.id in self._json_functions)
+        )
+        if not decodes:
             return
         if not value.args:
             return
@@ -347,6 +401,26 @@ _GUARDED = ("def f(r):\n    x = json.loads(r.stdout)\n"
         pytest.param("def f(line):\n    e = json.loads(line)\n    return e['t']\n",
                      False, False, "a log line, which is a different population",
                      id="not-a-reply"),
+        pytest.param("import json as _j\ndef f(p):\n    x = _j.loads(gh(p))\n"
+                     "    return x[0]\n",
+                     True, False, "an ALIASED decode, which the bare-name "
+                     "recogniser did not see at all — absent from the census "
+                     "rather than reported unguarded",
+                     id="aliased-json"),
+        pytest.param("from json import loads\ndef f(p):\n    x = loads(gh(p))\n"
+                     "    return x[0]\n",
+                     True, False, "the from-import spelling, invisible to an "
+                     "attribute matcher by construction",
+                     id="from-import-json"),
+        pytest.param("from json import *\ndef f(p):\n    x = loads(gh(p))\n"
+                     "    return x[0]\n",
+                     True, False, "the star import, which binds `loads` under "
+                     "its own name", id="star-import-json"),
+        pytest.param("def f(p):\n    x = loads(gh(p))\n    return x[0]\n",
+                     False, False, "a bare `loads(...)` with NO `from json` "
+                     "import — some other function, and reading it as a decode "
+                     "would invent a finding",
+                     id="loads-not-from-json"),
     ],
 )
 def test_the_reply_and_guard_predicates_discriminate(

--- a/scripts/workflows/temporal/tests/unit/test_citations.py
+++ b/scripts/workflows/temporal/tests/unit/test_citations.py
@@ -236,3 +236,103 @@ def test_equal_hashes_across_stages_are_EXPOSED_and_nothing_routes_on_them() -> 
 
     moved = rows + [web("c3", stage="b", digest=DIGEST_B)]
     assert converged_stages(moved) == []
+
+
+# --- the anchor, the fold, and the reader's own contract -------------------------
+
+@pytest.mark.parametrize("field,value", [
+    ("claim_id", "c1\n"),
+    ("claim_id", "\nc1"),
+    ("page_content_hash", DIGEST_A + "\n"),
+])
+def test_a_field_with_a_TRAILING_LINE_BREAK_is_refused(field, value) -> None:
+    """⚠ `^…$` ACCEPTED ALL THREE, AND ALL THREE ARE RENDERED INTO THE REPORT.
+
+    `$` matches before a trailing newline. `bag._RUN_ID_RE` states the `\\A`/`\\Z`
+    rule and this module held two hand-written regexes that did not use it —
+    which is why the digest rule is now asked of `content_store.validated_digest`
+    rather than restated here.
+    """
+    fields = dict(claim_id="c1", stage="draft", quote="q",
+                  source_ref="https://example.org/a", capture=CAPTURE_HARVEST,
+                  page_content_hash=DIGEST_A)
+    fields[field] = value
+    with pytest.raises(CitationError):
+        Citation(**fields)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("stage", "draft\n  evidence_set_hash[draft]: " + "0" * 64),
+    ("stage", "draft injected"),
+    ("source_ref", "https://example.org/a\nspan-missing: [x] forged"),
+    ("stage", "draft "),
+])
+def test_a_field_that_FOLDS_cannot_forge_a_line_in_the_verify_report(field, value) -> None:
+    """⚠ `stage` AND `source_ref` ARE PRINTED RAW BY `render_report`.
+
+    Both survived the JSON round trip intact, so a row could rewrite the report
+    about itself — the fifth and sixth consumers of the rule `validated_run_id`
+    enumerates. Asked of `folds_a_tag_line`, which puts the question to
+    `str.splitlines()`: the `\\u2028` case is why, since a hand-written
+    `"\\n" in value` check misses eight spellings.
+    """
+    fields = dict(claim_id="c1", stage="draft", quote="q",
+                  source_ref="https://example.org/a", capture=CAPTURE_HARVEST,
+                  page_content_hash=DIGEST_A)
+    fields[field] = value
+    with pytest.raises(CitationError):
+        Citation(**fields)
+
+
+@pytest.mark.parametrize("row", [
+    '{"claim_id": "c1"}',
+    '{"claim_id": "c1", "stage": "draft", "quote": "q"}',
+    '{"claim_id": 5, "stage": "draft", "quote": "q", '
+    '"source_ref": "https://example.org/a", "capture": "harvest", '
+    '"page_content_hash": "' + DIGEST_A + '"}',
+    '{"claim_id": "c1", "stage": ["draft"], "quote": "q", '
+    '"source_ref": "https://example.org/a", "capture": "harvest", '
+    '"page_content_hash": "' + DIGEST_A + '"}',
+])
+def test_a_TRUNCATED_or_MISTYPED_row_is_a_CitationError_not_a_TypeError(row) -> None:
+    """⚠ `cls(**data)` RAISED `TypeError` PAST THIS CLASS'S OWN GUARANTEE.
+
+    A row missing a required field is the single most likely corruption of a
+    JSON Lines file — which is the format this module chose BECAUSE a partial
+    write loses one row — and it raised `TypeError`, which is not what
+    `from_json`'s "re-validated on the way in" promises and not what
+    `verify_bag` catches. One truncated append killed a whole-journal sweep.
+    """
+    with pytest.raises(CitationError):
+        Citation.from_json(row)
+
+
+def test_the_citation_file_is_written_at_FILE_MODE_and_refuses_a_SYMLINK(tmp_path) -> None:
+    """⚠ BUILTIN `open(..., "a")` LEFT THE ONE FILE IN A BAG AT 0644, AND FOLLOWED LINKS.
+
+    Every other file this package writes goes through `os.open` with the mode set
+    at creation and `O_NOFOLLOW` — `_write_tag_file` states both rules, and
+    `content_store.store_bytes` restates them. `record_citation` did neither, so
+    the quotes and claim text were world-readable on a multi-user host, and a
+    planted `citations.jsonl` symlink diverted appended rows out of the bag. The
+    read side already refused to FOLLOW such a link; only the write side was open.
+    """
+    from modules.journal.bag import DIR_MODE, FILE_MODE
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    bag = open_bag(root, "modes")
+    writer = bag.writer_dir("draft")
+    citation = new_citation(claim_id="c1", stage="draft", quote="q",
+                            source_ref="https://example.org/a",
+                            capture=CAPTURE_HARVEST, page_content_hash=DIGEST_A)
+    target = record_citation(writer, citation)
+    assert target.stat().st_mode & 0o777 == FILE_MODE
+
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("")
+    diverted = bag.writer_dir("critic")
+    (diverted / CITATIONS_FILE).symlink_to(outside)
+    with pytest.raises(OSError):
+        record_citation(diverted, citation)
+    assert outside.read_text() == "", "an appended row escaped the bag through a symlink"

--- a/scripts/workflows/temporal/tests/unit/test_citations.py
+++ b/scripts/workflows/temporal/tests/unit/test_citations.py
@@ -1,0 +1,238 @@
+"""The citation record: what was claimed, against which bytes, under which guarantee.
+
+THE RECORD IS THE DURABLE ARTIFACT AND NOTHING REWRITES IT, so every check that
+matters happens at construction. A malformed row written today is a row every
+later reader has to cope with — which is why `__post_init__` refuses rather than
+coerces, and why `from_json` re-validates a file this package did not necessarily
+write.
+
+r7(c)'s RULING IS TESTED AS DATA, NOT AS A SENTENCE. `capture` distinguishes a
+row whose hash proves the claim was made against those bytes from one whose hash
+only proves they matched at harvest, and it has no default anywhere in the
+package. The tests below assert that absence, because a default is exactly how a
+weaker guarantee would start being reported as the stronger one.
+
+WHAT THIS FILE DOES NOT LOOK AT: it never hashes a stored object and never opens
+a file the store wrote, so it says nothing about whether the bytes a row names
+are present or intact — `test_content_store.py` and `test_verify_citations.py`
+own those. It reads and writes rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import open_bag
+from modules.journal.citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME,
+                                       CITATIONS_FILE, Citation, CitationError,
+                                       converged_stages, evidence_set_hash,
+                                       is_git_ref, new_citation, parse_git_ref,
+                                       read_citations, record_citation,
+                                       stage_evidence_hashes)
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def web(claim_id: str = "c1", *, stage: str = "draft", quote: str = "a quoted span",
+        digest: str = DIGEST_A, capture: str = CAPTURE_READ_TIME) -> Citation:
+    return new_citation(claim_id=claim_id, stage=stage, quote=quote,
+                        source_ref="https://example.org/a", capture=capture,
+                        page_content_hash=digest)
+
+
+@pytest.fixture
+def bag(root: Path):
+    return open_bag(root, "run-citations")
+
+
+# --- the record refuses what it cannot mean --------------------------------------
+
+@pytest.mark.parametrize("kwargs, why", [
+    ({"claim_id": ""}, "an empty claim id names nothing"),
+    ({"claim_id": "../escape"}, "a claim id is an identifier, not a path"),
+    ({"claim_id": "a" * 129}, "over the length ceiling"),
+    ({"stage": "  "}, "requirement 5 counts rows into a stage"),
+    ({"quote": "   "}, "a citation with no span has nothing to re-check"),
+    ({"capture": "maybe"}, "capture names one of two guarantees"),
+    ({"capture": ""}, "capture has no default"),
+])
+def test_a_row_that_cannot_be_checked_is_refused_at_construction(kwargs, why) -> None:
+    base = dict(claim_id="c1", stage="draft", quote="q",
+                source_ref="https://example.org/a", capture=CAPTURE_READ_TIME,
+                page_content_hash=DIGEST_A)
+    base.update(kwargs)
+    with pytest.raises(CitationError):
+        Citation(**base)
+
+
+def test_a_web_citation_without_a_digest_names_no_bytes() -> None:
+    """It would verify clean by having nothing to check, which is the worst outcome."""
+    with pytest.raises(CitationError) as caught:
+        Citation(claim_id="c1", stage="draft", quote="q",
+                 source_ref="https://example.org/a", capture=CAPTURE_READ_TIME)
+    assert "page_content_hash" in str(caught.value)
+
+
+@pytest.mark.parametrize("source_ref", [
+    "http://example.org/a", "file:///etc/passwd", "ftp://example.org/a",
+    "data:text/plain,hello", "example.org/a", "git:abc", "git:" + "z" * 40,
+])
+def test_a_source_ref_this_record_cannot_re_check_is_refused(source_ref) -> None:
+    with pytest.raises(CitationError):
+        Citation(claim_id="c1", stage="draft", quote="q", source_ref=source_ref,
+                 capture=CAPTURE_READ_TIME, page_content_hash=DIGEST_A)
+
+
+# --- requirement 6: code is a commit sha, and it is never copied in --------------
+
+def test_a_code_citation_carries_a_sha_and_no_stored_digest() -> None:
+    citation = Citation(claim_id="c1", stage="draft", quote="def f():",
+                        source_ref=f"git:{SHA}:lib/f.py", capture=CAPTURE_READ_TIME)
+    assert is_git_ref(citation.source_ref)
+    assert parse_git_ref(citation.source_ref) == (SHA, "lib/f.py")
+    assert citation.page_content_hash is None
+
+
+def test_a_code_citation_may_not_ALSO_carry_a_stored_digest() -> None:
+    """Two names for one guarantee, and the copy is the one that can drift."""
+    with pytest.raises(CitationError) as caught:
+        Citation(claim_id="c1", stage="draft", quote="q", source_ref=f"git:{SHA}",
+                 capture=CAPTURE_READ_TIME, page_content_hash=DIGEST_A)
+    assert "page_content_hash" in str(caught.value)
+
+
+def test_an_abbreviated_sha_is_refused() -> None:
+    """A prefix stops being unique as a repository grows; a citation names one object."""
+    with pytest.raises(CitationError):
+        Citation(claim_id="c1", stage="draft", quote="q", source_ref=f"git:{SHA[:8]}",
+                 capture=CAPTURE_READ_TIME)
+
+
+# --- round trip, and an unknown field is not silently dropped -------------------
+
+def test_a_row_survives_a_round_trip_through_json() -> None:
+    original = web()
+    assert Citation.from_json(original.to_json()) == original
+
+
+def test_a_git_row_does_not_serialise_a_null_digest() -> None:
+    """Absence is a property of the KIND of citation, not a value that is empty."""
+    citation = Citation(claim_id="c1", stage="draft", quote="q",
+                        source_ref=f"git:{SHA}", capture=CAPTURE_READ_TIME)
+    assert "page_content_hash" not in citation.to_json()
+
+
+@pytest.mark.parametrize("row", [
+    '{"claim_id": "c1", "stage": "s", "quote": "q", "source_ref": "https://e.org/a",'
+    ' "capture": "read-time", "page_content_hash": "' + DIGEST_A + '", "extra": 1}',
+    'not json at all',
+    '["not", "an", "object"]',
+    '{"claim_id": "c1", "stage": "s", "quote": "q", "source_ref": "file:///etc/passwd",'
+    ' "capture": "read-time"}',
+])
+def test_a_row_read_off_disk_is_RE_VALIDATED(row) -> None:
+    """`citations.jsonl` is a file this module did not necessarily write.
+
+    A reader that trusted the row would let a hand edit name whatever it liked —
+    the same reasoning that made the manifest parser contain its paths one
+    module over, after a hand-written manifest reported PASS over `/etc/hostname`.
+    """
+    with pytest.raises(CitationError):
+        Citation.from_json(row)
+
+
+# --- writing and reading a bag's rows -------------------------------------------
+
+def test_rows_are_written_per_writer_and_read_back_whole(bag) -> None:
+    """Two writers, two files, no lock — the contention was removed one layer up."""
+    first = bag.writer_dir("draft")
+    second = bag.writer_dir("critic")
+    record_citation(first, web("c1", stage="draft"))
+    record_citation(first, web("c2", stage="draft", digest=DIGEST_B))
+    record_citation(second, web("c3", stage="critic"))
+
+    assert (first / CITATIONS_FILE).is_file()
+    rows = read_citations(bag.path)
+    assert [r.claim_id for r in rows] == ["c3", "c1", "c2"], (
+        "rows come back in (stage, claim_id, source_ref) order, not file order, "
+        "so a set of citations has one spelling regardless of scheduling")
+
+
+def test_a_bag_with_no_citations_reads_as_no_citations(bag) -> None:
+    assert read_citations(bag.path) == []
+
+
+def test_a_symlinked_citations_file_is_NOT_FOLLOWED(bag, tmp_path: Path) -> None:
+    """A file that never travelled with the bag must not supply its citations.
+
+    The same class as a symlink under `data/` being hashed into the manifest: a
+    bag is meant to contain bytes, not pointers to bytes that live outside it.
+    """
+    outside = tmp_path / "planted.jsonl"
+    outside.write_text(web("planted").to_json() + "\n")
+    writer = bag.writer_dir("draft")
+    (writer / CITATIONS_FILE).symlink_to(outside)
+    assert read_citations(bag.path) == []
+
+
+def test_a_row_that_will_not_parse_names_its_file_and_line(bag) -> None:
+    writer = bag.writer_dir("draft")
+    (writer / CITATIONS_FILE).write_text(web().to_json() + "\n{ broken\n")
+    with pytest.raises(CitationError) as caught:
+        read_citations(bag.path)
+    assert ":2:" in str(caught.value)
+
+
+# --- requirement 5: the evidence set hash --------------------------------------
+
+def test_two_claims_on_one_page_are_ONE_piece_of_evidence() -> None:
+    """A set, not a count. Otherwise the hash measures how much a stage WROTE."""
+    one = evidence_set_hash([web("c1")])
+    many = evidence_set_hash([web("c1"), web("c2"), web("c3")])
+    assert one == many
+
+
+def test_the_hash_changes_when_the_evidence_does() -> None:
+    assert evidence_set_hash([web("c1")]) != evidence_set_hash(
+        [web("c1"), web("c2", digest=DIGEST_B)])
+
+
+def test_the_hash_ignores_the_order_rows_were_written_in() -> None:
+    a, b = web("c1"), web("c2", digest=DIGEST_B)
+    assert evidence_set_hash([a, b]) == evidence_set_hash([b, a])
+
+
+def test_the_quote_is_NOT_part_of_the_evidence_identity() -> None:
+    """Two stages quoting different spans of one page still saw the same evidence."""
+    assert (evidence_set_hash([web("c1", quote="first span")])
+            == evidence_set_hash([web("c2", quote="a different span")]))
+
+
+def test_a_code_citation_counts_as_its_git_ref() -> None:
+    code = Citation(claim_id="c1", stage="draft", quote="q",
+                    source_ref=f"git:{SHA}", capture=CAPTURE_READ_TIME)
+    assert code.evidence_id == f"git:{SHA}"
+    assert evidence_set_hash([code]) != evidence_set_hash([web("c1")])
+
+
+def test_equal_hashes_across_stages_are_EXPOSED_and_nothing_routes_on_them() -> None:
+    """Requirement 5 stops at computed and exposed, and so does the code.
+
+    The precedent is this fleet's own convergence signal, which was built,
+    shadowed and gated nothing — two positive observations are not a rate, and a
+    stopping rule that fires early ends productive work silently with no failing
+    test. `converged_stages` REPORTS; whoever proposes routing on it owns
+    producing the firing-rate evidence first.
+    """
+    rows = [web("c1", stage="a"), web("c2", stage="b")]
+    hashes = stage_evidence_hashes(rows)
+    assert set(hashes) == {"a", "b"}
+    assert hashes["a"] == hashes["b"]
+    assert converged_stages(rows) == [("b", "a")]
+
+    moved = rows + [web("c3", stage="b", digest=DIGEST_B)]
+    assert converged_stages(moved) == []

--- a/scripts/workflows/temporal/tests/unit/test_content_activities.py
+++ b/scripts/workflows/temporal/tests/unit/test_content_activities.py
@@ -89,11 +89,15 @@ def test_a_HOSTILE_STAGE_NAME_cannot_escape_the_payload(bag, stage: str) -> None
         "and rewriting the record would lose what the run actually called it")
 
 
-def test_a_harvested_row_carries_the_WEAKER_guarantee(bag) -> None:
-    """The provenance is data, so nothing downstream has to assume which arm ran."""
-    class Fake:
-        pass
+def test_a_harvested_row_carries_the_WEAKER_guarantee(bag, monkeypatch) -> None:
+    """The provenance is data, so nothing downstream has to assume which arm ran.
 
+    `monkeypatch` rather than a hand-written try/finally, which is what the
+    other thirty-one files in this tree use — and it is not a style point: a
+    hand-rolled restore leaves the module patched for the rest of the session
+    whenever an assertion raises before the `finally` is reached by a later
+    edit.
+    """
     import modules.journal.content_activities as mod
     captured = {}
 
@@ -102,14 +106,10 @@ def test_a_harvested_row_carries_the_WEAKER_guarantee(bag) -> None:
         return type("F", (), {"final_url": url, "data": PAGE,
                               "media_type": "text/html"})()
 
-    original = mod.fetch_source
-    mod.fetch_source = fake_fetch
-    try:
-        citation = capture_source(bag=bag, stage="harvest", claim_id="c1",
-                                  quote="a source the run read",
-                                  url="https://example.org/a")
-    finally:
-        mod.fetch_source = original
+    monkeypatch.setattr(mod, "fetch_source", fake_fetch)
+    citation = capture_source(bag=bag, stage="harvest", claim_id="c1",
+                              quote="a source the run read",
+                              url="https://example.org/a")
 
     assert captured["url"] == "https://example.org/a"
     assert citation.capture == CAPTURE_HARVEST

--- a/scripts/workflows/temporal/tests/unit/test_content_activities.py
+++ b/scripts/workflows/temporal/tests/unit/test_content_activities.py
@@ -1,0 +1,194 @@
+"""Capture and resolve — the store's two I/O boundaries, and what they refuse.
+
+REQUIREMENT 8's ARGUMENT IS THAT A SOURCE READ THROUGH A NON-CAPTURING PATH IS A
+CITATION NOBODY CAN RE-CHECK, AND IT FAILS SILENTLY. There is no error, no
+missing file and nothing to notice until somebody tries to verify a claim and
+finds no bytes behind it. This file asserts the two boundaries do what they say
+and, in `test_a_citation_with_no_captured_bytes_FAILS_CLOSED`, that the silence
+is broken by `verify` rather than by hope.
+
+r7(c)'s RULING IS VISIBLE HERE AS TWO ENTRY FUNCTIONS WITH DIFFERENT DEFAULTS.
+The harvest path defaults to the weaker guarantee because that is what it is; the
+bytes-in-hand path defaults to the stronger one because a caller that had the
+bytes as the source was read is the routed arm this phase did not take. Neither
+default is a claim about the fleet — the row records which was used.
+
+WHAT THIS FILE DOES NOT LOOK AT: it never exercises the fetch policy against a
+hostile URL (`test_source_fetch.py` owns that), and it does not re-derive the
+store's hashing (`test_content_store.py`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import open_bag
+from modules.journal.citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME,
+                                       CITATIONS_FILE, CitationError,
+                                       read_citations)
+from modules.journal.content_activities import (capture_code_citation,
+                                                capture_fetched_source,
+                                                capture_source,
+                                                resolve_citation)
+from modules.journal.content_store import load_object, object_path
+from modules.journal.verify import MISSING, VERIFIED, verify_bag, verify_citation
+
+PAGE = b"<p>a source the run read</p>"
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+@pytest.fixture
+def bag(root: Path):
+    return open_bag(root, "run-activities")
+
+
+def test_capturing_bytes_in_hand_stores_them_and_records_the_row(bag) -> None:
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="a source the run read",
+        source_ref="https://example.org/a", data=PAGE)
+    assert citation.capture == CAPTURE_READ_TIME
+    assert load_object(bag.path, citation.page_content_hash) == PAGE
+    assert read_citations(bag.path) == [citation]
+    assert verify_citation(bag.path, citation).outcome == VERIFIED
+
+
+def test_a_stage_capturing_a_SECOND_source_appends_to_its_own_file(bag) -> None:
+    """`Bag.writer_dir` allocates a NAME NOBODY ELSE GETS, which is right for a
+    writer claiming a workspace and wrong for a stage citing twice — its second
+    source must land beside the first, not in `draft-2`."""
+    for index in range(3):
+        capture_fetched_source(bag=bag, stage="draft", claim_id=f"c{index}",
+                               quote="a source", source_ref="https://example.org/a",
+                               data=f"source {index}".encode())
+    assert [p.name for p in sorted(bag.payload_dir.iterdir())
+            if p.is_dir() and p.name != "content-store"] == ["draft"]
+    assert (bag.payload_dir / "draft" / CITATIONS_FILE).read_text().count("\n") == 3
+
+
+@pytest.mark.parametrize("stage", ["../escape", "/absolute", "..", "a/b/c"])
+def test_a_HOSTILE_STAGE_NAME_cannot_escape_the_payload(bag, stage: str) -> None:
+    """⚠ THIS ESCAPED, AND `test_journal_containment` IS WHAT SAID SO.
+
+    The first version of `_writer_directory` composed the caller's stage onto
+    the payload path directly — the fifth instance of this package's own
+    containment class, written by the pass that had just read the module
+    documenting the other four. The remedy was the two rules `Bag.writer_dir`
+    already keeps, reached by name rather than re-implemented.
+    """
+    citation = capture_fetched_source(
+        bag=bag, stage=stage, claim_id="c1", quote="a source",
+        source_ref="https://example.org/a", data=PAGE)
+    written = [p for p in bag.path.rglob(CITATIONS_FILE)]
+    assert len(written) == 1
+    assert bag.payload_dir in written[0].parents, (
+        f"{written[0]} landed outside the payload directory")
+    assert citation.stage == stage, (
+        "the ROW keeps the stage the caller named — sanitising is a path rule, "
+        "and rewriting the record would lose what the run actually called it")
+
+
+def test_a_harvested_row_carries_the_WEAKER_guarantee(bag) -> None:
+    """The provenance is data, so nothing downstream has to assume which arm ran."""
+    class Fake:
+        pass
+
+    import modules.journal.content_activities as mod
+    captured = {}
+
+    def fake_fetch(url, *, policy=None):
+        captured["url"] = url
+        return type("F", (), {"final_url": url, "data": PAGE,
+                              "media_type": "text/html"})()
+
+    original = mod.fetch_source
+    mod.fetch_source = fake_fetch
+    try:
+        citation = capture_source(bag=bag, stage="harvest", claim_id="c1",
+                                  quote="a source the run read",
+                                  url="https://example.org/a")
+    finally:
+        mod.fetch_source = original
+
+    assert captured["url"] == "https://example.org/a"
+    assert citation.capture == CAPTURE_HARVEST
+    assert verify_citation(bag.path, citation).outcome == VERIFIED
+
+
+def test_the_capture_path_does_NOT_check_the_span(bag) -> None:
+    """A wrong quotation is a FINDING about the record, not a capture failure.
+
+    Refusing here would move the finding out of `verify` — where an operator
+    reads it as one of four outcomes — and into the run, where it becomes an
+    error the run has to handle mid-flight.
+    """
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="never on that page",
+        source_ref="https://example.org/a", data=PAGE)
+    assert citation.page_content_hash is not None
+    assert verify_citation(bag.path, citation).outcome == "span-missing"
+
+
+def test_a_code_citation_STORES_NOTHING(bag) -> None:
+    """Requirement 6. Git is already content-addressed; a copy can drift."""
+    citation = capture_code_citation(bag=bag, stage="draft", claim_id="c1",
+                                     quote="def f():", commit_sha=SHA, path="f.py")
+    assert citation.source_ref == f"git:{SHA}:f.py"
+    assert citation.page_content_hash is None
+    assert not (bag.payload_dir / "content-store").exists()
+
+
+def test_an_abbreviated_sha_is_refused_at_the_boundary(bag) -> None:
+    with pytest.raises(CitationError):
+        capture_code_citation(bag=bag, stage="draft", claim_id="c1", quote="q",
+                              commit_sha=SHA[:8])
+
+
+def test_an_unknown_capture_kind_is_refused(bag) -> None:
+    """It records WHICH guarantee the row carries, so it has no default here."""
+    with pytest.raises(CitationError):
+        capture_fetched_source(bag=bag, stage="draft", claim_id="c1", quote="q",
+                               source_ref="https://example.org/a", data=PAGE,
+                               capture="probably")
+
+
+def test_resolve_is_the_STORE_read_and_adds_nothing(bag) -> None:
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="a source",
+        source_ref="https://example.org/a", data=PAGE)
+    assert resolve_citation(bag=bag, citation=citation) == PAGE
+
+    object_path(bag.path, citation.page_content_hash).write_bytes(b"changed")
+    with pytest.raises(Exception) as caught:
+        resolve_citation(bag=bag, citation=citation)
+    assert "TAMPERED" in str(caught.value), (
+        "resolve must be `load_object` and not a softer read — a second resolver "
+        "is exactly what r7(d) exists to prevent")
+
+
+def test_resolve_REFUSES_to_guess_which_checkout_a_sha_belongs_to(bag) -> None:
+    citation = capture_code_citation(bag=bag, stage="draft", claim_id="c1",
+                                     quote="q", commit_sha=SHA)
+    with pytest.raises(CitationError) as caught:
+        resolve_citation(bag=bag, citation=citation)
+    assert "git" in str(caught.value)
+
+
+def test_a_citation_with_no_captured_bytes_FAILS_CLOSED(bag) -> None:
+    """REQUIREMENT 8's ACTUAL ENFORCEMENT, and the docstrings say so plainly.
+
+    An activity boundary does not make the call happen — nothing forces a
+    workflow to capture before it cites. What breaks the silence is `verify`
+    reporting `missing` with a non-zero exit for a citation naming a digest
+    nothing was stored under, so a read path that skipped capture surfaces as a
+    finding rather than as an empty result.
+    """
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="a source",
+        source_ref="https://example.org/a", data=PAGE)
+    object_path(bag.path, citation.page_content_hash).unlink()
+
+    report = verify_bag(bag.path)
+    assert not report.ok
+    assert report.counts()[MISSING] == 1

--- a/scripts/workflows/temporal/tests/unit/test_content_store.py
+++ b/scripts/workflows/temporal/tests/unit/test_content_store.py
@@ -63,6 +63,14 @@ def test_the_digest_is_the_only_input_to_the_path() -> None:
     SAMPLE_DIGEST + "0",
     "",
     "sha256:" + SAMPLE_DIGEST,
+    # A TRAILING NEWLINE, because `$` does not mean end-of-string. This gate
+    # was `re.compile(r"^…$")` and returned for this value — composing it onto
+    # a path in the function whose docstring says such a value is refused
+    # rather than composed. `test_journal_regex_anchors.py` holds the CLASS
+    # (no `^`/`$` anywhere in `modules/journal/`); this row is the instance,
+    # here in the battery a reader extending "what is not a digest" will open.
+    SAMPLE_DIGEST + "\n",
+    "\n" + SAMPLE_DIGEST,
 ])
 def test_a_value_that_is_not_a_digest_never_reaches_a_path(hostile: str) -> None:
     """The gate is on the WAY IN, so no traversal has to be contained on the way out.

--- a/scripts/workflows/temporal/tests/unit/test_content_store.py
+++ b/scripts/workflows/temporal/tests/unit/test_content_store.py
@@ -181,3 +181,125 @@ def test_stored_digests_ignores_a_file_that_is_not_an_object(bag) -> None:
 
 def test_an_empty_store_enumerates_to_nothing_rather_than_failing(bag) -> None:
     assert stored_digests(bag.path) == []
+
+
+# --- the anchor, and the staging name -------------------------------------------
+
+@pytest.mark.parametrize("digest", [
+    SAMPLE_DIGEST + "\n",
+    SAMPLE_DIGEST + "\r",
+    "\n" + SAMPLE_DIGEST,
+])
+def test_a_digest_with_a_LINE_BREAK_is_refused(digest) -> None:
+    """⚠ `^…$` ACCEPTED `"a"*64 + "\\n"` AND COMPOSED IT ONTO A PATH.
+
+    `$` matches before a trailing newline, so the function whose docstring says
+    "a value that is not 64 lowercase hex characters is refused here rather than
+    composed onto a path" was composing one. `bag._RUN_ID_RE` states the
+    `\\A`/`\\Z` rule twelve lines above the function this module reuses; this
+    module did not reach for it.
+
+    The leading case is here because `\\A` and `^` differ there too, and the
+    hostile parametrization above enumerates seven neighbours and misses all
+    three of these.
+    """
+    with pytest.raises(ContentStoreError):
+        validated_digest(digest)
+    with pytest.raises(ContentStoreError):
+        object_relpath(digest)
+
+
+def test_two_captures_of_ONE_source_on_two_threads_both_land(tmp_path, monkeypatch) -> None:
+    """⚠ THE STAGING NAME CARRIED ONLY THE PID, WHICH IS NOT UNIQUE ACROSS THREADS.
+
+    A Temporal worker runs sync activities on a thread pool — the shape this
+    package says the port carries — so two threads capturing the same bytes in
+    one process collided on one staging name. The loser's `O_EXCL` raised, and
+    its handler then unlinked the file the WINNER was still writing, so
+    `os.replace` failed for both and NEITHER capture landed. Both callers got a
+    `ContentStoreError` for a store that was working correctly.
+
+    The window is widened deterministically rather than raced for: `os.write` is
+    made slow, so the second thread is guaranteed to be inside `store_bytes`
+    while the first still holds its staging file.
+    """
+    import threading
+    import time
+    from modules.journal import content_store as store_mod
+
+    bag_path = tmp_path / "bag"
+    (bag_path / "data").mkdir(parents=True)
+    payload = b"one source, two concurrent captures"
+
+    real_write = store_mod.os.write
+
+    def slow_write(fd, data):
+        time.sleep(0.15)
+        return real_write(fd, data)
+
+    monkeypatch.setattr(store_mod.os, "write", slow_write)
+
+    start = threading.Barrier(4)
+    results: list[object] = []
+    lock = threading.Lock()
+
+    def capture() -> None:
+        start.wait(timeout=10)
+        try:
+            outcome = store_bytes(bag_path, payload)
+        except Exception as exc:               # noqa: BLE001 — the finding IS the exception
+            outcome = exc
+        with lock:
+            results.append(outcome)
+
+    threads = [threading.Thread(target=capture) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    failures = [r for r in results if isinstance(r, Exception)]
+    assert not failures, f"concurrent captures of one source failed: {failures}"
+    assert set(results) == {digest_of_bytes(payload)}
+    assert load_object(bag_path, digest_of_bytes(payload)) == payload
+    # No staging file survives — the cleanup removed only each call's own.
+    leftovers = [p.name for p in bag_path.rglob(".*.part")]
+    assert not leftovers, f"staging files left behind: {leftovers}"
+
+
+def test_the_three_read_failures_are_three_TYPES_not_three_sentences(tmp_path) -> None:
+    """⚠ `verify` CLASSIFIED THESE BY SUBSTRING AND A LEGAL RUN ID BROKE IT.
+
+    The outcome class is a fact about WHAT FAILED, so it has to survive the
+    message being reworded — and the message embeds the store path, which embeds
+    the run id, which `RUN_ID_PERMITTED` lets contain the word `TAMPERED`.
+    """
+    from modules.journal.content_store import (ObjectCorrupt, ObjectMissing,
+                                               ObjectUnreadable)
+    bag_path = tmp_path / "bag"
+    (bag_path / "data").mkdir(parents=True)
+
+    digest = store_bytes(bag_path, b"the bytes as received")
+    absent = digest_of_bytes(b"never stored")
+
+    with pytest.raises(ObjectMissing):
+        load_object(bag_path, absent)
+
+    target = object_path(bag_path, digest)
+    target.write_bytes(b"different bytes under the same name")
+    with pytest.raises(ObjectCorrupt):
+        load_object(bag_path, digest)
+
+    # Present and unreadable: a directory where the object should be. NOT
+    # `ObjectMissing` — "re-capture the source" is destructive advice for bytes
+    # that are merely behind a failing disk or a permission.
+    target.unlink()
+    target.mkdir()
+    with pytest.raises(ObjectUnreadable):
+        load_object(bag_path, digest)
+
+    # And every one of them is still a `ContentStoreError`, so a caller that
+    # does not care which stays correct.
+    assert issubclass(ObjectMissing, ContentStoreError)
+    assert issubclass(ObjectCorrupt, ContentStoreError)
+    assert issubclass(ObjectUnreadable, ContentStoreError)

--- a/scripts/workflows/temporal/tests/unit/test_content_store.py
+++ b/scripts/workflows/temporal/tests/unit/test_content_store.py
@@ -1,0 +1,183 @@
+"""The content store: a path is a function of the digest, and a read re-hashes.
+
+TWO PROPERTIES CARRY THIS MODULE AND EVERYTHING ELSE HERE IS SUPPORT. r7(b) says
+the on-disk path derives from the computed digest ALONE, because the store sits
+under the journal root beside the bags and a source-controlled string reaching
+the path writes outside it. r7(d) says every read re-hashes and fails closed,
+because a store checked only when somebody invokes a checker is checked never.
+
+WHAT THIS FILE DOES NOT LOOK AT, named because a guard that does not say so
+invites being read as complete: it never opens a socket, so nothing here says
+anything about the fetch policy (`test_source_fetch.py`), and it never reads a
+citation, so nothing here says whether a QUOTE still occurs in the bytes
+(`test_verify_citations.py`). It answers only where bytes go and what comes back.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import PAYLOAD_DIR, open_bag
+from modules.journal.content_store import (CONTENT_STORE_DIR, DIGEST_ALGORITHM,
+                                           ContentStoreError, digest_of_bytes,
+                                           has_object, load_object,
+                                           object_path, object_relpath,
+                                           store_bytes, store_dir,
+                                           stored_digests, validated_digest)
+
+SAMPLE = b"the bytes a claim was made against\n"
+SAMPLE_DIGEST = hashlib.sha256(SAMPLE).hexdigest()
+
+
+@pytest.fixture
+def bag(root: Path):
+    return open_bag(root, "run-content-store")
+
+
+# --- r7(b): the path is a function of the digest and of nothing else ------------
+
+def test_the_digest_is_the_only_input_to_the_path() -> None:
+    """Same digest, same path, every time — and no other argument exists to give.
+
+    The signature IS the guarantee: `object_relpath` takes one parameter, so a
+    URL, a filename or a `Content-Disposition` header has nowhere to enter. A
+    test that only checked the OUTPUT would pass against a function that also
+    accepted a name and ignored it today.
+    """
+    assert object_relpath(SAMPLE_DIGEST) == (
+        f"{PAYLOAD_DIR}/{CONTENT_STORE_DIR}/{DIGEST_ALGORITHM}/"
+        f"{SAMPLE_DIGEST[:2]}/{SAMPLE_DIGEST[2:]}")
+    assert object_relpath.__code__.co_argcount == 1
+
+
+@pytest.mark.parametrize("hostile", [
+    "../../../../etc/passwd",
+    "/etc/passwd",
+    "..",
+    "ab/../../../etc/passwd",
+    SAMPLE_DIGEST.upper(),
+    SAMPLE_DIGEST[:-1],
+    SAMPLE_DIGEST + "0",
+    "",
+    "sha256:" + SAMPLE_DIGEST,
+])
+def test_a_value_that_is_not_a_digest_never_reaches_a_path(hostile: str) -> None:
+    """The gate is on the WAY IN, so no traversal has to be contained on the way out.
+
+    Uppercase hex is refused rather than folded: a digest in the wrong case did
+    not come from this module's own hashing, and normalising it would hide that
+    the store had acquired two naming conventions.
+    """
+    with pytest.raises(ContentStoreError):
+        object_relpath(hostile)
+    with pytest.raises(ContentStoreError):
+        validated_digest(hostile)
+
+
+def test_a_stored_object_lands_under_the_bags_payload(bag) -> None:
+    """r7(a) RULED PER-RUN: the store is INSIDE `data/`, so the bag's manifest covers it.
+
+    This is the assertion the whole r7(a)/Phase-7/Phase-5 reconciliation rests
+    on. If the object landed beside the bag rather than inside it, a shipped bag
+    would validate clean at a destination with its cited bytes absent, and
+    retention deleting a run folder would leave its bytes behind.
+    """
+    digest = store_bytes(bag.path, SAMPLE)
+    target = object_path(bag.path, digest)
+    assert target.is_file()
+    assert target.read_bytes() == SAMPLE
+    assert bag.payload_dir in target.parents
+    assert store_dir(bag.path).name == CONTENT_STORE_DIR
+
+
+def test_the_bags_own_manifest_covers_every_stored_object(bag) -> None:
+    """Sealing the bag hashes the store's objects too — no second mechanism needed.
+
+    THE DERIVED HALF OF THE RULING. Phase 7 requirement 2 wants a shipped bag's
+    referenced objects to travel with it; because the store is payload, they are
+    already in `manifest-sha256.txt` and `validate_bag` already re-hashes them.
+    """
+    digest = store_bytes(bag.path, SAMPLE)
+    bag.seal()
+    manifest = bag.manifest_path.read_text(encoding="utf-8")
+    assert object_relpath(digest) in manifest
+    assert digest in manifest
+
+
+# --- r7(d): one read path, and it fails closed ----------------------------------
+
+def test_a_round_trip_returns_exactly_what_was_stored(bag) -> None:
+    digest = store_bytes(bag.path, SAMPLE)
+    assert digest == SAMPLE_DIGEST == digest_of_bytes(SAMPLE)
+    assert load_object(bag.path, digest) == SAMPLE
+
+
+def test_an_absent_object_is_MISSING_and_says_so(bag) -> None:
+    """`missing` and `tampered` carry different words because they exit differently."""
+    with pytest.raises(ContentStoreError) as caught:
+        load_object(bag.path, SAMPLE_DIGEST)
+    assert "MISSING" in str(caught.value)
+    assert "TAMPERED" not in str(caught.value)
+    assert not has_object(bag.path, SAMPLE_DIGEST)
+
+
+def test_an_ALTERED_STORED_BYTE_is_detected_on_read(bag) -> None:
+    """THE PHASE'S OWN CHECKLIST ITEM: change one byte, the read refuses.
+
+    A single byte, not a rewrite — the whole argument for naming an object by
+    its checksum is that the name changes if ONE byte does, and a test that
+    replaced the whole file would pass against a length check.
+    """
+    digest = store_bytes(bag.path, SAMPLE)
+    target = object_path(bag.path, digest)
+    data = bytearray(target.read_bytes())
+    data[0] ^= 0x01
+    target.write_bytes(bytes(data))
+
+    assert has_object(bag.path, digest), "the file is still there — that is the point"
+    with pytest.raises(ContentStoreError) as caught:
+        load_object(bag.path, digest)
+    assert "TAMPERED" in str(caught.value)
+    assert digest_of_bytes(bytes(data)) in str(caught.value), (
+        "the refusal must name what the bytes DO hash to, or an operator cannot "
+        "tell a corrupted object from one filed under the wrong name")
+
+
+def test_storing_the_same_bytes_twice_is_one_object(bag) -> None:
+    """Content addressing makes idempotency a property rather than a code path."""
+    first = store_bytes(bag.path, SAMPLE)
+    second = store_bytes(bag.path, SAMPLE)
+    assert first == second
+    assert stored_digests(bag.path) == [first]
+
+
+def test_the_store_refuses_text(bag) -> None:
+    """Encoding is the caller's decision, because the digest is over the bytes.
+
+    Choosing an encoding here would change the digest a citation was made
+    against, which is the one value in this design that must not be this
+    module's opinion.
+    """
+    with pytest.raises(ContentStoreError) as caught:
+        store_bytes(bag.path, "not bytes")
+    assert "bytes" in str(caught.value)
+
+
+def test_stored_digests_ignores_a_file_that_is_not_an_object(bag) -> None:
+    """A stray file must not be able to impersonate an object.
+
+    Derived by walking rather than by reading an index, so the walk has to say
+    what it will and will not count — otherwise a hand-dropped file appears in
+    an inventory that other code treats as authoritative.
+    """
+    digest = store_bytes(bag.path, SAMPLE)
+    stray = store_dir(bag.path) / DIGEST_ALGORITHM / SAMPLE_DIGEST[:2] / "README"
+    stray.write_text("not an object")
+    assert stored_digests(bag.path) == [digest]
+
+
+def test_an_empty_store_enumerates_to_nothing_rather_than_failing(bag) -> None:
+    assert stored_digests(bag.path) == []

--- a/scripts/workflows/temporal/tests/unit/test_every_subprocess_the_fleet_launches_is_bounded.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_subprocess_the_fleet_launches_is_bounded.py
@@ -110,6 +110,12 @@ _STREAMING_POPEN = {
 _OTHER_LAUNCH_SPELLINGS = frozenset({"call", "check_call", "check_output", "getoutput",
                                      "getstatusoutput"})
 
+# The two `os` functions that launch a shell. `os` is not refused when aliased —
+# it is RESOLVED — because unlike `subprocess` it is imported all over this tree
+# for reasons that have nothing to do with launching, so a blanket refusal of
+# `import os as X` would be a rule about the wrong thing.
+_OS_LAUNCH_SPELLINGS = frozenset({"system", "popen"})
+
 
 def where_or_module(stack: list[str]) -> str:
     return stack[0] if stack else "<module>"
@@ -120,10 +126,23 @@ class _Launches(ast.NodeVisitor):
 
     def __init__(self, rel: str) -> None:
         self.rel = rel
+        # Names reaching `os`. Seeded so a control snippet with no import in it
+        # still reads `os.system`, and replaced per-module by `visit_Module`.
+        self._os_names: set[str] = {"os"}
         self.func: list[str] = []
         self.runs: list[tuple[str, str, int, bool]] = []
         self.popens: list[tuple[str, str, int]] = []
         self.other: list[tuple[str, str, int, str]] = []
+
+    def visit_Module(self, node: ast.Module):  # noqa: N802
+        # RESOLVED UP FRONT rather than as the walk passes the import: a
+        # function-local `import os as _os` is visited after every call in the
+        # functions above it, so binding on arrival leaves those unresolved.
+        self._os_names = {"os"} | {
+            a.asname or a.name
+            for n in ast.walk(node) if isinstance(n, ast.Import)
+            for a in n.names if a.name == "os"}
+        self.generic_visit(node)
 
     def visit_FunctionDef(self, node: ast.FunctionDef):  # noqa: N802
         self.func.append(node.name)
@@ -154,17 +173,32 @@ class _Launches(ast.NodeVisitor):
             elif f.attr in _OTHER_LAUNCH_SPELLINGS:
                 self.other.append((self.rel, where, node.lineno, f"subprocess.{f.attr}"))
         elif (isinstance(f, ast.Attribute) and isinstance(f.value, ast.Name)
-                and f.value.id == "os" and f.attr in {"system", "popen"}):
+                and f.value.id in self._os_names and f.attr in _OS_LAUNCH_SPELLINGS):
             self.other.append((self.rel, where_or_module(self.func), node.lineno,
-                               f"os.{f.attr}"))
+                               f"{f.value.id}.{f.attr}"))
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom):  # noqa: N802
         # `from subprocess import run` defeats the attribute matcher entirely.
+        #
+        # `os` IS HELD TO THE SAME RULE, and it was not when this was written.
+        # The matcher below tests `f.value.id == "os"` for `system`/`popen`, so
+        # `from os import system` and `import os as _os` walked past it exactly
+        # as the `subprocess` spellings did — the residue of a fix applied to the
+        # site it was found at rather than to the class. Only the two LAUNCHING
+        # names are refused: `from os import environ` is ubiquitous and has
+        # nothing to do with this guard.
         if node.module == "subprocess":
             for alias in node.names:
                 self.other.append((self.rel, "<import>", node.lineno,
                                    f"from subprocess import {alias.name}"))
+        elif node.module == "os":
+            # `from os import *` binds both launch names, so it is refused as a
+            # whole rather than left as a spelling nobody looked at.
+            for alias in node.names:
+                if alias.name in _OS_LAUNCH_SPELLINGS or alias.name == "*":
+                    self.other.append((self.rel, "<import>", node.lineno,
+                                       f"from os import {alias.name}"))
         self.generic_visit(node)
 
     def visit_Import(self, node: ast.Import):  # noqa: N802
@@ -327,6 +361,17 @@ def test_the_bounded_predicate_discriminates(snippet: str, expect_bounded: bool,
         pytest.param("os.system(cmd)", "os.system", id="os-system"),
         pytest.param("from subprocess import run", "a direct import", id="import-from"),
         pytest.param("import subprocess as sp", "an aliased import", id="import-as"),
+        # THE `os` HALF, WHICH WAS THE RESIDUE. The two `subprocess` spellings
+        # were closed at the site they were found at; the identical pair on `os`
+        # was one `elif` away and stayed open.
+        pytest.param("import os as _os\n_os.system(cmd)", "an aliased `os.system`",
+                     id="os-aliased"),
+        pytest.param("import os as _os\n_os.popen(cmd)", "an aliased `os.popen`",
+                     id="os-popen-aliased"),
+        pytest.param("from os import system", "`os.system` reached by from-import",
+                     id="os-import-from"),
+        pytest.param("from os import *", "the star import, which binds both "
+                     "launch names", id="os-import-star"),
     ],
 )
 def test_the_other_spelling_detector_discriminates(snippet: str, why: str) -> None:
@@ -341,6 +386,34 @@ def test_the_control_does_not_flag_ordinary_code() -> None:
     v = _Launches("<control>")
     v.visit(ast.parse("import subprocess\nx = json.loads(r.stdout)\nos.path.join(a, b)\n"))
     assert v.other == [] and v.runs == [] and v.popens == []
+
+
+@pytest.mark.parametrize(
+    ("snippet", "why"),
+    [
+        pytest.param("import os as _os\n_os.path.join(a, b)",
+                     "an aliased `os` used for something that is not a launch",
+                     id="aliased-os-benign"),
+        pytest.param("from os import environ\nx = environ['HOME']",
+                     "the from-import spelling of a name that launches nothing",
+                     id="os-environ"),
+        pytest.param("import os\nos.fspath(p)", "an ordinary `os` call",
+                     id="os-fspath"),
+    ],
+)
+def test_resolving_os_ALIASES_does_not_invent_a_launch(snippet: str, why: str) -> None:
+    """THE COST OF RESOLVING RATHER THAN REFUSING, and why it is the right side.
+
+    `subprocess` is refused when aliased because a module imports it for exactly
+    one reason. `os` is not: this tree imports it everywhere for `environ`,
+    `fspath` and `path`, so refusing `import os as X` would be a rule about
+    aliasing rather than about launching, and would be answered by an exemption
+    list that says nothing. Resolving costs this control instead — the detector
+    must follow the alias to the two LAUNCH names and to nothing else.
+    """
+    v = _Launches("<control>")
+    v.visit(ast.parse(snippet))
+    assert v.other == [], f"{why} was wrongly read as a launch: {v.other}"
 
 
 @pytest.mark.parametrize(

--- a/scripts/workflows/temporal/tests/unit/test_journal_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_bag.py
@@ -34,7 +34,8 @@ from modules.journal import bag as bagmod
 from modules.journal.bag import (BAGIT_FILE, BAG_INFO_FILE, DIR_MODE,
                                  FILE_MODE, JOURNAL_SCHEMA_VERSION,
                                  MANIFEST_FILE, PAYLOAD_DIR, BagError,
-                                 open_bag, read_tag_file)
+                                 open_bag, read_tag_file,
+                                 safe_payload_segment)
 
 
 def _info(bag) -> dict[str, list[str]]:
@@ -123,6 +124,39 @@ def test_a_writer_name_is_slugified_rather_than_trusted(root: Path) -> None:
     allocated = bag.writer_dir("../weird name/../")
     assert allocated.parent == bag.payload_dir
     assert allocated.name not in ("", ".", "..")
+
+
+@pytest.mark.parametrize("name", ["..", ".", "...", "-.-", " .. "])
+def test_a_DOTS_ONLY_writer_name_does_not_become_a_RELATIVE_segment(
+        root: Path, name: str) -> None:
+    """⚠ THE ALLOWLIST ADMITS `.`, SO THE SLUG COULD BE A BARE `..`.
+
+    `[A-Za-z0-9._-]` permits a dot, so `safe_payload_segment("..")` returned
+    `".."` and `writer_dir` joined it onto the payload directory. The
+    containment declaration for that join asserted the opposite in prose. What
+    stopped an escape was `os.mkdir` failing on the already-existing parent and
+    the caller taking the next ordinal — an accident of the collision loop, not
+    the rule the declaration named. Found from one module over, when the content
+    store reached for the same slug rule and `contained_relpath` refused what it
+    produced.
+    """
+    bag = open_bag(root, "r")
+    allocated = bag.writer_dir(name)
+    assert allocated.parent == bag.payload_dir
+    assert allocated.resolve().parent == bag.payload_dir.resolve(), (
+        f"{allocated} resolves outside the payload directory")
+    assert safe_payload_segment(name) == "writer"
+
+
+def test_a_name_that_slugs_to_dots_AND_dashes_stays_a_real_segment() -> None:
+    """`../..` becomes `..-..`, which is a filename and not a relative segment.
+
+    The fallback is for names that reduce to nothing usable, not for every name
+    containing a dot — folding this one to `writer` too would collapse distinct
+    writers onto one directory for no safety gain.
+    """
+    assert safe_payload_segment("../..") == "..-.."
+    assert set("..-..") != {"."}
 
 
 # --- sealing -------------------------------------------------------------------

--- a/scripts/workflows/temporal/tests/unit/test_journal_containment.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_containment.py
@@ -83,9 +83,16 @@ _TRUSTED_JOINS = {
         "deny-list refused `a/b` and admitted a newline; the run id is also a "
         "tag VALUE, and `test_journal_tag_lines.py` is the sweep for that half.",
     ("bag.py", "slug if ordinal == 1 else f'{slug}-{ordinal}'"):
-        "writer_dir slugifies through _SAFE_SEGMENT_RE, which maps every "
-        "character outside [A-Za-z0-9._-] to '-', so no separator survives and "
-        "no segment can be a bare '..' that mkdir would follow.",
+        "writer_dir slugifies through `bag.safe_payload_segment`, which maps "
+        "every character outside [A-Za-z0-9._-] to '-' so no separator "
+        "survives, AND folds a dots-only result to 'writer' so the segment "
+        "cannot be a bare '..' or '.'. ⚠ THIS ROW USED TO CLAIM THE SECOND HALF "
+        "OF THAT WHILE THE CODE ONLY DID THE FIRST — the allowlist admits '.', "
+        "so `writer_dir('..')` slugged to '..' and joined onto the payload "
+        "directory. It escaped nothing only because `os.mkdir` fails on an "
+        "existing directory and the caller took the next ordinal, which is luck "
+        "rather than the stated rule. Found when the content store needed the "
+        "same rule and `contained_relpath` refused the result.",
     ("bag.py", "rel"):
         "seal() joins paths that payload_files() derived by walking the bag's "
         "own data/ directory — they come off the filesystem, not off a caller.",
@@ -95,6 +102,16 @@ _TRUSTED_JOINS = {
         "_parse_manifest passes every manifest entry through contained_relpath "
         "before it reaches this dict, and refuses the line otherwise. This is "
         "the join that reported PASS over /etc/hostname before that existed.",
+    ("content_store.py", "f'.{digest}.{os.getpid()}.part'"):
+        "store_bytes composes a staging name from two values NEITHER of which "
+        "a caller supplies: `digest` is this module's own sha256 hex output, "
+        "re-proven by `validated_digest` inside `object_path` on the line that "
+        "produced `parent`, and `os.getpid()` is an integer from the kernel. "
+        "The literal parts carry no separator, so the result is one filename "
+        "and cannot be a relative segment. It joins onto `parent`, which is "
+        "itself the contained object path's directory — the join that carries "
+        "the caller's value is `object_path`, and it goes through "
+        "`contained_relpath`.",
 }
 
 # Spellings of a path join this package must not use, because the sweep above

--- a/scripts/workflows/temporal/tests/unit/test_journal_containment.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_containment.py
@@ -102,11 +102,15 @@ _TRUSTED_JOINS = {
         "_parse_manifest passes every manifest entry through contained_relpath "
         "before it reaches this dict, and refuses the line otherwise. This is "
         "the join that reported PASS over /etc/hostname before that existed.",
-    ("content_store.py", "f'.{digest}.{os.getpid()}.part'"):
-        "store_bytes composes a staging name from two values NEITHER of which "
+    ("content_store.py", "f'.{digest}.{os.getpid()}.{uuid.uuid4().hex}.part'"):
+        "store_bytes composes a staging name from three values NONE of which "
         "a caller supplies: `digest` is this module's own sha256 hex output, "
         "re-proven by `validated_digest` inside `object_path` on the line that "
-        "produced `parent`, and `os.getpid()` is an integer from the kernel. "
+        "produced `parent`, `os.getpid()` is an integer from the kernel, and "
+        "`uuid.uuid4().hex` is 32 hex characters from the uuid module — added "
+        "because the pid alone is NOT unique across the threads a Temporal "
+        "worker runs sync activities on, and two threads collided on one "
+        "staging name. "
         "The literal parts carry no separator, so the result is one filename "
         "and cannot be a relative segment. It joins onto `parent`, which is "
         "itself the contained object path's directory — the join that carries "

--- a/scripts/workflows/temporal/tests/unit/test_journal_operator_tools_separate_typo_from_finding.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_operator_tools_separate_typo_from_finding.py
@@ -1,0 +1,196 @@
+"""An operator-named target that is not there is USAGE — swept over both tools.
+
+WHY THIS FILE EXISTS, AS THE MEASUREMENT RATHER THAN AS A PRINCIPLE. Phase 2 hit
+this defect twice, in the same shape, one review pass apart:
+
+  * `verify.main` short-circuited to `EXIT_USAGE` on any structural finding, so
+    a citation record that could not be read exited with the number documented
+    as "you invoked this wrongly". Fixed by splitting `EXIT_STRUCTURAL` out.
+  * `validate.main` did the mirror image and was left standing by that fix:
+    `if (target / BAGIT_FILE).is_file() or not target.is_dir()` routed a path
+    that is not there INTO `validate_bag`, so a mistyped argument printed a full
+    `result: FAIL` report — asserting `lifecycle`, `redacted`, `incomplete` and a
+    payload size about a bag that does not exist — and exited 1, the code that
+    means a bag's bytes did not match its manifest.
+
+The second was found by a reviewer sweeping OUTWARD from the diff into the
+sibling nobody edited, and the pass that fixed the first had the two `main()`
+bodies open side by side while rejecting an unrelated finding about them. So the
+lesson is not "check the sibling": it is that a rule applied by hand to one
+`main()` is a rule nothing holds. This sweep DERIVES the population and applies
+the rule to each member, so a third bag-inspection tool inherits it on the day it
+is written rather than on the day someone mistypes a path at it.
+
+THE POPULATION IS DERIVED, NOT LISTED. It is every non-kickoff entrypoint under
+`scripts/` that imports `modules.journal.validate` or `modules.journal.verify` —
+which is what "a tool that inspects a bag an operator names" means in this tree.
+A tool added later joins the sweep by importing the checker it wraps, which it
+must do to be one.
+
+⚠ WHAT THIS DOES NOT COVER, because a sweep is only as good as its predicate:
+
+  * IT DOES NOT REACH `validate_bag()` OR `verify_bag()`. Those deliberately
+    RETURN a structural report for a path that is not a directory, because a
+    programmatic sweep over a journal wants a report per bag rather than an
+    exception on the first bad one. The split is between what a library returns
+    and what an operator is told, and only the second half is asserted here.
+  * IT ASSERTS THE CODE AND THE SILENCE, NOT THE WORDING. A tool that exits 2
+    and prints nothing to stdout passes even if its stderr message is unhelpful.
+  * IT SEES A TARGET THAT DOES NOT EXIST. A target that exists and is the wrong
+    KIND of thing — a regular file, a directory holding no bags — is a separate
+    question each tool answers in its own docstring.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import pathlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import open_bag
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+TEMPORAL = REPO_ROOT / "scripts" / "workflows" / "temporal"
+ENTRYPOINTS_DIR = TEMPORAL / "scripts"
+
+_CHECKER_MODULES = ("modules.journal.validate", "modules.journal.verify")
+
+# The code every member of this population must return for a target that is not
+# there. It is spelled once so that a tool answering "2" for a coincidental
+# reason and a tool answering it for this reason are the same assertion.
+EXIT_USAGE = 2
+
+
+def imports_a_bag_checker(tree: ast.Module) -> bool:
+    """True when this module's parsed source wraps `validate` or `verify`.
+
+    AST rather than a substring search: a filename mentioned in a docstring or a
+    usage string is not an import, and this predicate's whole job is to be a
+    statement about what the module DOES.
+
+    TAKES A PARSED TREE RATHER THAN A PATH so the predicate can be exercised
+    against a literal snippet — see `test_the_predicate_answers_correctly_on_a_
+    LITERAL` below. A recogniser whose only evidence is that it worked against
+    the tree on the day it was written is the failure
+    `test_a_census_guard_proves_its_own_predicate.py` exists to refuse.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in _CHECKER_MODULES:
+                return True
+            if node.module == "modules.journal":
+                if any(alias.name in ("validate", "verify") for alias in node.names):
+                    return True
+        elif isinstance(node, ast.Import):
+            if any(alias.name in _CHECKER_MODULES for alias in node.names):
+                return True
+    return False
+
+
+def bag_inspection_entrypoints() -> list[Path]:
+    return sorted(p for p in ENTRYPOINTS_DIR.glob("*.py")
+                  if not p.name.startswith("run_")
+                  and imports_a_bag_checker(ast.parse(p.read_text(encoding="utf-8"))))
+
+
+def test_the_predicate_finds_something_at_all() -> None:
+    """A sweep whose population silently emptied is green and asserts nothing.
+
+    This is the failure `test_a_census_guard_proves_its_own_predicate` exists for,
+    stated here because a rename under `scripts/` would take the whole sweep out
+    without turning a single case red.
+    """
+    found = bag_inspection_entrypoints()
+    assert found, (
+        f"no entrypoint under {ENTRYPOINTS_DIR} imports {' or '.join(_CHECKER_MODULES)}; "
+        "either the tools moved or the predicate went blind")
+
+
+def test_the_predicate_answers_correctly_on_a_LITERAL() -> None:
+    """The recogniser, exercised on snippets the tree does not contain.
+
+    Both directions, because a predicate that answers `True` unconditionally
+    passes the population check above and every case below it.
+    """
+    assert imports_a_bag_checker(ast.parse("from modules.journal import validate"))
+    assert imports_a_bag_checker(ast.parse("from modules.journal import verify as v"))
+    assert imports_a_bag_checker(ast.parse("from modules.journal.verify import main"))
+    assert imports_a_bag_checker(ast.parse("import modules.journal.validate"))
+
+    # A filename in prose or in a usage string is not an import, and a sibling
+    # module of the checkers is not a checker.
+    assert not imports_a_bag_checker(ast.parse('"""runs validate_bag.py"""'))
+    assert not imports_a_bag_checker(ast.parse('USAGE = "modules.journal.verify"'))
+    assert not imports_a_bag_checker(ast.parse("from modules.journal import bag"))
+    assert not imports_a_bag_checker(
+        ast.parse("from modules.journal.root import resolve_journal_root"))
+
+
+@pytest.mark.parametrize("entrypoint", bag_inspection_entrypoints(),
+                         ids=lambda p: p.name)
+def test_a_target_that_is_not_there_is_usage_and_prints_no_report(
+        entrypoint: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Exit 2, and nothing on stdout that could be read as a verdict about a bag.
+
+    The silence is half the property. An exit code nobody looks at is repaired by
+    a report that says `result: FAIL` next to a path the operator mistyped.
+    """
+    if str(ENTRYPOINTS_DIR) not in sys.path:
+        sys.path.insert(0, str(ENTRYPOINTS_DIR))
+    module = importlib.import_module(entrypoint.stem)
+
+    code = module.main([str(tmp_path / "no-such-target")])
+    captured = capsys.readouterr()
+
+    assert code == EXIT_USAGE, (
+        f"{entrypoint.name} answered {code} for a target that is not there; "
+        f"{EXIT_USAGE} is usage and every other code this tool returns is a "
+        "statement about a bag that exists")
+    assert captured.out == "", (
+        f"{entrypoint.name} printed a report for a target that is not there:\n"
+        f"{captured.out}")
+
+
+@pytest.mark.parametrize("entrypoint", bag_inspection_entrypoints(),
+                         ids=lambda p: p.name)
+def test_a_bad_target_suppresses_the_report_for_a_good_one_beside_it(
+        entrypoint: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A usage error is answered ALONE, even when an earlier target was fine.
+
+    THE BEHAVIOUR IS DELIBERATE AND IT IS PINNED HERE BECAUSE IT IS SURPRISING.
+    Both tools return at the bad target rather than finishing the list, so a
+    valid earlier target's report is computed and never printed. The alternative
+    — print what succeeded, then the usage error — puts a `result: PASS` block
+    directly above a message saying the operator named something that is not
+    there, which is the same confusion between "a verdict about a bag" and "a
+    problem with your invocation" that the exit-code split exists to end.
+
+    It is asserted for the POPULATION rather than for one tool, so a third
+    bag-inspection tool cannot answer this question differently by accident.
+
+    ⚠ THE FIRST TARGET IS A REAL SEALED BAG AND THAT IS THE WHOLE TEST. The
+    first draft of this case used an empty directory, which both tools already
+    answer with 2 ("no bags under …") BEFORE they ever look at the second
+    argument — so it passed without the second argument existing and proved
+    nothing. Checked by running the empty directory alone; it returned 2 by
+    itself. A bag is the only first target that reaches the report-printing
+    path.
+    """
+    if str(ENTRYPOINTS_DIR) not in sys.path:
+        sys.path.insert(0, str(ENTRYPOINTS_DIR))
+    module = importlib.import_module(entrypoint.stem)
+
+    root = tmp_path / "journal"
+    root.mkdir()
+    good = open_bag(root, "good").path
+
+    code = module.main([str(good), str(tmp_path / "no-such-target")])
+    assert code == EXIT_USAGE
+    assert capsys.readouterr().out == "", (
+        f"{entrypoint.name} printed a report before answering a usage error; a "
+        "verdict about a bag and a problem with the invocation must not appear "
+        "together")

--- a/scripts/workflows/temporal/tests/unit/test_journal_prose_figures_are_DERIVED.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_prose_figures_are_DERIVED.py
@@ -80,6 +80,7 @@ from journal_entrypoint_facts import (ENTRYPOINTS_DIR,  # noqa: E402
 _PROSE = (
     sorted((TEMPORAL / "modules" / "journal").glob("*.py"))
     + [TEMPORAL / "scripts" / "validate_bag.py",
+       TEMPORAL / "scripts" / "verify_citations.py",
        TEMPORAL / "tests" / "conftest.py"]
     # THIS FILE IS EXCLUDED FROM ITS OWN SWEEP, and the reason is not
     # convenience: its negative controls QUOTE the defective prose verbatim, so
@@ -97,6 +98,21 @@ _PROSE = (
        TEMPORAL / "tests" / "unit" / "test_every_parent_opens_a_run_bag.py",
        TEMPORAL / "tests" / "unit" / "test_the_suite_never_writes_to_the_operators_journal.py",
        TEMPORAL / "tests" / "integration" / "test_a_real_bag_validates.py",
+       # ⚠ PHASE 2's SEVEN FILES, NAMED EXPLICITLY BECAUSE THE GLOB ABOVE
+       # MISSES ALL OF THEM. The unit glob is `test_journal_*.py` and the new
+       # tests are `test_content_store.py`, `test_citations.py`, and so on — so
+       # a population figure or a state enumeration written into any of them
+       # was invisible and the guard stayed green. That is the SAME gap this
+       # file already records against `journal_entrypoint_facts.py` two
+       # comments up, recurring one phase later because the remedy was a list
+       # of names rather than a rule about which files hold prose.
+       TEMPORAL / "tests" / "unit" / "test_content_store.py",
+       TEMPORAL / "tests" / "unit" / "test_citations.py",
+       TEMPORAL / "tests" / "unit" / "test_content_activities.py",
+       TEMPORAL / "tests" / "unit" / "test_source_fetch.py",
+       TEMPORAL / "tests" / "unit" / "test_verify_citations.py",
+       TEMPORAL / "tests" / "integration" / "test_citations_verify_offline.py",
+       PLANNING_ROOT / "development" / "edge-assistant" / "persistent-memory-protocol" / "phase2_content_store.md",
        PLANNING_ROOT / "development" / "edge-assistant" / "persistent-memory-protocol" / "phase1_the_run_bag.md",
        REPO_ROOT / "docs" / "file_structure.txt"]
 )
@@ -282,6 +298,20 @@ _DECLARED_NON_DERIVATIONS = {
     ("journal_activities.py", "nine of eleven"):
         "the same pre-fix figure carried into its consequence — nine of eleven "
         "RUNS would have recorded no worktree. Same absent ground truth.",
+    ("phase2_content_store.md", "two entry points"):
+        "NOT A POPULATION FIGURE, AND THE COLLISION IS IN THE PREDICATE RATHER "
+        "THAN IN THE PROSE. Phase 2 requirement 8 reads 'the store's two entry "
+        "points' — capture and resolve — which is ordinary English about two "
+        "functions, not a count of this fleet's kickoff entrypoints. It matches "
+        "because `_figures_in` tolerates `entry\\s?points?`, and every one of "
+        "the thirty-five registered figures in this file is written UNSPACED. "
+        "Narrowing the pattern to `entrypoints?` would drop the collision "
+        "without losing a single real figure — that is a change to a guard's "
+        "reach, so it is surfaced for the operator rather than made by a "
+        "correction pass, and this row is what keeps the sweep honest until "
+        "then. The same collision was hit one module over by the pass that "
+        "wrote the store, which reworded its own docstring; a phase doc in "
+        "another repository is not this repo's to reword.",
     ("phase1_the_run_bag.md", "nine of eleven entrypoints"):
         "the same pre-fix figure, in the doc that records why the 496-byte bag "
         "measurement was superseded. Not derivable for the same reason.",

--- a/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
@@ -1,0 +1,330 @@
+"""No pattern in this package anchors with `^`/`$` — swept over the whole package.
+
+WHY THIS FILE EXISTS, AS THE MEASUREMENT RATHER THAN AS A PRINCIPLE. `$` does not
+mean "end of string". It matches at the end of the string AND immediately before
+a trailing newline, so `re.compile(r"^[0-9a-f]{64}$")` accepts `"ab…f\\n"` — an
+anchored-LOOKING validator that admits a smuggled newline. `\\Z` has no such
+second meaning, and `\\A` says "start of string" where `^` says either that or
+"start of a line" depending on a flag written somewhere else.
+
+This package acquired the defect and then the false closure:
+
+  * `validated_digest` used `^…$`, so a digest carrying a trailing newline passed
+    the shape gate — and that gate IS the path safety, because the on-disk path
+    is composed from the digest. It RETURNED and was composed onto a path by the
+    function whose docstring says such a value is refused rather than composed.
+  * A review pass swept the package, converted what it found, and published the
+    sweep as exhaustive. `bag._LABEL_RE` was still `^…$` at that commit. Not a
+    live defect — both of its callers feed it `splitlines()` output — but a
+    published closure that was false, which is worse than an open one because the
+    next reviewer inherits it and does not look.
+
+Converting the sites did not converge; the next reviewer found the residue. What
+converges is a check that keys on the CLASS, so a `^` or `$` written into this
+package tomorrow fails at the moment it is written rather than at the moment
+somebody re-runs the sweep by hand.
+
+⚠ THE RULE IS ABSOLUTE HERE AND THAT IS A CHOICE, not an oversight. `^…$` under
+`re.MULTILINE` is correct line-scanning and nothing in this package does it; a
+pattern that needs it will fail this and should be added to `_DECLARED` below
+with the reason, exactly as the containment and tag-line sweeps do for their own
+exemptions. An empty escape hatch is the honest state, not a missing one.
+
+⚠ WHAT THIS DOES NOT COVER, because a sweep is only as good as its predicate:
+
+  * IT SWEEPS `modules/journal/*.py` AND NOTHING ELSE, the same scope as the
+    containment and tag-line sweeps. A pattern in another package is invisible
+    here and the scope is named in the failure message so a reader hitting it
+    learns the boundary rather than assuming there is none.
+  * IT SEES A STRING LITERAL PASSED TO `re.compile`. A pattern built by
+    concatenation at runtime, or handed to `re.match` directly without being
+    compiled, is invisible. A test below asserts this package compiles every
+    pattern it uses, which is what keeps the narrow predicate honest.
+  * IT IS A CHECK ON SPELLING, NOT ON CORRECTNESS. `\\A…\\Z` around the wrong
+    character class is still the wrong pattern, and no sweep reaches that.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+PACKAGE = REPO_ROOT / "scripts" / "workflows" / "temporal" / "modules" / "journal"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "workflows" / "temporal"))
+
+# Patterns in this package that legitimately anchor with `^` or `$`, each with
+# the reason it cannot use `\A`/`\Z`. Empty, and an entry added here is a claim a
+# reader can check — which is the point of declaring rather than skipping.
+_DECLARED: dict[str, str] = {}
+
+# The module-level functions this package may use to run an UNCOMPILED pattern.
+# `re.compile` is how a pattern becomes visible to the sweep above, so a direct
+# `re.match(r"...", s)` is a pattern the sweep cannot see.
+_UNCOMPILED_ENTRY_POINTS = ("match", "fullmatch", "search", "sub", "subn",
+                            "split", "findall", "finditer")
+
+
+def _anchor_positions(pattern: str) -> list[str]:
+    """The `^` and `$` in `pattern` that are ANCHORS, in source order.
+
+    A `^` immediately after `[` negates a character class and a `$` inside one is
+    a literal, so both are skipped; so is anything backslash-escaped. Without
+    this, `_SAFE_SEGMENT_RE`'s `[^A-Za-z0-9._-]+` would be reported as an anchor
+    and the sweep would be answered by suppressing it.
+
+    ⚠ A `]` IN LEADING POSITION IS A LITERAL, NOT THE CLOSE — `[]a]` and `[^]a]`
+    are single classes containing `]` and `a`. A scanner that closed on it would
+    read the rest of the pattern as being outside a class and report the class's
+    own `$` as an anchor, which is the direction that produces a FALSE finding
+    and gets answered with a `_DECLARED` suppression. No pattern in scope uses
+    the idiom today; the scanner handles it because a suppression added for a
+    scanner bug outlives the bug.
+    """
+    found: list[str] = []
+    in_class = False
+    i = 0
+    while i < len(pattern):
+        char = pattern[i]
+        if char == "\\":
+            i += 2
+            continue
+        if in_class:
+            if char == "]":
+                in_class = False
+            i += 1
+            continue
+        if char == "[":
+            in_class = True
+            i += 1
+            if i < len(pattern) and pattern[i] == "^":
+                i += 1
+            if i < len(pattern) and pattern[i] == "]":
+                i += 1          # a leading `]` is a member, not the close
+            continue
+        if char in "^$":
+            found.append(char)
+        i += 1
+    return found
+
+
+def _literal_parts(node: ast.expr) -> list[str] | None:
+    """The string literals inside a pattern expression, or `None` if unreadable.
+
+    ⚠ THIS RETURNING `None` IS A FINDING, NOT A SKIP, and the distinction is the
+    whole reason it is written this way. The first draft of this file matched
+    `ast.Constant` alone, which made `content_store._HEX_DIGEST_RE` —
+    `re.compile(r"\\A[0-9a-f]{%d}\\Z" % DIGEST_HEX_LENGTH)`, the gate that IS
+    r7(b)'s path safety — INVISIBLE to the sweep. Reverting that pattern to
+    `^…$` left the sweep green. Found by mutating this file's own new assertion
+    rather than by reading it, which is the only way it could have been found:
+    a blind sweep and a clean package are the same colour.
+
+    So an expression this cannot read fails `test_no_pattern_is_unreadable`
+    below. A pattern nobody can check must not look like a pattern that checked
+    out.
+    """
+    if isinstance(node, ast.Constant):
+        return [node.value] if isinstance(node.value, str) else None
+    # `"literal" % (…)` and `"literal" + …`: the anchors live in the literal
+    # halves, and a substituted value cannot introduce one without being a
+    # literal itself somewhere this walk reaches.
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Mod, ast.Add)):
+        left = _literal_parts(node.left)
+        if left is None:
+            return None
+        if isinstance(node.op, ast.Mod):
+            return left
+        right = _literal_parts(node.right)
+        return None if right is None else left + right
+    # An f-string: the constant segments carry the anchors, the interpolations
+    # are opaque and contribute nothing this sweep can rule on.
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif not isinstance(value, ast.FormattedValue):
+                return None
+        return parts
+    return None
+
+
+def compile_calls_in(tree: ast.Module) -> list[tuple[int, ast.expr]]:
+    """`(lineno, first-argument-expression)` for every `re.compile(…)` call.
+
+    TAKES A PARSED TREE RATHER THAN A PATH so the recogniser can be exercised
+    against a literal snippet — see `test_the_recogniser_answers_correctly_on_a_
+    LITERAL`.
+    """
+    return [(node.lineno, node.args[0])
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute) and node.func.attr == "compile"
+            and isinstance(node.func.value, ast.Name) and node.func.value.id == "re"
+            and node.args]
+
+
+def _compile_calls(path: pathlib.Path) -> list[tuple[int, ast.expr]]:
+    return compile_calls_in(ast.parse(path.read_text(encoding="utf-8")))
+
+
+def _compiled_patterns(path: pathlib.Path) -> list[tuple[int, str]]:
+    """`(lineno, pattern-fragment)` for every readable `re.compile(…)` in a module.
+
+    One entry per literal FRAGMENT, so a pattern assembled from two literals is
+    checked in both halves rather than in whichever one came first.
+    """
+    out: list[tuple[int, str]] = []
+    for lineno, expr in _compile_calls(path):
+        for part in _literal_parts(expr) or ():
+            out.append((lineno, part))
+    return out
+
+
+def _sources() -> list[pathlib.Path]:
+    return sorted(PACKAGE.glob("*.py"))
+
+
+def test_the_sweep_finds_patterns_at_all() -> None:
+    """A predicate that stopped matching is green and asserts nothing."""
+    total = sum(len(_compiled_patterns(p)) for p in _sources())
+    assert total, (
+        f"no `re.compile(<literal>)` found under {PACKAGE}; either the patterns "
+        "moved or the AST predicate went blind")
+
+
+@pytest.mark.parametrize("source", _sources(), ids=lambda p: p.name)
+def test_no_pattern_is_unreadable_to_the_sweep(source: pathlib.Path) -> None:
+    """A pattern this file cannot read must not pass silently.
+
+    The sweep below can only rule on literals it can recover. An expression it
+    cannot recover is reported HERE, so "no anchors found" never means "nothing
+    was looked at" — which is exactly what it meant before this test existed.
+    """
+    unreadable = [lineno for lineno, expr in _compile_calls(source)
+                  if _literal_parts(expr) is None]
+    assert not unreadable, (
+        f"{source.name} builds a regex the anchor sweep cannot read at line(s) "
+        f"{unreadable}; keep the pattern a literal (optionally `%`-formatted or "
+        "an f-string) so `_literal_parts` can recover it, or extend "
+        f"`_literal_parts` in {pathlib.Path(__file__).name} to cover the form")
+
+
+@pytest.mark.parametrize("source", _sources(), ids=lambda p: p.name)
+def test_no_pattern_anchors_with_caret_or_dollar(source: pathlib.Path) -> None:
+    """`\\A` and `\\Z` mean one thing each; `^` and `$` do not."""
+    offenders = [
+        (lineno, pattern, anchors)
+        for lineno, pattern in _compiled_patterns(source)
+        if (anchors := _anchor_positions(pattern)) and pattern not in _DECLARED
+    ]
+    assert not offenders, (
+        f"{source.relative_to(PACKAGE.parent.parent)} anchors with `^`/`$`:\n"
+        + "\n".join(f"  line {lineno}: {pattern!r} -> {''.join(anchors)}"
+                    for lineno, pattern, anchors in offenders)
+        + "\n`$` also matches before a TRAILING NEWLINE, so an anchored-looking "
+          "validator accepts one. Use `\\A`/`\\Z`, or add the pattern to "
+          f"`_DECLARED` in {pathlib.Path(__file__).name} with the reason it "
+          f"cannot. Scope: {PACKAGE}/*.py only.")
+
+
+@pytest.mark.parametrize("source", _sources(), ids=lambda p: p.name)
+def test_every_pattern_is_compiled_so_the_sweep_can_see_it(
+        source: pathlib.Path) -> None:
+    """`re.match(r"...", s)` is a pattern with no `re.compile` to be found at.
+
+    The sweep above reads compiled literals. This is the half that keeps that
+    predicate honest: the alternatives are ABSENT, rather than the predicate
+    being narrow and nobody having checked.
+    """
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    bare = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _UNCOMPILED_ENTRY_POINTS
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "re"
+    ]
+    assert not bare, (
+        f"{source.name} calls `re.<fn>(pattern, …)` directly at line(s) "
+        f"{bare}; compile the pattern to a module constant so the anchor sweep "
+        "in this file can see it")
+
+
+def test_the_recogniser_answers_correctly_on_a_LITERAL() -> None:
+    """`compile_calls_in` + `_literal_parts`, on snippets the tree does not hold.
+
+    The population check above is a floor; this is the control under it. A
+    recogniser that quietly stopped matching `re.compile` would leave every
+    per-file assertion trivially true and every one of them green.
+    """
+    def parts(src: str) -> list[list[str] | None]:
+        return [_literal_parts(expr)
+                for _, expr in compile_calls_in(ast.parse(src))]
+
+    assert parts('X = re.compile(r"^abc$")') == [["^abc$"]]
+    assert parts('X = re.compile(r"\\Aabc\\Z", re.I)') == [["\\Aabc\\Z"]]
+    # `%`-formatted: the anchors live in the left literal, and this is the form
+    # the sweep's own first draft could not see.
+    assert parts('X = re.compile(r"^[0-9a-f]{%d}$" % N)') == [["^[0-9a-f]{%d}$"]]
+    # f-string: the constant segments are recovered, the interpolation is opaque.
+    assert parts('X = re.compile(f"^{PREFIX}$")') == [["^", "$"]]
+    # Concatenation: both halves, so an anchor in either is checked.
+    assert parts('X = re.compile("^a" + "b$")') == [["^a", "b$"]]
+    # UNREADABLE, and reported as such rather than skipped.
+    assert parts('X = re.compile("".join(PARTS))') == [None]
+
+    # Not a `re.compile` call at all.
+    assert parts('X = compile("^abc$")') == []
+    assert parts('X = other.compile(r"^abc$")') == []
+    assert parts('"""re.compile(r\'^abc$\') in a docstring"""') == []
+
+
+def test_the_anchor_scanner_ignores_a_negated_character_class() -> None:
+    """The scanner's own predicate, pinned.
+
+    `[^A-Za-z0-9._-]+` is live in `bag.py` and contains a `^` that is not an
+    anchor. A scanner that reported it would be answered by a `_DECLARED` entry,
+    which is how a sweep starts accumulating suppressions and stops being read.
+    """
+    assert _anchor_positions(r"[^A-Za-z0-9._-]+") == []
+    assert _anchor_positions(r"[$]") == []
+    assert _anchor_positions(r"\^\$") == []
+    assert _anchor_positions(r"^abc$") == ["^", "$"]
+    assert _anchor_positions(r"\A[^:\s][^:]*\Z") == []
+    # A `]` in leading position is a member of the class, so the `$` after the
+    # real close is the only anchor in these.
+    assert _anchor_positions(r"[]a]$") == ["$"]
+    assert _anchor_positions(r"[^]a]$") == ["$"]
+    assert _anchor_positions(r"[]$]") == []
+
+
+def test_the_package_pattern_that_was_the_residue_refuses_a_trailing_newline() -> None:
+    """The instance, pinned beside the class check that would now catch it.
+
+    Both of `_LABEL_RE`'s callers feed it `splitlines()` output, so this was
+    never live — and that is exactly why it survived a sweep published as
+    exhaustive. What is asserted here is the pattern's own contract, so a caller
+    change cannot quietly turn it into a defect.
+    """
+    from modules.journal.bag import _LABEL_RE
+
+    assert _LABEL_RE.match("Label: value") is not None
+    assert _LABEL_RE.match("Label: value\n") is None
+
+
+def test_the_digest_gate_refuses_a_trailing_newline() -> None:
+    """The other instance of the same class, in the gate that IS the path safety."""
+    from modules.journal.content_store import ContentStoreError, validated_digest
+
+    good = "a" * 64
+    assert validated_digest(good) == good
+    with pytest.raises(ContentStoreError):
+        validated_digest(good + "\n")

--- a/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
@@ -40,6 +40,23 @@ exemptions. An empty escape hatch is the honest state, not a missing one.
     concatenation at runtime, or handed to `re.match` directly without being
     compiled, is invisible. A test below asserts this package compiles every
     pattern it uses, which is what keeps the narrow predicate honest.
+
+    `re` IS MATCHED THROUGH ITS IMPORT BINDINGS, and that was NOT true when this
+    file first shipped. Both recognisers required the bare name — `node.func.
+    value.id == "re"` — so `import re as _r` / `_r.compile(r"^x$")`, the aliased
+    `_r.match(r"^x$", s)`, and `from re import compile as _c` / `_c(r"^x$")`
+    were all invisible, verified by three mutations against a green suite. The
+    honesty test in the bullet above SHARED that blind spot, so a blind sweep
+    and a clean package stayed the same colour — which is the one condition this
+    file's own docstring says is why its earlier blindness was ever found. Not
+    live when caught (all three regex-using modules import `re` plainly), but
+    the closure stated two paragraphs up was published and false.
+
+    THAT DEFECT HAS ITS OWN CLASS AND ITS OWN CHECK. A guard recogniser that
+    hard-codes a module's bare name is evaded by an alias in any file, not only
+    this one; `testing/scripts/tests/unit/test_a_guard_RESOLVES_the_module_it_
+    MATCHES.py` sweeps the repository for it, and this file is in that
+    population.
   * IT IS A CHECK ON SPELLING, NOT ON CORRECTNESS. `\\A…\\Z` around the wrong
     character class is still the wrong pattern, and no sweep reaches that.
 """
@@ -154,19 +171,86 @@ def _literal_parts(node: ast.expr) -> list[str] | None:
     return None
 
 
+def re_bindings(tree: ast.Module) -> tuple[set[str], dict[str, str]]:
+    """Every name in this module that reaches `re`, in both spellings.
+
+    Returns `(module_names, function_names)` — the names `re` ITSELF is bound to
+    (`re`, plus any `import re as X`), and a `{local-name: re-function}` map for
+    `from re import compile [as X]`.
+
+    SHARED BY BOTH RECOGNISERS BELOW, AND THAT SHARING IS THE POINT. The two
+    used to hard-code `"re"` independently, so the sweep and the test that keeps
+    the sweep honest had the identical blind spot: an aliased `^…$` was invisible
+    to the sweep AND invisible to the check that the sweep can see everything,
+    and the suite was green either way. `re` is seeded unconditionally because a
+    control drives these on a snippet with no import statement in it at all.
+
+    `from re import *` IS CLOSED RATHER THAN DECLARED. It binds `compile` and
+    every entry point under its own name, so the star is expanded to exactly the
+    names this file cares about. Nothing in the tree uses it; a hole that costs
+    one line to close does not earn a bullet in the boundary list.
+    """
+    modules = {"re"}
+    functions: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules |= {a.asname or a.name for a in node.names if a.name == "re"}
+        elif isinstance(node, ast.ImportFrom) and node.module == "re":
+            for alias in node.names:
+                if alias.name == "*":
+                    functions |= {n: n for n in ("compile", *_UNCOMPILED_ENTRY_POINTS)}
+                else:
+                    functions[alias.asname or alias.name] = alias.name
+    return modules, functions
+
+
 def compile_calls_in(tree: ast.Module) -> list[tuple[int, ast.expr]]:
     """`(lineno, first-argument-expression)` for every `re.compile(…)` call.
 
     TAKES A PARSED TREE RATHER THAN A PATH so the recogniser can be exercised
     against a literal snippet — see `test_the_recogniser_answers_correctly_on_a_
     LITERAL`.
+
+    BOTH SPELLINGS: `<re-alias>.compile(…)` and a bare `<name>(…)` bound by
+    `from re import compile`. See `re_bindings`.
     """
-    return [(node.lineno, node.args[0])
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute) and node.func.attr == "compile"
-            and isinstance(node.func.value, ast.Name) and node.func.value.id == "re"
-            and node.args]
+    modules, functions = re_bindings(tree)
+    found: list[tuple[int, ast.expr]] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and node.args):
+            continue
+        func = node.func
+        attribute_call = (isinstance(func, ast.Attribute)
+                          and func.attr == "compile"
+                          and isinstance(func.value, ast.Name)
+                          and func.value.id in modules)
+        bare_call = (isinstance(func, ast.Name)
+                     and functions.get(func.id) == "compile")
+        if attribute_call or bare_call:
+            found.append((node.lineno, node.args[0]))
+    return found
+
+
+def uncompiled_calls_in(tree: ast.Module) -> list[int]:
+    """Line numbers of every `re.<fn>(<pattern>, …)` run WITHOUT being compiled.
+
+    TAKES A PARSED TREE FOR THE SAME REASON `compile_calls_in` DOES: this is the
+    control on the sweep's own narrowness, and an uncontrolled control is what
+    let both halves share one blind spot. It was written inline inside the test
+    and could only ever be driven by the tree it audits.
+    """
+    modules, functions = re_bindings(tree)
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and ((isinstance(node.func, ast.Attribute)
+              and node.func.attr in _UNCOMPILED_ENTRY_POINTS
+              and isinstance(node.func.value, ast.Name)
+              and node.func.value.id in modules)
+             or (isinstance(node.func, ast.Name)
+                 and functions.get(node.func.id) in _UNCOMPILED_ENTRY_POINTS))
+    ]
 
 
 def _compile_calls(path: pathlib.Path) -> list[tuple[int, ast.expr]]:
@@ -241,17 +325,13 @@ def test_every_pattern_is_compiled_so_the_sweep_can_see_it(
     The sweep above reads compiled literals. This is the half that keeps that
     predicate honest: the alternatives are ABSENT, rather than the predicate
     being narrow and nobody having checked.
+
+    IT RESOLVES `re` THE SAME WAY THE SWEEP DOES, through `re_bindings`. It used
+    to hard-code the bare name, which is the blind spot the sweep had — so this
+    control shared the hole it exists to compensate for, and neither half could
+    report the other's blindness.
     """
-    tree = ast.parse(source.read_text(encoding="utf-8"))
-    bare = [
-        node.lineno
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr in _UNCOMPILED_ENTRY_POINTS
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "re"
-    ]
+    bare = uncompiled_calls_in(ast.parse(source.read_text(encoding="utf-8")))
     assert not bare, (
         f"{source.name} calls `re.<fn>(pattern, …)` directly at line(s) "
         f"{bare}; compile the pattern to a module constant so the anchor sweep "
@@ -285,6 +365,47 @@ def test_the_recogniser_answers_correctly_on_a_LITERAL() -> None:
     assert parts('X = compile("^abc$")') == []
     assert parts('X = other.compile(r"^abc$")') == []
     assert parts('"""re.compile(r\'^abc$\') in a docstring"""') == []
+
+    # THE THREE SPELLINGS THAT USED TO BE INVISIBLE. Each was mutated into
+    # `citations.py` against a 35-passing baseline and each came back GREEN,
+    # which is how this hole was found rather than reasoned about.
+    assert parts('import re as _r\nX = _r.compile(r"^abc$")') == [["^abc$"]]
+    assert parts('from re import compile as _c\nX = _c(r"^abc$")') == [["^abc$"]]
+    assert parts('from re import compile\nX = compile(r"^abc$")') == [["^abc$"]]
+    # And the binding is per-module: a bare `compile(...)` with no `from re`
+    # import is the BUILTIN, and reading it as a pattern would invent findings.
+    assert parts('X = compile("^abc$")\nimport re') == []
+    # `import re as _r` does not make an unrelated `re.compile` disappear — the
+    # seeded name stays, because a module may do both.
+    assert parts('import re as _r\nX = re.compile(r"^abc$")') == [["^abc$"]]
+    # The star, closed rather than declared as a hole.
+    assert parts('from re import *\nX = compile(r"^abc$")') == [["^abc$"]]
+
+
+def test_the_UNCOMPILED_recogniser_answers_correctly_on_a_LITERAL() -> None:
+    """The other recogniser's control, which it did not have.
+
+    This is the half that keeps the sweep's narrowness honest, so it had the
+    most to lose from being untested — and it had the sweep's exact blind spot:
+    both keyed on the bare name `re`, so an aliased uncompiled call was
+    invisible to the check that uncompiled calls are absent. A blind sweep and a
+    clean package are the same colour, and so are a blind honesty test and an
+    honest package.
+    """
+    def lines(src: str) -> list[int]:
+        return uncompiled_calls_in(ast.parse(src))
+
+    assert lines('re.match(r"^x$", s)') == [1]
+    assert lines('import re as _r\n_r.match(r"^x$", s)') == [2]
+    assert lines('from re import match\nmatch(r"^x$", s)') == [2]
+    assert lines('from re import search as _s\n_s(r"^x$", s)') == [2]
+    assert lines('from re import *\nmatch(r"^x$", s)') == [2]
+    # NEGATIVE CONTROLS. A compiled pattern is what the sweep wants and must not
+    # be reported here, and neither may an unrelated `.match` on some other
+    # object — `_LABEL_RE.match(line)` is live in this package.
+    assert lines('import re\nP = re.compile(r"\\\\Ax\\\\Z")\nP.match(s)') == []
+    assert lines('other.match(r"^x$", s)') == []
+    assert lines('match(r"^x$", s)') == []
 
 
 def test_the_anchor_scanner_ignores_a_negated_character_class() -> None:

--- a/scripts/workflows/temporal/tests/unit/test_journal_tag_lines.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_tag_lines.py
@@ -91,6 +91,30 @@ _DECLARED_TAG_VALUES = {
         "same call: `_refuse_folded_value` puts the value through "
         "`folds_a_tag_line`, which asks `read_tag_file`'s own parser rather "
         "than holding a list of line terminators.",
+    # ⚠ THE TWO ROWS BELOW ARE THE SWEEP MATCHING A SHAPE THAT IS NOT A TAG
+    # LINE, and they are declared rather than reworded around because the
+    # predicate is `<colon><space>` in an f-string and widening it to exclude
+    # these would cost it the composers it exists for. Neither expression can
+    # reach `_write_tag_file` or `_append_tag_line`: `verify.py` imports neither.
+    ("verify.py", "sha"):
+        "git_blob builds `<sha>:<path>`, an ARGUMENT TO `git cat-file`, not a "
+        "tag line — it is passed as one element of an argv list, never composed "
+        "into a file. `sha` is 40 hex characters by `GIT_REF_RE`, which "
+        "`parse_git_ref` enforces before this function is reached, so it cannot "
+        "carry a line break in any case.",
+    ("verify.py", "path"):
+        "the other half of that same `git cat-file` argument. It is handed to "
+        "git, which resolves it inside an OBJECT DATABASE rather than on the "
+        "filesystem, and it reaches no tag file; a line break in it makes git "
+        "report an unknown object, which surfaces as a `missing` outcome.",
+    ("verify.py", "outcome"):
+        "render_report writes to STDOUT, not to `bag-info.txt`. `outcome` is "
+        "one of the four module constants in `OUTCOMES`, assigned by this "
+        "module and never by a caller.",
+    ("verify.py", "counts[outcome]"):
+        "the same stdout line: an int from `VerifyReport.counts`, which counts "
+        "results. A tag line cannot be forged with an integer, and this is not "
+        "a tag line.",
 }
 
 # Spellings of a tag line this package must not use, because the sweep cannot

--- a/scripts/workflows/temporal/tests/unit/test_journal_tag_lines.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_tag_lines.py
@@ -115,6 +115,19 @@ _DECLARED_TAG_VALUES = {
         "the same stdout line: an int from `VerifyReport.counts`, which counts "
         "results. A tag line cannot be forged with an integer, and this is not "
         "a tag line.",
+    ("verify.py", "type(exc).__name__"):
+        "verify_bag labels a STRUCTURAL FINDING with the class name of the "
+        "exception that produced it, for a `VerifyReport.structural` entry that "
+        "render_report writes to STDOUT. It reaches no tag file — `verify.py` "
+        "imports neither composer — and the value is a Python type name, which "
+        "the language cannot spell with a line break.",
+    ("verify.py", "exc"):
+        "the other half of that same structural label: the exception's own "
+        "message, from `read_citations` failing on a citation file. It is "
+        "printed, never written into `bag-info.txt`. A line break in it "
+        "produces an ugly finding, not a forged label — and the finding is the "
+        "point, since the alternative this replaced was the exception "
+        "propagating and killing the whole sweep.",
 }
 
 # Spellings of a tag line this package must not use, because the sweep cannot

--- a/scripts/workflows/temporal/tests/unit/test_journal_validator.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_validator.py
@@ -34,6 +34,7 @@ import pytest
 
 from modules.journal.bag import (BAGIT_FILE, BAG_INFO_FILE, MANIFEST_FILE,
                                  PAYLOAD_DIR, open_bag)
+from modules.journal.validate import main as validate_main
 from modules.journal.validate import render_report, validate_bag
 
 
@@ -225,6 +226,22 @@ def test_a_path_that_is_not_a_bag_reports_rather_than_raising(root: Path) -> Non
     assert not report.ok
     assert report.structural and "not a directory" in report.structural[0]
     assert (report.lifecycle, report.redacted, report.incomplete) == ("open", False, False)
+
+
+def test_main_still_reaches_exit_1_for_a_bag_that_really_failed(
+        root: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The usage/finding split must not have taken the finding code with it.
+
+    `main` now answers 2 for a target that is not there, which is the whole point
+    of the split — and that is only worth anything if 1 still means what it meant.
+    `test_journal_operator_tools_separate_typo_from_finding.py` owns the 2 across
+    both tools; this owns the other side of the same distinction for this one.
+    """
+    bag = _bag(root, "broken", sealed=True, redacted=False, incomplete=False)
+    (bag.payload_dir / "child" / "payload.jsonl").unlink()
+
+    assert validate_main([str(bag.path)]) == 1
+    assert "result     : FAIL" in capsys.readouterr().out
 
 
 def test_a_malformed_manifest_line_is_STRUCTURAL_not_a_crash(root: Path) -> None:

--- a/scripts/workflows/temporal/tests/unit/test_pr_url_address.py
+++ b/scripts/workflows/temporal/tests/unit/test_pr_url_address.py
@@ -194,6 +194,13 @@ DECLARED_SPLITS = {
     # on a URL has no equivalent of. The maxsplit of 1 is load-bearing — a
     # payload path may legitimately contain spaces.
     ("validate.py", "_parse_manifest"),
+    # `span_occurs_in` splits a QUOTE and a stored SOURCE on whitespace and
+    # rejoins both with single spaces, so a quote survives its source being
+    # re-wrapped. Not a URL and not a path: the split yields no segment that is
+    # used to address anything — the result is compared for containment and
+    # then discarded. The failure mode this gate exists for, a segment that
+    # looks right and points elsewhere, has no analogue in a substring test.
+    ("verify.py", "span_occurs_in"),
 }
 
 

--- a/scripts/workflows/temporal/tests/unit/test_source_fetch.py
+++ b/scripts/workflows/temporal/tests/unit/test_source_fetch.py
@@ -317,3 +317,129 @@ def test_a_non_redirect_http_error_is_reported_not_followed() -> None:
     with pytest.raises(FetchRefused) as caught:
         fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
     assert "404" in str(caught.value)
+
+
+# --- the parser's own refusals, and the redirect handler itself ------------------
+
+@pytest.mark.parametrize("url", [
+    "https://[::1",
+    "https://host:99999/",
+    "https://host:-1/",
+])
+def test_an_UNPARSEABLE_url_is_a_REFUSAL_not_a_ValueError(url) -> None:
+    """⚠ `urlsplit` AND `.port` RAISE `ValueError`, PAST EVERY CALLER.
+
+    `check_url`'s contract is "prove one URL may be fetched, refuse otherwise",
+    and `FetchRefused` is what a capture activity catches. A malformed URL —
+    which is exactly the kind a model-influenceable value produces — crashed the
+    activity instead of being recorded as a policy refusal. A boundary that
+    validates input owes its own refusal for the inputs the PARSER rejects too,
+    not only for the ones its rules reject.
+    """
+    with pytest.raises(FetchRefused):
+        check_url(url, FetchPolicy(), resolve=resolver_for({"host": [PUBLIC]}))
+
+
+@pytest.mark.parametrize("address", [
+    "64:ff9b::a9fe:a9fe",     # 169.254.169.254, the cloud metadata address
+    "64:ff9b::7f00:1",        # 127.0.0.1
+    "64:ff9b:1::a9fe:a9fe",   # the local-use translation prefix, RFC 8215
+])
+def test_a_NAT64_TRANSLATED_address_is_refused(address) -> None:
+    """RFC 6052 EMBEDS AN IPv4 ADDRESS IN A v6 PREFIX, AND `is_reserved` CATCHES IT.
+
+    `64:ff9b::a9fe:a9fe` is `169.254.169.254` behind a NAT64 gateway, and neither
+    `is_private`, `is_loopback` nor `is_link_local` is true of it — which is why
+    a review raised it as an uncovered category and why a correction pass wrote
+    a hand-written prefix table before checking. `is_reserved` is ALREADY true
+    across `64::/16`, so the table refused nothing and its test passed with the
+    table deleted. The table was reverted; this test stays, PINNED, so the next
+    reader finds the property asserted rather than re-deriving the same table.
+
+    ⚠ THIS IS A PIN, NOT A CLOSURE. A network-specific translation prefix — RFC
+    6052 permits any /32, /40, /48, /56, /64 or /96 an operator chooses — is not
+    reserved and is not enumerable from here. That is a residual, beside DNS
+    rebinding, and this test does not claim otherwise.
+    """
+    assert refused_address_reason(address) is not None
+
+
+def test_a_PUBLIC_v6_address_is_still_permitted() -> None:
+    """DISCRIMINATION CONTROL for the row above. A refusal table that refused
+    every v6 address would pass the test above and close the fetcher entirely.
+
+    (The first draft of this control used `64:ff9a::1`, which is itself reserved
+    — a control that could not have discriminated. Named because it is the same
+    mistake as the table it was written to check.)
+    """
+    assert refused_address_reason("2606:2800:220:1:248:1893:25c8:1946") is None
+    assert refused_address_reason("2001:4860:4860::8888") is None
+
+
+def test_the_redirect_HANDLER_ITSELF_stops_urllib_following() -> None:
+    """⚠ EVERY OTHER REDIRECT TEST HANDS `fetch_source` A PRE-BUILT `HTTPError`.
+
+    Those prove `fetch_source` re-validates a hop it is GIVEN. None of them
+    constructs the real `OpenerDirector`, so the thing that turns urllib's own
+    following OFF — `_NoRedirects` — was never exercised: a CPython change to
+    `HTTPRedirectHandler`'s method set, which is the exact risk that class's
+    docstring names, would silently re-enable automatic following and every SSRF
+    redirect test in this file would still be green.
+
+    ⚠ AND THE FIRST VERSION OF THIS TEST WAS ITSELF VACUOUS, WHICH IS WHY THE
+    STUB RETURNS RATHER THAN RAISES. It had the stub handler RAISE `HTTPError`,
+    which propagates straight out of `OpenerDirector.open` and never reaches the
+    error chain at all — so `redirect_request` was not on the path and deleting
+    the override changed nothing. The mutation caught it: predicted one failure,
+    observed zero. A 3xx only reaches `http_error_302` when a handler RETURNS a
+    response that `HTTPErrorProcessor` sees, so that is what this builds.
+    """
+    import email.message
+    import urllib.error
+    import urllib.request
+    import urllib.response
+
+    from modules.journal.source_fetch import _NoRedirects
+
+    START = "https://start.example/a"
+    INNER = "https://elsewhere.example/inner"
+    visited: list[str] = []
+
+    class Body(io.BytesIO):
+        """`HTTPErrorProcessor.http_response` reads `response.msg`, and
+        `addinfourl` delegates unknown attributes to the file it wraps."""
+        msg = "Found"
+
+    def real_headers(**fields) -> email.message.Message:
+        """⚠ `email.message.Message`, NOT THIS FILE'S `FakeHeaders`, AND THE
+        DIFFERENCE IS WHAT MADE THE SECOND DRAFT OF THIS TEST VACUOUS TOO.
+
+        `http_error_302` asks `"location" in headers` in lower case. `Message`
+        is case-insensitive; a plain `dict` is not — so a `{"Location": ...}`
+        stand-in made even the STOCK `HTTPRedirectHandler` decline to follow,
+        and the mutation came back green a second time against a fixture that
+        could not have discriminated. Verified by running both handlers against
+        this fixture: stock follows to the inner URL, `_NoRedirects` raises 302.
+        """
+        message = email.message.Message()
+        for key, value in fields.items():
+            message[key] = value
+        return message
+
+    class StubHTTPSHandler(urllib.request.HTTPSHandler):
+        def https_open(self, req):
+            visited.append(req.full_url)
+            if req.full_url == START:
+                return urllib.response.addinfourl(
+                    Body(b""), real_headers(Location=INNER), req.full_url, 302)
+            return urllib.response.addinfourl(
+                Body(b"the inner body"), real_headers(), req.full_url, 200)
+
+    opener = urllib.request.build_opener(_NoRedirects, StubHTTPSHandler)
+    with pytest.raises(urllib.error.HTTPError) as caught:
+        opener.open(urllib.request.Request(START))
+
+    assert caught.value.code == 302
+    assert visited == [START], (
+        "urllib followed the redirect ITSELF — the hop never came back to "
+        f"`fetch_source` to re-enter `check_url`. Visited: {visited}")

--- a/scripts/workflows/temporal/tests/unit/test_source_fetch.py
+++ b/scripts/workflows/temporal/tests/unit/test_source_fetch.py
@@ -1,0 +1,319 @@
+"""The fetch policy — the one place this package can be pointed at a machine.
+
+WHY THIS FILE IS THE MOST ADVERSARIAL IN THE PACKAGE. The URL is
+model-influenceable and may itself have come out of a previously-fetched
+document, and the response is DURABLY STORED and RE-SERVABLE OFFLINE. That is
+strictly worse than an ordinary server-side request forgery: the payload outlives
+the request and is read back later by a checker that trusts the store. Every
+assertion below is a case that, unclosed, makes the content store a way to reach
+this network.
+
+EVERY TEST RUNS OFFLINE, and that is a property of the code rather than of the
+test harness. `fetch_source` takes its opener and its resolver as parameters
+precisely so the rules can be exercised against a name with a hostile answer
+without a socket — a policy that could only be tested against a live host is a
+policy nobody tests.
+
+WHAT THIS FILE DOES NOT LOOK AT, said out loud: it never touches the content
+store, so nothing here says a fetched byte was stored correctly, and it never
+checks a quote. It also does not close DNS rebinding — the module names that as
+a residual, and a test asserting the addresses are checked does not make the
+name resolve the same way twice.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from modules.journal.source_fetch import (MAX_SOURCE_BYTES, USER_AGENT,
+                                          FetchPolicy, FetchRefused,
+                                          check_url, fetch_source,
+                                          refused_address_reason,
+                                          resolved_addresses)
+
+PUBLIC = "93.184.216.34"
+
+
+class FakeHeaders(dict):
+    """Just enough of `email.message.Message` for the fetcher's three reads."""
+
+    def get(self, key, default=None):  # noqa: D102
+        for name, value in self.items():
+            if name.lower() == key.lower():
+                return value
+        return default
+
+    def get_content_type(self):  # noqa: D102
+        return self.get("Content-Type", "text/plain").split(";")[0]
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, headers: dict | None = None):
+        self._stream = io.BytesIO(body)
+        self.headers = FakeHeaders(headers or {})
+
+    def read(self, size=-1):
+        return self._stream.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeOpener:
+    """Records what was asked for, and answers from a scripted map."""
+
+    def __init__(self, responses: dict):
+        self.responses = responses
+        self.requests: list = []
+        self.timeouts: list = []
+
+    def open(self, request, timeout=None):
+        self.requests.append(request)
+        self.timeouts.append(timeout)
+        answer = self.responses[request.full_url]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+def resolver_for(mapping: dict):
+    """A `getaddrinfo` stand-in: host -> list of addresses it resolves to."""
+    def resolve(host, port, family=0, socktype=0):
+        if host not in mapping:
+            import socket
+            raise socket.gaierror(-2, "Name or service not known")
+        return [(2, 1, 6, "", (address, port)) for address in mapping[host]]
+    return resolve
+
+
+ONLY_PUBLIC = resolver_for({"example.org": [PUBLIC], "other.example": [PUBLIC]})
+
+
+# --- the address rules ----------------------------------------------------------
+
+@pytest.mark.parametrize("address", [
+    "127.0.0.1", "::1",                 # loopback
+    "169.254.169.254", "fe80::1",       # link-local — the cloud metadata range
+    "10.0.0.5", "192.168.1.1", "172.16.0.1", "fd00::1",   # private
+    "0.0.0.0", "::",                    # unspecified
+    "224.0.0.1",                        # multicast
+    "240.0.0.1",                        # reserved
+])
+def test_an_address_inside_this_network_is_refused(address: str) -> None:
+    assert refused_address_reason(address) is not None
+
+
+@pytest.mark.parametrize("address", [PUBLIC, "2606:2800:220:1:248:1893:25c8:1946"])
+def test_a_public_address_is_permitted(address: str) -> None:
+    """THE NEGATIVE HALF. A rule that refused everything would pass every test above."""
+    assert refused_address_reason(address) is None
+
+
+def test_EVERY_resolved_address_is_checked_not_just_the_first() -> None:
+    """A name with one public and one loopback record must not be reachable by luck.
+
+    Ordering in a DNS answer is not a security property, and a check that read
+    `[0]` would pass or fail depending on which record a resolver happened to
+    return first — which is a policy that works until it does not.
+    """
+    resolve = resolver_for({"mixed.example": [PUBLIC, "127.0.0.1"]})
+    with pytest.raises(FetchRefused) as caught:
+        check_url("https://mixed.example/a", FetchPolicy(), resolve=resolve)
+    assert "loopback" in str(caught.value)
+
+
+def test_a_name_that_resolves_to_nothing_is_refused() -> None:
+    with pytest.raises(FetchRefused):
+        resolved_addresses("nowhere.example", 443, resolve=resolver_for({}))
+
+
+# --- the scheme allowlist -------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://example.org/a", "file:///etc/passwd", "ftp://example.org/a",
+    "data:text/plain,hello", "gopher://example.org/a", "https:///nohost",
+])
+def test_a_scheme_or_shape_outside_the_allowlist_is_refused(url: str) -> None:
+    with pytest.raises(FetchRefused):
+        check_url(url, FetchPolicy(), resolve=ONLY_PUBLIC)
+
+
+# --- the fetch itself -----------------------------------------------------------
+
+def test_a_permitted_fetch_returns_the_bytes_AS_RECEIVED() -> None:
+    """THE NEGATIVE CONTROL FOR THE WHOLE FILE: the happy path must still work.
+
+    Every other test here asserts a refusal, and a `fetch_source` that raised
+    unconditionally would satisfy all of them.
+    """
+    body = b"<html>the source said this</html>"
+    opener = FakeOpener({"https://example.org/a": FakeResponse(
+        body, {"Content-Type": "text/html; charset=utf-8"})})
+    fetched = fetch_source("https://example.org/a", opener=opener,
+                           resolve=ONLY_PUBLIC)
+    assert fetched.data == body
+    assert fetched.final_url == "https://example.org/a"
+    assert fetched.media_type == "text/html"
+    assert fetched.hops == ("https://example.org/a",)
+
+
+def test_the_request_asks_for_no_content_coding_and_names_itself() -> None:
+    opener = FakeOpener({"https://example.org/a": FakeResponse(b"x")})
+    fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
+    headers = opener.requests[0].headers
+    assert headers["Accept-encoding"] == "identity"
+    assert headers["User-agent"] == USER_AGENT
+
+
+def test_the_timeout_reaches_the_opener() -> None:
+    """A hung server must not be able to hold a run open indefinitely."""
+    opener = FakeOpener({"https://example.org/a": FakeResponse(b"x")})
+    fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC,
+                 policy=FetchPolicy(timeout_seconds=3.5))
+    assert opener.timeouts == [3.5]
+
+
+def test_an_encoded_response_is_REFUSED_rather_than_decoded() -> None:
+    """Refusing removes the decompression case; a decoded cap would only bound it.
+
+    It also keeps "the digest is over the bytes the server sent" literally true,
+    which is the sentence the whole store's guarantee rests on.
+    """
+    opener = FakeOpener({"https://example.org/a": FakeResponse(
+        b"\x1f\x8b garbage", {"Content-Encoding": "gzip"})})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
+    assert "gzip" in str(caught.value)
+
+
+def test_an_identity_content_encoding_is_permitted() -> None:
+    """The refusal is of a CODING, not of the header. `identity` is no coding."""
+    opener = FakeOpener({"https://example.org/a": FakeResponse(
+        b"plain", {"Content-Encoding": "identity"})})
+    assert fetch_source("https://example.org/a", opener=opener,
+                        resolve=ONLY_PUBLIC).data == b"plain"
+
+
+# --- the size cap ---------------------------------------------------------------
+
+def test_the_cap_is_enforced_on_the_READ_not_on_the_declared_length() -> None:
+    """`Content-Length` is the server's claim about its own body.
+
+    A fetcher that trusted it would store however many bytes actually arrived,
+    which is the whole point of a cap that a hostile server can set to zero.
+    """
+    opener = FakeOpener({"https://example.org/a": FakeResponse(
+        b"x" * 5000, {"Content-Length": "10"})})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC,
+                     policy=FetchPolicy(max_bytes=100))
+    assert "exceeds" in str(caught.value)
+
+
+def test_an_over_declared_length_is_refused_before_the_body_is_read() -> None:
+    """The cheap early exit, which is all the declared length is ever used for."""
+    opener = FakeOpener({"https://example.org/a": FakeResponse(
+        b"x" * 10, {"Content-Length": str(MAX_SOURCE_BYTES + 1)})})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
+    assert "declares" in str(caught.value)
+
+
+def test_a_body_exactly_at_the_cap_is_STORED_not_refused() -> None:
+    """An off-by-one here silently truncates the corpus a checker later reads."""
+    opener = FakeOpener({"https://example.org/a": FakeResponse(b"x" * 100)})
+    fetched = fetch_source("https://example.org/a", opener=opener,
+                           resolve=ONLY_PUBLIC, policy=FetchPolicy(max_bytes=100))
+    assert len(fetched.data) == 100
+
+
+# --- redirects: every hop re-enters every check ---------------------------------
+
+def _redirect(location: str, code: int = 302):
+    import urllib.error
+    return urllib.error.HTTPError(
+        "https://example.org/a", code, "Found",
+        FakeHeaders({"Location": location}), None)
+
+
+def test_a_redirect_to_a_LOOPBACK_host_is_refused() -> None:
+    """THE STANDARD BYPASS. A permitted URL redirecting to the metadata range.
+
+    Automatic redirect following is switched off precisely so this hop comes
+    back here to be checked; a fetcher that let the library follow would store
+    the response with the intermediate URL never having passed a check.
+    """
+    resolve = resolver_for({"example.org": [PUBLIC], "evil.example": ["127.0.0.1"]})
+    opener = FakeOpener({
+        "https://example.org/a": _redirect("https://evil.example/steal"),
+        "https://evil.example/steal": FakeResponse(b"secrets"),
+    })
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=resolve)
+    assert "loopback" in str(caught.value)
+
+
+def test_a_redirect_to_a_LINK_LOCAL_address_is_refused() -> None:
+    resolve = resolver_for({"example.org": [PUBLIC],
+                            "metadata.example": ["169.254.169.254"]})
+    opener = FakeOpener({
+        "https://example.org/a": _redirect("https://metadata.example/latest/meta-data/"),
+    })
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=resolve)
+    assert "link-local" in str(caught.value)
+
+
+def test_a_redirect_to_a_NON_HTTPS_scheme_is_refused() -> None:
+    opener = FakeOpener({"https://example.org/a": _redirect("http://example.org/a")})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
+    assert "scheme" in str(caught.value)
+
+
+def test_a_relative_redirect_is_resolved_against_the_hop_that_sent_it() -> None:
+    """A `Location: /b` is a real redirect shape and must not be treated as a URL."""
+    opener = FakeOpener({
+        "https://example.org/a": _redirect("/b"),
+        "https://example.org/b": FakeResponse(b"arrived"),
+    })
+    fetched = fetch_source("https://example.org/a", opener=opener,
+                           resolve=ONLY_PUBLIC)
+    assert fetched.data == b"arrived"
+    assert fetched.final_url == "https://example.org/b"
+    assert fetched.hops == ("https://example.org/a", "https://example.org/b")
+    assert fetched.url == "https://example.org/a", (
+        "the URL asked for is kept alongside the one that answered — a citation "
+        "records where it landed, and an operator needs to see the chain")
+
+
+def test_a_permitted_redirect_to_another_public_host_is_followed() -> None:
+    opener = FakeOpener({
+        "https://example.org/a": _redirect("https://other.example/b", code=308),
+        "https://other.example/b": FakeResponse(b"moved permanently"),
+    })
+    fetched = fetch_source("https://example.org/a", opener=opener,
+                           resolve=ONLY_PUBLIC)
+    assert fetched.data == b"moved permanently"
+
+
+def test_a_redirect_LOOP_ends_rather_than_spinning() -> None:
+    opener = FakeOpener({"https://example.org/a": _redirect("https://example.org/a")})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC,
+                     policy=FetchPolicy(max_redirects=2))
+    assert "redirects" in str(caught.value)
+
+
+def test_a_non_redirect_http_error_is_reported_not_followed() -> None:
+    import urllib.error
+    opener = FakeOpener({"https://example.org/a": urllib.error.HTTPError(
+        "https://example.org/a", 404, "Not Found", FakeHeaders({}), None)})
+    with pytest.raises(FetchRefused) as caught:
+        fetch_source("https://example.org/a", opener=opener, resolve=ONLY_PUBLIC)
+    assert "404" in str(caught.value)

--- a/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
@@ -174,9 +174,21 @@ def test_the_population_this_sweeps_MATCHES_THE_TREE() -> None:
     journal root, then update this number.
     """
     modules = _entrypoint_driving_modules()
-    assert len(modules) == 6, (
+    # 6 → 7 on 2026-09-01: `test_verify_citations.py` joined the population when
+    # a correction pass added a case calling `verify.main()` in-process to prove
+    # that a target which is not there exits USAGE and not the new structural
+    # code. It previously drove the entrypoint only through `subprocess`, which
+    # this predicate does not see — so the module was outside the redirect sweep
+    # while already touching an entrypoint. Confirmed it cannot litter the
+    # operator's root: the case passes a `tmp_path` child and `main` returns
+    # before `verify_bag` on a target that is not a directory.
+    #
+    # The sibling copy this message names in `tests/conftest.py` no longer
+    # states a count — it was changed to name the population instead, which is
+    # why there is nothing to update there this time.
+    assert len(modules) == 7, (
         f"{len(modules)} test module(s) under {UNIT_DIR} drive an entrypoint "
-        f"`main()`; it was 5 when this was pinned. Found: "
+        f"`main()`; it was 6 when this was pinned. Found: "
         f"{[m.name for m in modules]}.\n"
         f"If a module was ADDED, it now runs inside the subprocess sweep below "
         f"and this number goes up. If the count DROPPED, the discovery "

--- a/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_suite_never_writes_to_the_operators_journal.py
@@ -186,9 +186,16 @@ def test_the_population_this_sweeps_MATCHES_THE_TREE() -> None:
     # The sibling copy this message names in `tests/conftest.py` no longer
     # states a count — it was changed to name the population instead, which is
     # why there is nothing to update there this time.
-    assert len(modules) == 7, (
+    #
+    # 7 → 8 on 2026-09-01, one correction pass later: the class-check written
+    # for that same finding —
+    # `test_journal_operator_tools_separate_typo_from_finding.py` — drives
+    # `main()` on EVERY bag-inspection entrypoint it discovers, which is the
+    # point of it. Confirmed it cannot litter the operator's root: every case
+    # passes a `tmp_path` child, and each tool returns before reaching a bag.
+    assert len(modules) == 8, (
         f"{len(modules)} test module(s) under {UNIT_DIR} drive an entrypoint "
-        f"`main()`; it was 6 when this was pinned. Found: "
+        f"`main()`; it was 7 when this was pinned. Found: "
         f"{[m.name for m in modules]}.\n"
         f"If a module was ADDED, it now runs inside the subprocess sweep below "
         f"and this number goes up. If the count DROPPED, the discovery "

--- a/scripts/workflows/temporal/tests/unit/test_verify_citations.py
+++ b/scripts/workflows/temporal/tests/unit/test_verify_citations.py
@@ -34,7 +34,7 @@ from modules.journal.verify import (EXIT_MISSING, EXIT_OK, EXIT_SPAN_MISSING,
                                     EXIT_TAMPERED, EXIT_USAGE, MISSING,
                                     SPAN_MISSING, TAMPERED, VERIFIED,
                                     exit_code_for, render_report, span_occurs_in,
-                                    verify_bag, verify_citation)
+                                    split_args, verify_bag, verify_citation)
 
 PAGE = b"<p>The store proves the bytes, not the claim.</p>\n"
 QUOTE = "The store proves the bytes, not the claim."
@@ -322,3 +322,55 @@ def test_the_import_walk_can_SEE_a_fetcher_edge() -> None:
     breaking something the assertion would have caught by accident.
     """
     assert "source_fetch" in _intra_package_closure("content_activities")
+
+
+# --- the argument grammar, which had two parses and one of them was wrong ------
+
+def test_the_repo_flags_VALUE_is_not_mistaken_for_a_TARGET() -> None:
+    """⚠ THE DEFECT THIS PINS SHIPPED IN THE ENTRYPOINT AND WAS FOUND BY RUNNING IT.
+
+    `verify_citations.py` decides whether to fall back to the configured journal
+    root by asking whether any target was named. It asked that with a filter over
+    the raw argument list, which counted `--repo`'s own path as a target — so
+    `verify_citations.py --repo <path>` printed a usage message instead of
+    verifying the configured root. One grammar, written twice, and the second
+    copy was wrong on arrival. `split_args` is now the only parse.
+    """
+    assert split_args(["--repo", "/r"]) == (Path("/r"), [])
+    assert split_args(["--repo", "/r", "/bag"]) == (Path("/r"), ["/bag"])
+    assert split_args(["/bag", "--repo", "/r"]) == (Path("/r"), ["/bag"])
+    assert split_args(["/bag"]) == (None, ["/bag"])
+    assert split_args([]) == (None, [])
+
+
+def test_a_repo_flag_with_no_path_is_a_usage_error_not_a_crash() -> None:
+    with pytest.raises(ValueError):
+        split_args(["--repo"])
+
+
+def test_the_entrypoint_and_the_module_share_ONE_parse() -> None:
+    """The extraction is the fix; a second correct copy would decay the same way.
+
+    ASSERTED OVER THE AST, NOT OVER THE TEXT. A substring check went red on the
+    COMMENT explaining why the second parse was removed — which is a guard that
+    forbids describing the defect it exists for. Docstrings are excluded for the
+    same reason: the usage line legitimately names the flag.
+    """
+    path = Path(verifymod.__file__).parents[2] / "scripts" / "verify_citations.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    docstrings = {id(node.body[0].value) for node in ast.walk(tree)
+                  if isinstance(node, (ast.Module, ast.FunctionDef, ast.ClassDef))
+                  and node.body and isinstance(node.body[0], ast.Expr)
+                  and isinstance(node.body[0].value, ast.Constant)}
+    literals = [n for n in ast.walk(tree)
+                if isinstance(n, ast.Constant) and n.value == "--repo"
+                and id(n) not in docstrings]
+    assert not literals, (
+        f"the entrypoint names `--repo` in code at line(s) "
+        f"{[n.lineno for n in literals]} — that is a second parse of a grammar "
+        f"`verify.split_args` owns, and the second copy is what shipped wrong")
+
+    calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)
+             and isinstance(n.func, ast.Attribute) and n.func.attr == "split_args"]
+    assert calls, "the entrypoint no longer calls the shared parse at all"

--- a/scripts/workflows/temporal/tests/unit/test_verify_citations.py
+++ b/scripts/workflows/temporal/tests/unit/test_verify_citations.py
@@ -1,0 +1,324 @@
+"""Four outcomes, four exit codes, and a checker that never opens a socket.
+
+THE DISTINCTIONS ARE THE PRODUCT. Requirement 3 names verified / missing /
+tampered and requirement 4 splits span-missing out of them, because each has a
+different remedy: re-capture the source, distrust the store, or correct the
+claim. A verifier that returned one boolean would invite exactly the over-reading
+the phase doc spends three paragraphs refusing.
+
+OFFLINE IS ASSERTED STRUCTURALLY, NOT PROMISED. `test_the_verifier_reaches_no
+_fetcher` walks the import graph, because a docstring saying "no network" is the
+kind of claim that survives the module quietly gaining an import.
+
+WHAT THIS FILE DOES NOT LOOK AT: it does not check the fetch policy at all
+(`test_source_fetch.py`), and it takes the store's hashing as given
+(`test_content_store.py`). It answers what a verdict MEANS and which number the
+process exits with.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from modules.journal import verify as verifymod
+from modules.journal.bag import open_bag
+from modules.journal.citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME,
+                                       CITATIONS_FILE, Citation, new_citation,
+                                       record_citation)
+from modules.journal.content_store import object_path, store_bytes
+from modules.journal.verify import (EXIT_MISSING, EXIT_OK, EXIT_SPAN_MISSING,
+                                    EXIT_TAMPERED, EXIT_USAGE, MISSING,
+                                    SPAN_MISSING, TAMPERED, VERIFIED,
+                                    exit_code_for, render_report, span_occurs_in,
+                                    verify_bag, verify_citation)
+
+PAGE = b"<p>The store proves the bytes, not the claim.</p>\n"
+QUOTE = "The store proves the bytes, not the claim."
+
+
+@pytest.fixture
+def bag(root: Path):
+    return open_bag(root, "run-verify")
+
+
+def cite(bag, claim_id="c1", *, quote=QUOTE, stage="draft", data=PAGE,
+         capture=CAPTURE_READ_TIME) -> Citation:
+    digest = store_bytes(bag.path, data)
+    citation = new_citation(claim_id=claim_id, stage=stage, quote=quote,
+                            source_ref="https://example.org/a", capture=capture,
+                            page_content_hash=digest)
+    directory = bag.payload_dir / stage
+    if not directory.is_dir():
+        directory = bag.writer_dir(stage)
+    record_citation(directory, citation)
+    return citation
+
+
+# --- the four outcomes ----------------------------------------------------------
+
+def test_intact_bytes_holding_the_quote_are_VERIFIED(bag) -> None:
+    citation = cite(bag)
+    assert verify_citation(bag.path, citation).outcome == VERIFIED
+    report = verify_bag(bag.path)
+    assert report.ok and report.counts()[VERIFIED] == 1
+
+
+def test_bytes_that_were_never_stored_are_MISSING(bag) -> None:
+    """The check could not be MADE. That is a different fact from a failed check."""
+    citation = cite(bag)
+    object_path(bag.path, citation.page_content_hash).unlink()
+    result = verify_citation(bag.path, citation)
+    assert result.outcome == MISSING
+    assert "MISSING" in result.detail
+
+
+def test_bytes_that_no_longer_hash_to_their_name_are_TAMPERED(bag) -> None:
+    """The STORE failed. The citation may be perfectly good, and the report says so."""
+    citation = cite(bag)
+    target = object_path(bag.path, citation.page_content_hash)
+    data = bytearray(target.read_bytes())
+    data[0] ^= 0x01
+    target.write_bytes(bytes(data))
+    assert verify_citation(bag.path, citation).outcome == TAMPERED
+
+
+def test_an_ABSENT_QUOTE_over_INTACT_BYTES_is_its_own_outcome(bag) -> None:
+    """REQUIREMENT 4, AND THE DISTINCTION IS THE WHOLE POINT OF IT.
+
+    A source can change without invalidating a quote, and a quote can vanish
+    from an UNCHANGED source only if the citation was wrong to begin with. That
+    is an epistemic finding about the record, not an integrity finding about the
+    store — so it must not share an exit code with an altered hash.
+    """
+    citation = cite(bag, quote="a sentence that was never on that page")
+    result = verify_citation(bag.path, citation)
+    assert result.outcome == SPAN_MISSING
+    assert "the store is fine" in result.detail.lower()
+
+
+def test_a_tampered_object_is_reported_as_TAMPERED_not_as_a_missing_span(bag) -> None:
+    """ORDER OF THE TWO CHECKS IS THE DIAGNOSIS.
+
+    Corrupting the stored bytes also destroys the quote in them. A verifier that
+    looked for the span first would report a wrong citation when the real
+    finding is a corrupt store — the diagnosis would point at the innocent half.
+    """
+    citation = cite(bag)
+    object_path(bag.path, citation.page_content_hash).write_bytes(b"different entirely")
+    assert verify_citation(bag.path, citation).outcome == TAMPERED
+
+
+# --- the span check -------------------------------------------------------------
+
+def test_a_quote_survives_its_source_being_RE_WRAPPED() -> None:
+    """The overwhelmingly common shape of a quote copied out of rendered text."""
+    assert span_occurs_in("one two three", b"one\n  two\tthree\n")
+
+
+def test_a_quote_that_is_not_there_is_not_there() -> None:
+    assert not span_occurs_in("four five", b"one two three")
+
+
+def test_a_source_that_is_not_valid_utf8_still_gets_a_SPAN_ANSWER() -> None:
+    """A decode failure reported as an integrity problem would be a wrong diagnosis."""
+    assert span_occurs_in("hello", b"\xff\xfe hello \xff")
+
+
+# --- requirement 6: code resolves from git ------------------------------------
+
+def test_a_code_citation_resolves_from_the_repository(bag, tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e",
+           "HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    (repo / "f.py").write_text("def marked_function():\n    return 1\n")
+    for args in (["init", "-q"], ["add", "f.py"], ["commit", "-qm", "x"]):
+        subprocess.run(["git", *args], cwd=repo, env=env, check=True,
+                       capture_output=True, timeout=30)
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, env=env,
+                         capture_output=True, text=True, check=True,
+                         timeout=30).stdout.strip()
+
+    citation = Citation(claim_id="c1", stage="draft", quote="def marked_function():",
+                        source_ref=f"git:{sha}:f.py", capture=CAPTURE_READ_TIME)
+    assert verify_citation(bag.path, citation, repo_root=repo).outcome == VERIFIED
+
+    wrong = Citation(claim_id="c2", stage="draft", quote="def absent():",
+                     source_ref=f"git:{sha}:f.py", capture=CAPTURE_READ_TIME)
+    assert verify_citation(bag.path, wrong, repo_root=repo).outcome == SPAN_MISSING
+
+    absent = Citation(claim_id="c3", stage="draft", quote="x",
+                      source_ref=f"git:{'0' * 40}:f.py", capture=CAPTURE_READ_TIME)
+    assert verify_citation(bag.path, absent, repo_root=repo).outcome == MISSING
+
+
+def test_a_code_citation_with_no_repository_is_MISSING_and_says_why(bag) -> None:
+    """Honest: this run could not make the check. Not that the check failed."""
+    citation = Citation(claim_id="c1", stage="draft", quote="q",
+                        source_ref=f"git:{'a' * 40}", capture=CAPTURE_READ_TIME)
+    result = verify_citation(bag.path, citation)
+    assert result.outcome == MISSING
+    assert "repository" in result.detail
+
+
+# --- exit codes -----------------------------------------------------------------
+
+def test_each_outcome_class_has_its_own_exit_code(bag) -> None:
+    assert len({EXIT_OK, EXIT_MISSING, EXIT_TAMPERED, EXIT_SPAN_MISSING,
+                EXIT_USAGE}) == 5
+
+
+def test_a_mixed_run_exits_on_the_MOST_SEVERE_outcome(bag) -> None:
+    """Ordered by how much of the report the outcome invalidates.
+
+    A tampered object means every other verdict in the same run is provisional;
+    a missing one means one check could not be made; a span-missing is a
+    complete, trustworthy check with a negative answer.
+    """
+    def report_with(*outcomes):
+        results = tuple(verifymod.CitationResult(
+            claim_id=f"c{i}", stage="s", outcome=o, capture=CAPTURE_READ_TIME,
+            source_ref="https://example.org/a")
+            for i, o in enumerate(outcomes))
+        return verifymod.VerifyReport(path=bag.path, results=results)
+
+    assert exit_code_for([report_with(VERIFIED)]) == EXIT_OK
+    assert exit_code_for([report_with(VERIFIED, SPAN_MISSING)]) == EXIT_SPAN_MISSING
+    assert exit_code_for([report_with(SPAN_MISSING, MISSING)]) == EXIT_MISSING
+    assert exit_code_for([report_with(MISSING, TAMPERED)]) == EXIT_TAMPERED
+    assert exit_code_for([report_with(SPAN_MISSING, MISSING, TAMPERED)]) == EXIT_TAMPERED
+
+
+def test_an_unparseable_citation_file_is_STRUCTURAL_not_one_bad_claim(bag) -> None:
+    """The record of what was claimed is unreadable — reporting it per-row would
+    understate it, and `ok` must be False even with zero results."""
+    writer = bag.writer_dir("draft")
+    (writer / CITATIONS_FILE).write_text("{ not json\n")
+    report = verify_bag(bag.path)
+    assert report.structural and not report.ok
+    assert exit_code_for([report]) == EXIT_USAGE
+
+
+def test_a_bag_with_no_citations_is_not_a_failure(bag) -> None:
+    """Most runs cite nothing. A checker that called them broken is unreadable."""
+    report = verify_bag(bag.path)
+    assert report.ok and report.results == ()
+    assert exit_code_for([report]) == EXIT_OK
+
+
+# --- the report -----------------------------------------------------------------
+
+def test_the_report_prints_every_outcome_class_even_at_zero(bag) -> None:
+    """A reader of `tampered: 0` learns something; a reader of an omitted line
+    cannot tell zero from not-looked-for."""
+    cite(bag)
+    text = render_report(verify_bag(bag.path))
+    for outcome in (VERIFIED, MISSING, TAMPERED, SPAN_MISSING):
+        assert f"{outcome}:" in text
+    assert "result     : PASS" in text
+
+
+def test_the_report_names_the_CAPTURE_PROVENANCE_of_a_failing_row(bag) -> None:
+    """r7(c)'s ruling surfaces in the output rather than in a global sentence.
+
+    A harvested row's hash proves its bytes matched AT HARVEST, not that the
+    claim was made against them. The verifier reports which, per row, so no
+    result can over-claim.
+    """
+    cite(bag, quote="never on that page", capture=CAPTURE_HARVEST)
+    text = render_report(verify_bag(bag.path))
+    assert CAPTURE_HARVEST in text
+    assert "result     : FAIL" in text
+
+
+def test_the_report_exposes_the_evidence_set_hash_PER_STAGE(bag) -> None:
+    """Requirement 5: computed and exposed. Nothing here routes on it."""
+    cite(bag, "c1", stage="draft")
+    cite(bag, "c2", stage="critic", data=b"a different source entirely",
+         quote="different source")
+    report = verify_bag(bag.path)
+    assert set(report.evidence_hashes) == {"draft", "critic"}
+    assert report.evidence_hashes["draft"] != report.evidence_hashes["critic"]
+    assert "evidence_set_hash[draft]" in render_report(report)
+
+
+def test_ok_is_DERIVED_and_cannot_be_constructed_to_disagree(bag) -> None:
+    """A PASS printed above a tampered object is the worst thing a checker emits."""
+    assert "ok" not in verifymod.VerifyReport.__dataclass_fields__
+    assert isinstance(verifymod.VerifyReport.ok, property)
+
+
+# --- offline is structural ------------------------------------------------------
+
+def _intra_package_closure(start: str) -> set[str]:
+    """Every module in this package `start` reaches, following relative imports.
+
+    STATIC, AND THAT IS THE WHOLE POINT. A `sys.modules` check after importing
+    `modules.journal.verify` measures the PACKAGE's `__init__`, which eagerly
+    imports every submodule — so it reports the fetcher as reached no matter
+    what `verify.py` itself does, and would keep reporting it after a genuine
+    regression was fixed. Walking the import statements answers the question
+    that matters: is there a path from `verify` to a module that can open a
+    socket.
+    """
+    package = Path(verifymod.__file__).parent
+    seen: set[str] = set()
+    frontier = [start]
+    while frontier:
+        name = frontier.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        source = (package / f"{name}.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level == 1:
+                if node.module:
+                    frontier.append(node.module)
+                else:
+                    frontier.extend(alias.name for alias in node.names)
+    return seen
+
+
+def test_the_verifier_reaches_no_fetcher() -> None:
+    """REQUIREMENT 2 AS A PROPERTY OF THE IMPORT GRAPH.
+
+    `verify` resolves from the store alone, so nothing on its code path may be
+    able to fetch. Asserted over the modules `verify` actually imports, because
+    that is the code that runs when a citation is checked.
+
+    ⚠ WHAT THIS DOES NOT LOOK AT, and it is the reason the first version of this
+    test failed on a tree with no defect in it: the PACKAGE's `__init__` imports
+    every submodule eagerly, so `import modules.journal.verify` does pull
+    `urllib.request` into the process. That is an import, not a fetch — nothing
+    on the resolve path calls it — and the property worth guarding is the code
+    path rather than the process's module table. A run that wants the stronger
+    property imports `modules.journal.verify` as a file rather than through the
+    package, and the network-off demonstration is what proves the whole thing
+    end to end regardless.
+    """
+    reached = _intra_package_closure("verify")
+    assert "source_fetch" not in reached, (
+        f"`verify` now reaches the fetcher. Its closure: {sorted(reached)}")
+    assert "content_activities" not in reached, (
+        "the activities module imports the fetcher, so reaching it reaches that")
+    assert {"content_store", "citations", "bag"} <= reached, (
+        f"the walk found {sorted(reached)} — a closure missing the modules "
+        f"`verify` demonstrably uses means the walk read nothing and its "
+        f"absence claim proves nothing")
+
+
+def test_the_import_walk_can_SEE_a_fetcher_edge() -> None:
+    """DISCRIMINATOR. The absence above is only evidence if a presence is visible.
+
+    `content_activities` is the module that legitimately imports the fetcher, so
+    its closure is the positive control — and it is a SEPARATE starting point
+    rather than a mutation of `verify.py`, so the control cannot pass by
+    breaking something the assertion would have caught by accident.
+    """
+    assert "source_fetch" in _intra_package_closure("content_activities")

--- a/scripts/workflows/temporal/tests/unit/test_verify_citations.py
+++ b/scripts/workflows/temporal/tests/unit/test_verify_citations.py
@@ -29,6 +29,7 @@ from modules.journal.bag import open_bag
 from modules.journal.citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME,
                                        CITATIONS_FILE, Citation, new_citation,
                                        record_citation)
+from modules.journal.content_activities import capture_fetched_source
 from modules.journal.content_store import object_path, store_bytes
 from modules.journal.verify import (EXIT_MISSING, EXIT_OK, EXIT_SPAN_MISSING,
                                     EXIT_TAMPERED, EXIT_USAGE, MISSING,
@@ -169,8 +170,10 @@ def test_a_code_citation_with_no_repository_is_MISSING_and_says_why(bag) -> None
 # --- exit codes -----------------------------------------------------------------
 
 def test_each_outcome_class_has_its_own_exit_code(bag) -> None:
+    """SIX, not five. `structural` shared 2 with usage and that made a real
+    finding indistinguishable from a wrong invocation."""
     assert len({EXIT_OK, EXIT_MISSING, EXIT_TAMPERED, EXIT_SPAN_MISSING,
-                EXIT_USAGE}) == 5
+                EXIT_USAGE, verifymod.EXIT_STRUCTURAL}) == 6
 
 
 def test_a_mixed_run_exits_on_the_MOST_SEVERE_outcome(bag) -> None:
@@ -196,12 +199,30 @@ def test_a_mixed_run_exits_on_the_MOST_SEVERE_outcome(bag) -> None:
 
 def test_an_unparseable_citation_file_is_STRUCTURAL_not_one_bad_claim(bag) -> None:
     """The record of what was claimed is unreadable — reporting it per-row would
-    understate it, and `ok` must be False even with zero results."""
+    understate it, and `ok` must be False even with zero results.
+
+    ⚠ THIS ASSERTED `EXIT_USAGE` AND THAT WAS THE DEFECT, NOT THE PIN. A record
+    that cannot be read is a REAL FINDING and it exited with the number the
+    entrypoint documents as "you invoked me wrong", so automation treating 2 as
+    a usage error discarded it. `EXIT_STRUCTURAL` is its own code and outranks
+    `tampered`, because an unreadable record means the citations were never
+    enumerated at all.
+    """
     writer = bag.writer_dir("draft")
     (writer / CITATIONS_FILE).write_text("{ not json\n")
     report = verify_bag(bag.path)
     assert report.structural and not report.ok
-    assert exit_code_for([report]) == EXIT_USAGE
+    assert report.worst == verifymod.STRUCTURAL
+    assert exit_code_for([report]) == verifymod.EXIT_STRUCTURAL
+    # AND IT OUTRANKS EVERY CITATION OUTCOME IN THE SAME RUN. A sweep holding
+    # one unreadable record and one tampered object used to exit 2 and report
+    # neither; the ranking is what makes the severest class decide.
+    tampered_elsewhere = verifymod.VerifyReport(
+        path=bag.path,
+        results=(verifymod.CitationResult(
+            claim_id="c9", stage="draft", outcome=TAMPERED, capture="harvest",
+            source_ref="https://example.org/z"),))
+    assert exit_code_for([report, tampered_elsewhere]) == verifymod.EXIT_STRUCTURAL
 
 
 def test_a_bag_with_no_citations_is_not_a_failure(bag) -> None:
@@ -374,3 +395,114 @@ def test_the_entrypoint_and_the_module_share_ONE_parse() -> None:
     calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)
              and isinstance(n.func, ast.Attribute) and n.func.attr == "split_args"]
     assert calls, "the entrypoint no longer calls the shared parse at all"
+
+
+# --- the outcome comes from the TYPE, and the sweep survives the bag ------------
+
+def test_a_run_id_containing_the_word_TAMPERED_still_reports_MISSING(tmp_path) -> None:
+    """⚠ THE CLASSIFIER READ THE MESSAGE, AND THE MESSAGE CARRIES THE RUN ID.
+
+    `verify_citation` chose its outcome with `"TAMPERED" in str(exc)`. The
+    `missing` message embeds `store_dir(bag_path)`, which embeds the run id, and
+    `RUN_ID_PERMITTED` allows those letters — so a run named `TAMPERED-2026`
+    reported every genuinely ABSENT object as a corrupted one: exit 4, and a
+    verdict the module documents as "nothing else in the journal should be
+    trusted". A legal run id silently inverted the store's own diagnosis.
+
+    The remedy is that the outcome is a fact about WHAT FAILED and is carried by
+    the exception type, so it cannot be undone by rewording a sentence.
+    """
+    from modules.journal.bag import DIR_MODE
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    bag = open_bag(root, "TAMPERED-2026")
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="a quoted span",
+        source_ref="https://example.org/a", data=b"a quoted span lives here")
+    object_path(bag.path, citation.page_content_hash).unlink()
+
+    report = verify_bag(bag.path)
+    assert report.counts()[MISSING] == 1, (
+        "an absent object was classified by reading a sentence that contains "
+        f"the run id: {[ (r.outcome, r.detail) for r in report.results ]}")
+    assert report.counts()[TAMPERED] == 0
+
+
+def test_an_object_that_is_PRESENT_and_UNREADABLE_is_not_reported_as_MISSING(tmp_path) -> None:
+    """`missing` MEANS "re-capture the source", WHICH IS DESTRUCTIVE ADVICE HERE.
+
+    The third branch of `load_object` — a generic `OSError` from a permission
+    failure, a failing disk, or a path that has become a directory — contained
+    neither of the two words the old substring test looked for, so it fell
+    through to `missing`. The bytes may be perfectly intact behind that error,
+    and re-capturing would overwrite a record rather than repair it. It belongs
+    in the class that means "the store is not currently to be trusted".
+    """
+    from modules.journal.bag import DIR_MODE
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    bag = open_bag(root, "unreadable")
+    citation = capture_fetched_source(
+        bag=bag, stage="draft", claim_id="c1", quote="a quoted span",
+        source_ref="https://example.org/a", data=b"a quoted span lives here")
+    target = object_path(bag.path, citation.page_content_hash)
+    target.unlink()
+    target.mkdir()
+
+    report = verify_bag(bag.path)
+    assert report.counts()[TAMPERED] == 1
+    assert report.counts()[MISSING] == 0
+
+
+@pytest.mark.parametrize("wreck", ["non-utf8", "unreadable-file"])
+def test_a_bag_that_cannot_be_READ_is_a_FINDING_not_a_raised_exception(tmp_path, wreck) -> None:
+    """⚠ `verify_bag` CAUGHT ONLY `CitationError`, SO ONE BAD BAG KILLED THE SWEEP.
+
+    `read_citations` reaches `read_text(encoding="utf-8")`, which raises
+    `UnicodeDecodeError` (a `ValueError`) on non-UTF-8 bytes and `OSError` on a
+    permission failure or a file that vanished between `rglob` and the read.
+    Neither is a `CitationError`, so both propagated out of a whole-journal run
+    and it reported nothing about any of the other bags.
+
+    This is verbatim the regression `validate.py` records against ITSELF — "one
+    such bag killed the whole sweep" — and the fix there was not carried across.
+    """
+    from modules.journal.bag import DIR_MODE
+    root = tmp_path / "journal"
+    root.mkdir(mode=DIR_MODE)
+    broken = open_bag(root, "broken")
+    writer = broken.writer_dir("draft")
+    target = writer / CITATIONS_FILE
+    if wreck == "non-utf8":
+        target.write_bytes(b"\xff\xfe not utf-8 at all\n")
+    else:
+        target.write_text("{}\n")
+        target.chmod(0o000)
+
+    healthy = open_bag(root, "healthy")
+    capture_fetched_source(bag=healthy, stage="draft", claim_id="ok",
+                          quote="a quoted span",
+                          source_ref="https://example.org/a",
+                          data=b"a quoted span lives here")
+
+    reports = [verify_bag(broken.path), verify_bag(healthy.path)]
+    try:
+        assert reports[0].structural and not reports[0].ok
+        # THE OTHER BAG IS STILL REPORTED. That is the whole point: the sweep
+        # continued, which is what an exception took away.
+        assert reports[1].ok and len(reports[1].results) == 1
+        assert exit_code_for(reports) == verifymod.EXIT_STRUCTURAL
+    finally:
+        if wreck == "unreadable-file":
+            target.chmod(0o600)
+
+
+def test_a_target_that_is_NOT_THERE_is_USAGE_and_not_a_structural_finding(tmp_path) -> None:
+    """The two must stay separable, which is why `EXIT_STRUCTURAL` exists.
+
+    A path the operator named that does not exist is a wrong invocation; a bag
+    that exists and whose record cannot be read is a finding. Collapsing them is
+    what put a real finding behind the usage code in the first place, and
+    splitting the code without splitting these would just move the collapse.
+    """
+    assert verifymod.main([str(tmp_path / "no-such-directory")]) == EXIT_USAGE

--- a/testing/scripts/tests/unit/test_a_guard_RESOLVES_the_module_it_MATCHES.py
+++ b/testing/scripts/tests/unit/test_a_guard_RESOLVES_the_module_it_MATCHES.py
@@ -1,0 +1,294 @@
+"""No AST guard recognises a module by its BARE NAME — swept repo-wide.
+
+WHY THIS FILE EXISTS, AS THE MEASUREMENT RATHER THAN AS A PRINCIPLE. A guard
+that matches `<module>.<function>(...)` by comparing the bare name —
+`node.func.value.id == "re"` — is evaded by one import statement:
+
+    import re as _r          ->  _r.compile(r"^x$")      invisible
+    from re import compile   ->  compile(r"^x$")         invisible
+
+The evaded call is not reported as a violation. It is ABSENT FROM THE POPULATION,
+which is the direction that reads as a clean tree, and the guard stays green.
+
+WHY THIS LIVES BESIDE `test_test_tree_hygiene.py` AND NOT IN A COMPONENT, for the
+reason that file already writes down: the property is repo-wide, and the defect
+it holds was found three times in three different components. A gate scoped to
+one of them would have closed one spelling and left the other two.
+
+THE FOUR OCCURRENCES, WHICH ARE THE EVIDENCE:
+
+  * `test_a_census_guard_proves_its_own_predicate.py` — `_walks_the_tree`
+    resolved `ast` aliases and `_parses_a_literal` hard-coded `"ast"`, so the two
+    disagreed about the same call. A grandfathered guard paying its debt as
+    `_ast.parse("<snippet>")` would have read as uncontrolled forever. Fixed at
+    the site, and the fix is `_ast_aliases`.
+  * `test_every_subprocess_the_fleet_launches_is_bounded.py` — `from subprocess
+    import run` was promoted from unlooked-at to refused, and `import subprocess
+    as sp` was found still open ONE IMPORT STATEMENT AWAY, by a reviewer. The
+    identical pair on `os` then survived both passes and was found by this
+    sweep.
+  * `test_journal_regex_anchors.py` — a class-check written to end a recurring
+    sweep-residue class, itself blind to an aliased `re`, AND its own
+    compensating honesty test blind in the same way. Three mutations green
+    against a 35-passing baseline. This is the finding that produced this file.
+  * `test_a_gh_reply_is_checked_for_SHAPE_not_only_parsed.py` — `json.loads`
+    matched by the bare name, so a `gh` reply decoded through `import json as
+    _j` was not reported unguarded, it was ABSENT FROM THE CENSUS. Found by the
+    sweep this file's own predicate performs, in a component none of the other
+    three touch, and it is the reason the count in this heading is four.
+
+Four independent authors, four components, one defect. Converting the sites did
+not converge — the guard written to stop the class had the class. What converges
+is a check that keys on the CLASS, so the next recogniser fails at the moment it
+is written.
+
+⚠ THAT HEADING SAID **THREE** WHEN IT SHIPPED, and the fourth bullet is the one
+the same correction pass had already fixed two files away. A population claim
+that undercounts its own diff is the exact defect this family exists to refuse,
+written into the file that exists to refuse it — caught by review, recorded here
+rather than quietly renumbered, because the pattern is the point.
+
+TWO ANSWERS SATISFY THIS, and both are import-aware:
+
+  * RESOLVE — walk the module's `import` statements and match every name it is
+    bound to. Right when the module has legitimate non-matching uses (`os` is
+    imported everywhere for `environ` and `path`; refusing an alias would be a
+    rule about aliasing).
+  * REFUSE — report the aliased or from-imported spelling as a finding in its own
+    right. Right when a module is imported for exactly one reason, which is why
+    `subprocess` takes this arm.
+
+The failure is being NEITHER: comparing the bare name and never looking at an
+import statement.
+
+⚠ WHAT THIS DOES NOT COVER, because a sweep is only as good as its predicate:
+
+  * IT SEES A STRING LITERAL COMPARED AGAINST A `.id` ATTRIBUTE. A recogniser
+    that binds the name to a variable first (`want = "re"` … `node.id == want`)
+    is invisible. No guard in this tree does that today, and the failure
+    direction is that a new spelling escapes rather than that a good guard is
+    blocked.
+  * IT ASKS WHETHER THE FILE LOOKS AT IMPORTS FOR THAT MODULE AT ALL, not
+    whether the resolution is correct or reaches the matcher. A file that
+    resolves `re` in one function and hard-codes it in another satisfies this.
+    That is the same standing `test_a_census_guard_proves_its_own_predicate`
+    takes for its own controls: this asks that the question was asked.
+  * IT IS A CHECK ON MODULES, NOT ON NAMES GENERALLY. `node.func.value.id ==
+    "notes"` matches a local variable and aliasing does not apply; the
+    membership test is `sys.stdlib_module_names`, so only importable modules are
+    held to the rule.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# This repo's own worktrees live under `.claude/`; scanning them would count
+# another branch's files as this branch's. RELATIVE parts, not absolute — an
+# absolute-path match skips every file when the suite runs from inside a
+# worktree, which is a scan that visits nothing and reports a clean tree. Same
+# list and same reasoning as `test_test_tree_hygiene.py`.
+SKIP_PARTS = {".git", ".claude", "__pycache__", "node_modules", ".venv"}
+
+# Sites that legitimately compare a module's bare name without resolving it,
+# each with the reason. Empty, and an entry added here is a claim a reader can
+# check — which is the point of declaring rather than skipping. Keyed
+# `"<file>:<module>"` rather than by line, so an unrelated edit above the site
+# does not silently retire the exemption.
+_DECLARED: dict[str, str] = {}
+
+
+def _sources() -> list[Path]:
+    return [
+        path for path in sorted(REPO_ROOT.rglob("*.py"))
+        if not SKIP_PARTS & set(path.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def module_names_matched_in(tree: ast.Module) -> list[tuple[int, str]]:
+    """`(lineno, module)` for every stdlib module compared against a `.id`.
+
+    TAKES A PARSED TREE RATHER THAN A PATH so the recogniser can be exercised
+    against a literal snippet — `test_the_recogniser_discriminates` below. A
+    census guard that never drives its own predicate reports green the moment
+    the predicate stops matching, which is the defect this whole family exists
+    to refuse.
+
+    Both comparison shapes, because a recogniser writes either one: `node.func.
+    value.id == "re"` and `node.func.value.id in {"re", "regex"}`.
+    """
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not (isinstance(node.left, ast.Attribute) and node.left.attr == "id"):
+            continue
+        for op, comparator in zip(node.ops, node.comparators):
+            if isinstance(op, ast.Eq):
+                literals = ([comparator.value]
+                            if isinstance(comparator, ast.Constant) else [])
+            elif isinstance(op, ast.In):
+                # A set/tuple/list of literals. A NAME here (`in aliases`) is the
+                # resolved form and contributes nothing, which is correct.
+                literals = [c.value for c in ast.walk(comparator)
+                            if isinstance(c, ast.Constant)]
+            else:
+                continue
+            found += [(node.lineno, lit) for lit in literals
+                      if isinstance(lit, str) and lit in sys.stdlib_module_names]
+    return found
+
+
+def resolves_imports_of(tree: ast.Module, module: str) -> bool:
+    """Does this file look at `import` statements for `module`?
+
+    RECOGNISED BY BEHAVIOUR, NOT BY A HELPER'S NAME. Every import-aware guard in
+    this tree — whether it RESOLVES or REFUSES — reaches the same two attributes
+    to do it: `alias.name` on an `ast.Import`, `node.module` on an
+    `ast.ImportFrom`. That is a fact the language records, rather than a
+    convention a file may or may not have adopted, and it is the same argument
+    `_walks_the_tree` makes for recognising a census guard by what it does.
+    """
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Compare)
+                and isinstance(node.left, ast.Attribute)
+                and node.left.attr in {"name", "module"}):
+            continue
+        for comparator in node.comparators:
+            if any(isinstance(c, ast.Constant) and c.value == module
+                   for c in ast.walk(comparator)):
+                return True
+    return False
+
+
+def _findings() -> list[tuple[str, int, str]]:
+    """`(relative-path, lineno, module)` for every bare-name match with no resolution."""
+    out: list[tuple[str, int, str]] = []
+    for path in _sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        rel = str(path.relative_to(REPO_ROOT))
+        for lineno, module in sorted(set(module_names_matched_in(tree))):
+            if resolves_imports_of(tree, module):
+                continue
+            if f"{path.name}:{module}" in _DECLARED:
+                continue
+            out.append((rel, lineno, module))
+    return out
+
+
+def test_the_sweep_reads_the_tree() -> None:
+    """A SCAN THAT VISITS NOTHING REPORTS A CLEAN TREE.
+
+    `SKIP_PARTS` and `REPO_ROOT` are the two ways this file goes silently blind:
+    a wrong `parents[N]` roots it in the wrong directory and an over-broad skip
+    empties the walk. Both look identical to a repo with no defect in it.
+
+    A FLOOR RATHER THAN AN EQUALITY, and rather than a snapshot count in the
+    message. The population is "every Python file in the repository", which
+    moves on ordinary commits — an equality would go red as noise and a
+    remembered figure would rot, which is the defect this whole family is about.
+    What the floor has to separate is "reading the tree" from "reading nothing",
+    and any number far below the tree and far above zero does that.
+    """
+    sources = _sources()
+    assert len(sources) >= 100, (
+        f"the walk found {len(sources)} Python file(s) under {REPO_ROOT}, which "
+        f"is not a repository — check `REPO_ROOT`'s `parents[N]` and "
+        f"`SKIP_PARTS`. Both fail this way silently, and a walk that visits "
+        f"nothing is the same colour as a tree with no defect in it")
+
+
+def test_no_guard_matches_a_MODULE_by_its_bare_name() -> None:
+    """THE RULE. A recogniser keyed on a bare module name is evaded by an alias."""
+    findings = _findings()
+    assert findings == [], (
+        "these compare a module's BARE NAME against an AST node's `.id` and "
+        "never look at an import statement for it, so `import <mod> as X` and "
+        "`from <mod> import <fn>` walk straight past the check — and the evaded "
+        "call is ABSENT from the guard's population rather than reported by it, "
+        "which is the colour of a clean tree:\n"
+        + "\n".join(f"  {rel}:{lineno} -> {module!r}"
+                    for rel, lineno, module in findings)
+        + "\n\nEither RESOLVE the module through its bindings (collect "
+          "`a.asname or a.name` from every `ast.Import` of it, and the names "
+          "bound by `ast.ImportFrom`, then match `.id in <that set>`) or REFUSE "
+          "the aliased and from-imported spellings as findings in their own "
+          "right. Pick refusal only when the module is imported for exactly one "
+          "reason — `subprocess` is, `os` is not. If the literal is not a module "
+          "at all, add it to `_DECLARED` in "
+          f"{Path(__file__).name} with the reason.")
+
+
+@pytest.mark.parametrize(
+    ("snippet", "expected", "why"),
+    [
+        pytest.param('n.func.value.id == "re"', [(1, "re")],
+                     "the equality spelling, which is what all three occurrences "
+                     "were written as", id="eq"),
+        pytest.param('n.func.value.id in {"re", "json"}', [(1, "re"), (1, "json")],
+                     "a set of literals is the same defect written wider",
+                     id="in-set"),
+        pytest.param('n.func.value.id in aliases', [],
+                     "the RESOLVED form — a name, not a literal, and the shape "
+                     "this rule asks for", id="in-name"),
+        pytest.param('n.func.value.id == "notes"', [],
+                     "a local variable that is not an importable module; "
+                     "aliasing does not apply and flagging it would invent a "
+                     "finding", id="not-a-module"),
+        pytest.param('n.func.attr == "compile"', [],
+                     "a FUNCTION name, which no import can rebind out from "
+                     "under the matcher", id="attr-not-id"),
+        pytest.param('alias.name == "re"', [],
+                     "the resolution itself — comparing against an import's own "
+                     "name, not against a node's `.id`", id="import-side"),
+    ],
+)
+def test_the_recogniser_discriminates(
+        snippet: str, expected: list[tuple[int, str]], why: str) -> None:
+    """WOULD THIS TEST FAIL IF THE PROPERTY WERE VIOLATED? Asked of the guard itself.
+
+    Both directions, because the failures are asymmetric: a recogniser that
+    stops matching empties the population and every assertion above goes
+    permanently green, while one that matches any string turns every local
+    variable named `time` or `code` into a finding and gets answered with a
+    `_DECLARED` entry — which is how a sweep accumulates suppressions and stops
+    being read.
+    """
+    assert sorted(module_names_matched_in(ast.parse(snippet))) == sorted(expected), why
+
+
+@pytest.mark.parametrize(
+    ("snippet", "module", "expected", "why"),
+    [
+        pytest.param('for a in n.names:\n    if a.name == "re":\n        pass',
+                     "re", True, "`import re as X` walked via `alias.name`",
+                     id="import-alias"),
+        pytest.param('if n.module == "subprocess":\n    pass',
+                     "subprocess", True,
+                     "`from subprocess import run` walked via `node.module` — "
+                     "the REFUSE arm, which counts", id="import-from"),
+        pytest.param('for a in n.names:\n    if a.name == "re":\n        pass',
+                     "json", False,
+                     "resolving a DIFFERENT module is not resolving this one, "
+                     "and reading it as one would excuse every file that "
+                     "resolves anything", id="wrong-module"),
+        pytest.param('x = 1', "re", False, "a file that looks at no imports",
+                     id="no-imports"),
+    ],
+)
+def test_the_resolution_recogniser_discriminates(
+        snippet: str, module: str, expected: bool, why: str) -> None:
+    """THE OTHER PREDICATE, WHICH DECIDES WHO IS ALREADY COMPLIANT.
+
+    A control on the matcher alone was never enough: the rule can be perfectly
+    enforced and then excused for everyone by a resolution check that answers
+    True unconditionally. That is the permanent green this family exists to
+    refuse, and it is the exact shape `_parses_a_literal` shipped with.
+    """
+    assert resolves_imports_of(ast.parse(snippet), module) is expected, why


### PR DESCRIPTION
Builds [Phase 2 of the Persistent Memory Protocol](https://github.com/helloskyy-io/skyynet-master-planning/blob/main/development/edge-assistant/persistent-memory-protocol/phase2_content_store.md): keep the bytes a claim was made against, name them by their own checksum, and re-check every citation **from that cache alone** — offline, repeatably, with four outcomes that have four different remedies.

Planning companion: **helloskyy-io/skyynet-master-planning#5** (the two rulings, the measurement, and the checkbox reconciliation).

## What was built

Five modules under `modules/journal/`, one operator entrypoint, 110 new tests.

| File | What it owns |
|---|---|
| `content_store.py` | Bytes filed under their own sha256. The on-disk path is a function of the **computed digest alone** (r7b) and every read re-hashes and fails closed (r7d) |
| `citations.py` | The record: `claim_id`, `quote`, `source_ref`, `page_content_hash`, plus `stage`, `capture` and `recorded_at`. The `evidence_set_hash` (r5) |
| `source_fetch.py` | The fetch policy the tree had no existing fetcher to inherit (r7c) |
| `content_activities.py` | Capture and resolve as the store's two I/O boundaries (r8) |
| `verify.py` | The read-path invariant run in bulk: four outcomes, four exit codes (r2/r3/r4) |
| `scripts/verify_citations.py` | The operator tool, sibling to `validate_bag.py` |

**It landed inside `modules/journal/` rather than as a new `modules/` child.** The roadmap's open item 7 names "the content store starting" as the trigger for the operator to rule whether `modules/<capability>/` is an admitted shape. Placing it here keeps that precedent a **single case** rather than forcing the ruling by build — and it matches what the code is, since the store lives inside a bag's payload.

## The two rulings the plan said were owed *before* the capture path was built

**r7(a) → per-run, inside the payload.** The objects are covered by the bag's own manifest, so Phase 7 r2 ("referenced objects ship with the bag") is satisfied by construction and Phase 5's reachability pass is a no-op. Cost: a source cited by many runs is stored once per run. Both downstream checkboxes are flipped in the companion PR.

**r7(c) → post-exit harvest, with the guarantee as PER-ROW DATA rather than an amended sentence.** The doc offers two arms and says the routed-fetcher arm "is not a decision this phase can take alone." Rather than downgrading requirement 2's global sentence (the doc's own suggested remedy), every citation carries `capture: read-time | harvest` with **no default anywhere in the package**, and `verify` prints the provenance it read. A verify result therefore cannot over-claim, and the routed arm stays reachable at zero cost — the day a fleet-side read path exists it calls the same activity with `capture="read-time"` and no stored record is rewritten.

## Deviation summary — planned vs built

| Planned | Built | Note |
|---|---|---|
| r1 store by content hash under the journal root | ✅ | |
| r2 verify from the store alone, network actually off | **⚠ partial** | Network-off **demonstrated** (see below). "On a run captured at read time" is **not met** and the box is left unchecked — no research run's sources go through fleet code |
| r3 three exit codes | ✅ **four** | r4 splits a fourth out, so `span-missing` gets its own code rather than sharing one |
| r4 span-miss distinct from hash-mismatch | ✅ | Resolve runs **before** the span check, so a corrupt store is never reported as a wrong quotation |
| r5 `evidence_set_hash` per stage, routed nowhere | ✅ | `converged_stages` reports; nothing consumes it |
| r6 code as a commit SHA, resolved from git | ✅ | A git row carries **no** `page_content_hash` — a second checksum over a copy is a second thing that can drift |
| r7(a)/(b)/(c) specified | ✅ | Rulings above |
| r8 capture and resolve as activities | ✅ | With the same honest caveat Phase 1 r11 carries: the boundary does not make the call happen; `verify` failing closed is what breaks the silence |

**Deferred, and it is the plan's own boundary:** the phase is scoped to `bernstein`'s **S** version. No lineage artifact, and `research-critic` is unchanged — migrating it is a separate change with its own evidence bar, which the plan says explicitly.

## The network-off demonstration, and how the network was disabled

`unshare -rn` is **unavailable** to an unprivileged process on this host: `kernel.apparmor_restrict_unprivileged_userns` is `1`, so `/proc/self/uid_map` is refused. Every variant was tried (`unshare -rn`, plain `-n`, `--map-user`); `bwrap` and `firejail` are not installed.

What was used instead denies the capability **below the language the code under test is written in**: an `LD_PRELOAD` shim whose `socket()`, `connect()` and `getaddrinfo()` fail at the C library. **A control fetch runs under the same shim first and must fail**, or the verify run would prove only that nothing tried. The verifier then returns all four verdicts and the correct exit code with no network at all.

## Test results

```
python/unit         PASS   4414 passed, 8 skipped   (was 4267 — +147)
python/integration  PASS    100 passed, 1 skipped
RESULT: PASSED
```

`ruff --select F821` clean; `lint-prompts.sh` clean; the file-structure map gate passes **with the new files staged** (it reads tracked files, so it was answered after `git add`, not before).

### Mutation evidence — seven mutations, seven predictions, seven matches

Predicted before running, per the discipline that a number named in advance is evidence and a red suite inspected afterwards is a story fitted to the result.

| Mutation (derived from the claim the code makes about itself) | Predicted | Observed |
|---|---|---|
| `validated_digest` accepts anything — the shape gate *is* the path safety (r7b) | 9 | **9** |
| `load_object` stops re-hashing — every read re-hashes and fails closed (r7d) | 7 | **7** |
| Only the first hop is checked — every redirect re-enters every check (r7c) | 3 | **3** |
| `refused_address_reason` permits everything (r7c) | 15 | **15** |
| `tampered` collapses into `missing` (r3) | 5 | **5** |
| Severity puts `missing` above `tampered` (r3) | 2 | **2** |
| Evidence hash counts rows rather than the SET (r5) | 2 | **2** |

Baseline 0 failures; restored to 0 afterwards (restored from a copy, never `git checkout --`).

**One earlier mutation was rejected before it ran**, and it is worth recording: dropping `is_link_local` from the address refusal changes nothing, because `ipaddress` already classifies both `169.254.0.0/16` and `fe80::/10` as `is_private`. That would have been a mutation that satisfies "goes red" by breaking something the assertion catches by accident. It was replaced with one that actually removes the property.

## Findings addressed

The repo's own class-guards caught four things in this work, and one of them was a **live defect in pre-existing code**.

1. **A real containment escape, in my code.** `_writer_directory` composed the caller-supplied `stage` straight onto the payload path — the **fifth** instance of this package's own escape class, written by the pass that had just read the module documenting the other four. Routed through `safe_payload_segment` + `contained_relpath`.
2. **A pre-existing hole in `bag.py`, and a containment declaration that described a rule the code did not have.** `_TRUSTED_JOINS` claimed `writer_dir` slugging meant "no segment can be a bare `..`". It does not: the allowlist `[A-Za-z0-9._-]` **admits a dot**, so `writer_dir("..")` slugged to `".."`. Nothing escaped only because `os.mkdir` fails on an existing directory and the caller took the next ordinal — luck, not the stated rule. Fixed in `safe_payload_segment`, the declaration corrected to say what the code now does, and pinned by a new test in `test_journal_bag.py`.
3. **My own offline test was wrong in a way that would have shipped a false guard.** The first version asserted over `sys.modules` after importing `modules.journal.verify` — which measures the **package `__init__`**, not `verify`'s own graph, so it reported the fetcher as reached on a tree with no defect in it and would have kept reporting it after a real regression was fixed. Replaced with a static intra-package import closure, plus a discriminator that starts the same walk at `content_activities` (which legitimately *does* import the fetcher).
4. **Three census/declaration registries updated** rather than routed around: the launch-reply census (7→8, with its docstring), the tag-line sweep, and the URL-splitting census. Each edit *is* the gate, by those guards' own design.

## Rejected, with reasoning

- **`test_journal_prose_figures_are_DERIVED` flagged the phrase "two entry points"** in a docstring, matching its entrypoint-population predicate. Not a claim about the fleet's kickoff entrypoints — reworded to "two I/O boundaries" rather than adding a `_DECLARED_NON_DERIVATIONS` row, because declaring it would normalise the collision. The predicate's `entry\s?points?` tolerance is noted in the reflection, not changed.
- **Refusing a content-coded response rather than applying a decoded-size cap.** The plan permits either. Refusing removes the decompression case outright instead of bounding it, and keeps "the digest is over the bytes the server sent" literally true — the sentence the whole store's guarantee rests on.

## Success criteria

- [x] r1 — every cited artifact stored by content hash under the journal root
- [ ] r2 — **partial.** Verify resolves from the store alone and runs with the network actually denied. *At read time* is not met: nothing routes the model's reads through fleet code, which is what r7(c) rules on
- [x] r3 — verified / missing / tampered distinguished by exit code (0 / 3 / 4)
- [x] r4 — span-missing is its own outcome and its own exit code (5)
- [x] r5 — `evidence_set_hash` computed per stage, exposed, routed on by nothing
- [x] r6 — code carried as a commit SHA, resolved via `git cat-file`, never copied in
- [x] r7 — shape, path derivation and fetch policy all specified and ruled
- [x] r8 — capture and resolve are activities, and `verify` fails closed on a citation with no stored bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Refine pass (`build-refine`, commits `84c4d47` + `625ab3d`)

An independent pass reviewed the draft above, reproduced every finding by execution before fixing it, and swept each finding's CLASS rather than its site. **Everything above this line still describes what the PR contains**; this section states what changed and where the draft's own account is now wrong.

## Three Criticals in the checker, all confirmed by running it

**1. A legal run id inverted the store's diagnosis.** `verify_citation` chose `missing` vs `tampered` with `"TAMPERED" in str(exc)` — over a message that embeds the store path, which embeds the run id, which `RUN_ID_PERMITTED` allows to contain those letters. Reproduced: a bag named `TAMPERED-2026` with its object *deleted* reported `tampered: 1`. `content_store` now raises `ObjectMissing` / `ObjectCorrupt` / `ObjectUnreadable`; the outcome comes from the exception TYPE. `ObjectUnreadable` is its own class because the old code sent a present-but-unreadable object to `missing`, whose remedy is "re-capture the source" — destructive advice for bytes behind a failing disk.

**2. A real finding exited with the number documented as "usage".** `exit_code_for` short-circuited to `EXIT_USAGE` on any structural finding, so an unreadable citation record exited 2 — while `EXIT_USAGE`'s own comment claimed a wrong invocation and a real finding are never the same number. That sentence was false when written. **`EXIT_STRUCTURAL` (6)** now ranks above `tampered`; `main` returns 2 for a target that is not there, so the two stay separable; and `VerifyReport.worst` ranks structural rather than returning `verified` for a report whose `ok` is False.

**3. One bad bag killed a whole-journal sweep.** `verify_bag` caught only `CitationError`, but `read_citations` reaches `read_text(encoding="utf-8")`. Reproduced: a `citations.jsonl` of non-UTF-8 bytes raised `UnicodeDecodeError` straight out. This is verbatim the regression `validate.py` already records against itself — *"one such bag killed the whole sweep"* — and the fix was not carried across.

## The class sweeps — a finding names a site, not the defect

| Class | Sweep | Found | Disposition |
|---|---|---|---|
| Regex anchors | all 6 `re.compile` in `modules/journal/` — **exhaustive** | **4** used `^…$`, which matches before a trailing newline | All 4 → `\A…\Z`. `validated_digest("a"*64 + "\n")` **returned** and was composed onto a path by the function whose docstring says such a value is refused rather than composed |
| Report injection | every value `render_report` prints — **exhaustive** | `stage` and `source_ref` unguarded; a row could forge a report line | Both → `folds_a_tag_line`, the derived predicate `bag` already owns |
| File creation / symlink-follow | every write in the package — **exhaustive** | **2** sites | (1) `record_citation`'s builtin `open(..., "a")`: 0664 where every other file in a bag is 0600, and it FOLLOWED symlinks — the read side already refused to follow a planted link while the write side appended through one. (2) `bag._append_tag_line`, found while re-checking the count above: mode already correct, follow open. **Both** now `os.open` + `O_NOFOLLOW` + `FILE_MODE`. The second is pre-existing on `main` (verified with `git show`) and fixed rather than surfaced, because reporting an exhaustive sweep and leaving a member it named is the failure the sweep exists to prevent — commit `625ab3d` |

Plus: `check_url` leaked `ValueError` from `urlsplit`/`.port` past every caller catching `FetchRefused`; `from_json` leaked `TypeError` past its own *"re-validated on the way in"* guarantee on a truncated row; `git_blob` raised `ContentStoreError` into the branch that classifies STORE failures (now `GitResolveError`); and the staging name carried only the pid, so two threads capturing one source unlinked each other's in-flight file and **neither** landed.

## Prose that was wrong, in files readers are trained to trust

- `verify.py` cited **`test_verify_is_offline.py`** as the guard for its offline property. **That file has never existed.** Now cites `tests/unit/test_verify_citations.py::test_the_verifier_reaches_no_fetcher`.
- `__init__.py` named `phase1_the_run_bag.md` as the authority for *"every decision this package implements"* — five of its ten modules implement Phase 2. Both docs now named, scoped.
- `capture_source` claimed the fetcher is not on `verify`'s import path. True of the intra-package closure, false of the process: `__init__` imports it eagerly. Qualifier added.

## Guards extended rather than routed around

The prose sweep globbed `test_journal_*.py` and matched **none** of Phase 2's five new test files — the same gap that file already records against `journal_entrypoint_facts.py`, recurring one phase later. Seven paths added; verified non-vacuous by mutation. The containment and tag-line declaration registries carry the new expressions with reasons; the entrypoint-driving census moved **6 → 7** because a new case calls `verify.main()` in-process (which puts that module inside the journal-redirect sweep for the first time).

## One of my own fixes was reverted

A **NAT64 prefix table**, written for a review finding, turned out to be **dead code**: `ipaddress.is_reserved` is already true across `64::/16`, so the table refused nothing and its test passed with the table deleted. Table removed; the property survives as a **pinned** test carrying that reasoning, so the next reader does not re-derive it. The reasoning is also recorded in `refused_address_reason`'s docstring, whose own argument this is.

## Test results

```
python/unit         PASS   4448 passed, 8 skipped   (was 4417 — +31)
python/integration  PASS    102 passed, 0 skipped
python/e2e          —      no tests/e2e directories in the tree
RESULT: PASSED
```

`ruff --select F821,F401,E9` clean. The file-structure map gate passes **with the new `tests/integration/conftest.py` staged**.

### Mutation evidence — safety-control tier, 12 mutations, 12 matches

| Mutation | Predicted | Observed |
|---|---|---|
| digest anchor back to `^…$` | 2 | **2** |
| `claim_id` anchor back to `^…$` | 1 | **1** |
| drop the `folds_a_tag_line` loop | 4 | **4** |
| `from_json` stops wrapping `TypeError` | 2 | **2** |
| drop the `isinstance` type-check loop | 1 | **1** |
| classifier back to the substring test | 2 | **2** |
| `verify_bag` catches `CitationError` only | 2 | **2** |
| `exit_code_for` short-circuits to USAGE | 3 | **3** |
| `check_url` stops wrapping `ValueError` | 3 | **3** |
| `_NoRedirects` stops overriding | 1 | **1** ¹ |
| staging name back to pid-only | 1 | **1** |
| prose sweep, figure in a newly-swept file | red | **red** |

Baseline 0, restored to 0 (from a copy, never `git checkout --`).

**¹ This one mismatched first — predicted 1, observed 0 — and the defect was in MY OWN new test, twice.** The reviewer correctly found that the shipped redirect tests never exercise `_NoRedirects` (they hand `fetch_source` a pre-built `HTTPError`). My replacement had a stub handler *raise* `HTTPError`, which propagates straight out of `OpenerDirector.open` and never reaches the redirect chain at all. The second draft *returned* a 302 but used this file's `FakeHeaders` — a plain `dict`, case-sensitive, where `http_error_302` asks `"location" in headers` in lower case — so even the **stock** `HTTPRedirectHandler` declined to follow and the mutation came back green again. Verified by running both handlers against the corrected fixture: stock follows to the inner URL, `_NoRedirects` raises 302.

## Corrections to the draft's own claims above

- **"three exit codes … four"** → **five** distinct codes now (0/2/3/4/5) plus **6** for structural. The draft's success-criteria list below says "0 / 3 / 4"; that is still true of those three outcomes.
- **"110 new tests"** → the tests directory now carries **+31** beyond the draft.
- The draft's rejection of the `"two entry points"` prose-guard flag stands, but the phase DOC in the planning repo carries the same phrase and is now inside the sweep, so it is declared with the reason. **Narrowing the predicate to the unspaced `entrypoints?` — the draft's own reflection suggestion — was NOT done: verified that 0 of 35 registered figures use the spaced form, so it would lose nothing, but changing a guard's reach is the operator's call and not a correction pass's.**

## What is still NOT met

**Requirement 2 remains partial and its box stays unchecked**, unchanged by this pass: verify resolves from the store alone and runs with the network actually denied, but *"on a run captured at read time"* is not met because nothing routes a research run's reads through fleet code. That is r7(c)'s ruling, and it is the honest state.



---

# Correction pass (`build-refine-minor`, commit `1718df1`)

`review-pr` pass 1 returned **five HOLD findings**. Each is fixed, and each was
treated as an INSTANCE: the class it belongs to was swept, the other members
fixed with it, and — for the two classes that had one — a check was added that
keys on the CLASS, so the next member fails at the moment it is written rather
than at the next review pass. **Everything above this line still describes what
the PR contains**; this section states what changed and corrects the figures the
refine pass published.

## The five findings

| Finding | Fixed as | Class swept | Other members found |
|---|---|---|---|
| `typo-reports-journal-as-corrupt` | `validate.main` now answers a target that is not a directory with **exit 2 and no report**, mirroring `verify.main`. `validate_bag()` itself is untouched — its structural return for a non-directory is for programmatic callers | every `main()` in `modules/` + `scripts/` that takes an operator-supplied path target — **exhaustive, 15 `main()`s read** | **0.** `verify.main` was already correct; the `--task-file` runners route a missing file through `resolve_task_source`, which already separates missing from unreadable |
| `anchor-sweep-residue-in-label-re` | `bag._LABEL_RE` → `\A…\Z` | **every** anchored `re.compile` in `modules/` + `scripts/` — **exhaustive, 23 sites**, scanned by AST rather than by grep | **2**, both outside the journal package: `plan_activities._LOOKS_LIKE_A_PHASE` and `plan_draft_activities._PHASE_FILE`, both whole-string filename validators. The remaining 20 are `re.MULTILINE` line-scanners or bare `^` (≡ `\A` without the flag) — converting those would be a defect, not a fix |
| `map-annotation-says-four-over-five` | `docs/file_structure.txt` "All four" → "All five", and the dangling `who` from the rewrap is folded back | count-words in the map lines **this PR added** — exhaustive over the diff | **0.** The enumeration itself was checked against `ls scripts/workflows/temporal/scripts/*.py` and is correct at five, so the precheck's "wider defect" branch does not apply |
| `conftest-scope-trap-undocumented` | the autouse fixture's docstring now states that a test body runs *inside* it, that an integration test reading the real journal must resolve at **module** scope, and that the failure is a skip wearing an environment-sounding reason | prose only; behaviour, scope and the `CONFIG_PATH` redirect unchanged | — |
| `verify-citations-absent-from-operator-guide` | one paragraph in `guide/operations.md` naming `verify_citations.py`, its three target forms, `--repo`, the offline property and the four outcomes | cross-repo — landed on **skyynet-master-planning#5**'s branch, commit `00414ba` | — |

## The two class-checks, and why a check and not a fix

Both findings that recur (a `main()` collapsing usage into a verdict; a `^…$`
anchor) had already been fixed once by hand in this PR and came back one review
pass later at the adjacent site. Enumerating instances did not converge, so what
changed is what the check keys on:

- **`tests/unit/test_journal_regex_anchors.py`** — fails on any `^`/`$` anchor
  in any `re.compile` under `modules/journal/`. `_DECLARED` is the escape hatch
  and it is **empty**, which is the honest state rather than a missing one.
- **`tests/unit/test_journal_operator_tools_separate_typo_from_finding.py`** —
  **derives** the population (every `scripts/*.py` importing
  `modules.journal.validate` or `.verify`) and asserts each answers exit 2 with
  an empty stdout for a target that is not there. A third bag-inspection tool
  joins the sweep by importing the checker it wraps, which it must do to be one.

Both carry a literal positive control, so the census guard that audits census
guards counts them as **controlled** rather than grandfathered.

## My own guard was blind, and mutating it is what found that

`test_journal_regex_anchors.py`'s first draft matched `ast.Constant` alone. That
made **`content_store._HEX_DIGEST_RE`** — spelled `re.compile(r"\A[0-9a-f]{%d}\Z"
% DIGEST_HEX_LENGTH)`, and the gate that IS r7(b)'s path safety — **invisible to
the sweep**: reverting it to `^…$` left the new guard green. Predicted 2 red,
observed 1, and the missing one was the guard's own reach.

`_literal_parts` now recovers `%`-formatted, concatenated and f-string patterns,
and an expression it *cannot* read fails `test_no_pattern_is_unreadable_to_the_sweep`
rather than being skipped — a pattern nobody can check must not look like a
pattern that checked out.

A second of my own new tests was vacuous the same way. The multi-target case
first used an empty directory as its "good" target; both tools answer that with
exit 2 by themselves, **before** looking at the second argument, so it passed
without the second argument existing. Checked by running the empty directory
alone; replaced with a real sealed bag.

## Corrections to figures published earlier on this PR

- The refine pass's sweep row reads *"all 6 `re.compile` in `modules/journal/` —
  **exhaustive** … 4 used `^…$` … All 4 → `\A…\Z`."* The count of sites was
  right; the closure was not — a fifth, `bag._LABEL_RE`, was still `^…$` at that
  commit. It is now **5 of 6 anchored with `\A…\Z`**, the sixth being
  `_SAFE_SEGMENT_RE`, a substitution character class that is deliberately
  unanchored, and the package is at **zero** `^`/`$`.
- Test totals: **4494 unit** (was 4448 — +46) and **102 integration**.

## Reviewer findings, and their dispositions

One `code-reviewer` agent, both lenses. **Zero Critical.**

- **Warning — multi-target usage short-circuit is untested.** With two targets
  where the second is not a directory, an earlier valid target's report is
  computed and never printed. **FIXED** by pinning it as deliberate, for the
  whole population rather than for one tool: a `result: PASS` block printed
  directly above "you named something that is not there" is the same confusion
  the exit-code split exists to end. Negative control: making `validate.main`
  finish the list turns the case red.
- **Medium — the digest trailing-newline case is homed in the new sweep file,
  not in `test_content_store.py`'s `hostile` battery** where a contributor
  extending "what is not a digest" would look. **FIXED** — both `digest + "\n"`
  and `"\n" + digest` added there, with a pointer to where the class lives.
- **Low — `_anchor_positions` mis-parses a leading `]`** (`[]a]`, `[^]a]`), which
  would report a class's own `$` as an anchor. Not live in scope. **FIXED
  anyway** with two literal controls: a false finding gets answered with a
  `_DECLARED` suppression, and a suppression added for a scanner bug outlives
  the bug.
- **Low — `validate.py` uses bare exit-code literals where `verify.py` names
  constants. REJECTED.** The two files are not in the same position: `verify.py`
  needs constants because its six codes carry a *severity ranking* that is
  itself data (`SEVERITY`, `_EXIT_FOR`, `exit_code_for`), so an unnamed integer
  there would appear in a lookup table. `validate.py` has three codes, no
  ranking, and no table; its contract is now stated in one place, `main`'s
  docstring. That is a structural difference, not an inconsistency.

## Test results

```
python/unit         PASS   4494 passed, 8 skipped
python/integration  PASS    102 passed
python/e2e          —      no tests/e2e directories in the tree
RESULT: PASSED
```

`ruff --select F821,F401,E9` reports 26 pre-existing unused imports across the
tree and **none in this diff** (one I orphaned was removed). `lint-prompts.sh`
clean. Delivered CI on the parent commit was green on all four checks.

## Still not met, unchanged by this pass

**Requirement 2 remains partial and its box stays unchecked.** Verify resolves
from the store alone and runs with the network actually denied, but *"on a run
captured at read time"* is not met because nothing routes a research run's reads
through fleet code. That is r7(c)'s open ruling.


---

# Correction pass 2 (`build-refine-minor`)

`review-pr` pass 2 returned **one HOLD finding**: `anchor-guard-blind-to-aliased-re-import`.
It is fixed, and it was treated as an **INSTANCE**. The class was swept, three
other members were found and fixed with it, and a check that keys on the CLASS
now exists so the next member fails at the moment it is written.
**Everything above this line still describes what the PR contains**; this
section states what changed and corrects the figures the prior passes published.

## The finding, reproduced before it was fixed

`test_journal_regex_anchors.py` publishes *"a `^` or `$` written into this
package tomorrow fails at the moment it is written."* Both of its recognisers
required the bare name `re`. Mutated into `modules/journal/citations.py` against
a 35-passing baseline, restoring from a copy each time:

| Mutation | Before | After |
|---|---|---|
| `import re as _r` / `_r.compile(r"^mutant$")` | **GREEN** | **RED** |
| `import re as _r` / `_r.match(r"^mutant$", s)` | **GREEN** | **RED** |
| `from re import compile as _c` / `_c(r"^mutant$")` | **GREEN** | **RED** |
| `from re import match as _m` / `_m(r"^mutant$", s)` ¹ | — | **RED** |

¹ A fourth spelling the finding did not name, added because the from-import arm
has two halves and closing one is how this class keeps recurring.

The second recogniser is the file's own **compensating control** for a narrow
predicate, and it shared the blind spot it compensates for — so a blind sweep
and a clean package were the same colour. It is now driven by a shared
`re_bindings()`, and it was **lifted out of its test into a module-level
`uncompiled_calls_in()`** so a literal can drive it; it had no control at all.

## The class sweep — EXHAUSTIVE, and it found three more members

**The class:** *an AST guard recogniser that matches `<module>.<fn>(…)` by
comparing the module's bare name, so one import statement evades it — and the
evaded call is **absent from the population** rather than reported by it, which
is the colour of a clean tree.*

**How I searched:** an AST pass over **every `.py` in the repository** (244
files, `.git`/`.claude`/`__pycache__` excluded) for a string literal compared
against a node's `.id`, filtered to `sys.stdlib_module_names`. Not grep — the
comparison is written in two shapes (`== "re"` and `in {"re", …}`) and a grep
for either misses the other. **5 sites, 3 files unhandled, 1 already handled.**

| Site | Module | State | Disposition |
|---|---|---|---|
| `test_journal_regex_anchors.py:168, 253` | `re` | unhandled | **FIXED** — the runway finding |
| `test_a_gh_reply_is_checked_for_SHAPE_not_only_parsed.py:159` | `json` | unhandled | **FIXED** — a `gh` reply decoded via `import json as _j` was **not in the census at all**, so it read as a clean tree rather than as an unguarded decode |
| `test_every_subprocess_the_fleet_launches_is_bounded.py:157` | `os` | unhandled | **FIXED** — the residue of a fix applied at its site. The two `subprocess` spellings were closed (one of them by a reviewer, *"one import statement away"*); the **identical pair on `os` survived both passes** |
| `test_every_subprocess…:138` | `subprocess` | already refused | correct as-is |
| `test_a_census_guard_proves_its_own_predicate.py` | `ast` | already resolved | correct as-is — and its docstring records making this exact mistake, which is occurrence zero |

**Two answers satisfy the rule and both are import-aware.** RESOLVE (walk the
imports, match every bound name) is right where a module has legitimate
non-matching uses — `os` is imported everywhere for `environ` and `path`, so
refusing an alias would be a rule about aliasing. REFUSE (report the aliased
spelling as a finding) is right where a module is imported for exactly one
reason, which is why `subprocess` keeps that arm. **The failure is being
neither.** `from <mod> import *` is closed in all three rather than declared as
a hole.

## The class check — `testing/scripts/tests/unit/test_a_guard_RESOLVES_the_module_it_MATCHES.py`

Enumerating instances did not converge here, and that is measured rather than
asserted: the guard written to end this PR's sweep-residue class **had the
class**, and had already been fixed once on the *literal-recovery* axis while
staying open on the *call-recognition* axis. So this pass changes what the check
keys on.

It sweeps the repository, and it **independently catches all three members** —
verified by reverting each fixed file in turn to its `HEAD` version and watching
`test_no_guard_matches_a_MODULE_by_its_bare_name` go red, three for three.

**It lives beside `test_test_tree_hygiene.py`**, which makes the identical
placement argument for the identical reason: the property is repo-wide, and this
defect appeared in **four components**. A gate scoped to one of them would have
closed one spelling and left three. That placement puts it **outside**
`test_a_census_guard_proves_its_own_predicate.py`'s population (which globs
`temporal/tests/unit/`), so `_PINNED` does **not** move — it ships its own
literal controls on **both** predicates anyway, because a rule can be perfectly
enforced by a resolution check that answers `True` unconditionally.

## Reviewer findings, and their dispositions

One `code-reviewer` agent, both lenses. **Zero Critical.**

- **Warning — the class check's own evidence docstring undercounted its
  population**, listing three occurrences while the same diff fixed four (it
  omitted the `json` one it had itself found). A population claim that
  undercounts its own diff, inside the file that exists to refuse exactly that.
  **FIXED**, and the miscount is recorded in the file rather than quietly
  renumbered, because the pattern is the point.
- **Warning — `from re import *` / `from json import *` handled by none of the
  three resolvers**, latent (no star import exists in the tree; verified).
  Reviewer proposed declaring it as a stated boundary. **FIXED instead** — it
  costs one line per file to close, and a hole that cheap does not earn a bullet
  in a boundary list. Negative control: dropping all three star handlers turns
  four assertions red.
- **Medium — three near-identical alias resolvers now exist in three files;
  extract a shared helper. REJECTED.** They are 5–8 lines each and
  `code-style.md` is explicit that three similar blocks beat a premature
  abstraction — but the load-bearing reason is different: **the convergence
  mechanism here is the class check, not shared code**, and that is demonstrated
  rather than argued (reverting any one of the three turns the class check red).
  A shared resolver would also sit outside all three files' own control
  populations, so each would lose the literal controls it just gained. The
  reviewer named this counter-argument itself and left the call here.
- **Medium — `re_bindings` is public while `_json_bindings` is private.
  REJECTED**, on the reviewer's own analysis: `re_bindings` must be public
  because two module-level recognisers and their literal controls drive it
  directly, while `_json_bindings` is only ever reached through `_Parses`. Each
  follows its file's local convention, which `code-style.md` asks for.
- **Low — placement of the new class check.** Reviewer confirmed it correct
  against the `test_test_tree_hygiene.py` precedent. No action.

## Blast-radius sweep of my own edits

- **Prose figures I wrote, re-derived against the tree.** *"All three
  regex-using modules import `re` plainly"* — `grep` returns exactly
  `bag.py`, `citations.py`, `content_store.py`, each `import re` on its own
  line. ✅
- **A snapshot count I wrote into the new guard's failure message (`243`) was
  already wrong** — the walk reads 244 with the new file in it. **Removed
  rather than corrected:** the population is "every `.py` in the repo", which
  moves on ordinary commits, so a remembered figure there rots by construction.
  The floor separates *reading the tree* from *reading nothing*, which needs no
  snapshot.
- **`docs/file_structure.txt`** carries the new file; the map gate was answered
  **with it staged**, since it reads tracked files.
- **`main` moved under this branch** (`0557dcf`, the `merge-pr` activity — the
  prior review pass recorded merge-base as `origin/main` exactly, and that is no
  longer true). All six of its Python files were run through the new class
  check's predicate at `origin/main`: **clean**, so the guard does not break on
  merge.

## Test results

```
python/unit         PASS   4519 passed, 8 skipped   (was 4494 — +25)
python/integration  PASS    102 passed
python/e2e          —      no tests/e2e directories in the tree
RESULT: PASSED
```

`ruff --select F821,F401,E9` clean on all four files. Delivered CI on the parent
commit was green on all four checks.

## Still not met, unchanged by this pass

**Requirement 2 remains partial and its box stays unchecked.** Verify resolves
from the store alone and runs with the network actually denied, but *"on a run
captured at read time"* is not met because nothing routes a research run's reads
through fleet code. That is r7(c)'s open ruling.
