### PR TITLE
build-draft: PMP Phase 3 — the emit rule, every fleet-code write also emits to the journal

### DIFF
--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -789,6 +789,44 @@ claude-dot-files/
 │                   │                                #   more. Sweeps every f"{label}: {value}" for an undeclared value; the battery beside it
 │                   │                                #   is DERIVED from splitlines() rather than from a remembered list, and the round trip
 │                   │                                #   is the property: for any accepted value, reading the file returns what was written
+│                   ├── test_journal_events.py        # PMP Phase 3's CONTRACT — what an event is, what makes it admissible, and the two replay
+│                   │                                #   rules. Owns no I/O; test_journal_emit.py drives the failure cases, and keeping them apart is
+│                   │                                #   what stops a contract written wrongly and exercised wrongly from agreeing with itself. Every
+│                   │                                #   admission check is asserted as a REFUSAL, because a test that built an admissible event and
+│                   │                                #   read its fields would leave all five untested while looking thorough. Two assertions carry
+│                   │                                #   the whole design: dedupe keys on (id, KIND) — keyed on id alone it drops every completion
+│                   │                                #   and replay applies nothing — and an intent with no completion is NOT applied, which is what
+│                   │                                #   stops Phase 4 materialising content the store never got. Identity is asserted deterministic
+│                   │                                #   AND discriminating on each of its three inputs, or the first assertion passes for a constant
+│                   ├── test_journal_emit.py          # The four write-failure cases, driven against REAL bags on a real filesystem — a mocked open()
+│                   │                                #   proves the code branches, not that the bag ends up in the state the branch claims. Ordering is
+│                   │                                #   asserted from INSIDE the store write, which is the only place write-ahead is visible: reading
+│                   │                                #   the file afterwards proves write order, not order relative to the side effect. Case (d) needs
+│                   │                                #   the tag FILE unwritable, not its directory — a 0500 directory refuses creation and an existing
+│                   │                                #   bag-info.txt still takes an append, which is how the first version of that test asserted case
+│                   │                                #   (d) and observed case (c). Mode-induced refusals skip under uid 0 rather than passing vacuously
+│                   ├── test_journal_edge_id_and_capture_filter.py # Two modules in one file because they share one argument: keeping a secret out of a durable
+│                   │                                #   record. A digest-shaped edge id is refused (hash(api_key) is ruled out twice — it changes on
+│                   │                                #   rotation, and a stored hash of a live credential is a confirmation oracle) and a PREFIXED
+│                   │                                #   random token is accepted, which is the control that keeps the refusal from being total. The
+│                   │                                #   filter's ten rules each fire on their own sample, ordinary prose and a git SHA do NOT fire it,
+│                   │                                #   and the STATED BLIND SPOTS — a bare password, a base64-ed token — are asserted AS blind spots
+│                   │                                #   so the suite reads as a boundary rather than as a completeness claim
+│                   ├── test_the_tag_namespace_is_HELD_BY_CODE.py # PMP Phase 3 r13. Separate from test_journal_tag_lines.py because that owns the LINE and this
+│                   │                                #   owns the NAMESPACE, and they failed independently — the line's rule leaked twice through
+│                   │                                #   different writers, the namespace never had a rule because it was closed by construction until
+│                   │                                #   WD Phase 5 took a tag from outside. Lifecycle labels refused, descriptive ones accepted, an
+│                   │                                #   unrecognised one VALIDATES and is REPORTED. (c) is deliberately open and a test holds it open:
+│                   │                                #   test_no_bag_level_version_field_was_invented goes red if a later change quietly settles it.
+│                   │                                #   Also drives the bag-info.txt race from three PROCESSES — an advisory flock is a cross-process
+│                   │                                #   control, so a threading test would exercise the GIL rather than the lock
+│                   ├── test_every_fleet_write_path_EMITS.py # PMP Phase 3 r1, wired. Two halves: a CENSUS that keeps requirement 9's inventory complete, and
+│                   │                                #   one behavioural test per inventoried path. The census walks for ONE shape — a subprocess whose
+│                   │                                #   argv[0] is `gh`, from an uninventoried module — and deliberately NOT for a bare write_text,
+│                   │                                #   which would be almost all false positives and teach a reader to add exemptions. It asserts a
+│                   │                                #   non-zero examined count, because a walk that scoped itself wrongly reports a clean sweep over
+│                   │                                #   nothing. The discriminators are the point: a gh READ must not emit, and the case-(d) report
+│                   │                                #   must not emit while an ORDINARY comment must — the exception is narrow or it is a hole
 │                   ├── test_dispatch_context.py     # The run context's behaviour: the worktree name follows the workflow key (every key,
 │                   │                                #   because the drift was in a single runner), the object is frozen, the echo is gated on
 │                   │                                #   `is_the_run` rather than on `minted` — a retry supplies its name and is exactly the

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -279,6 +279,24 @@ claude-dot-files/
 │           │                                        #   propose changing that set. The tag carries the population beside the hash so a
 │           │                                        #   reader can recompute it without this module; an unestablishable population is
 │           │                                        #   recorded as `unavailable reason=<slug>` and does NOT stop the run
+│           │                                        #   PHASE 3 ADDS THE EMIT RULE — every write to any store also emits to the journal — as four
+│           │                                        #   more files here, for the reason Phase 2's five are here: they write into a bag's payload.
+│           │                                        #   events.py is the event contract, SEPARATE from the typed exit record's and sharing one
+│           │                                        #   vocabulary with it (modules/vocabulary.py) — exit-protocol.md §2 forbids a field added for
+│           │                                        #   a consumer that does not exist and §2.5 bounds that record at 4096 bytes, and an event adds
+│           │                                        #   six such fields and carries content verbatim, so an extension is not available. Five event
+│           │                                        #   kinds, four admission fields (identity, edge_id, key_epoch, provenance), and two replay
+│           │                                        #   rules: dedupe on identity, and apply ONLY an intent that has a completion — which is what
+│           │                                        #   stops Phase 4 materialising content the store never got. edge_id.py persists the machine's
+│           │                                        #   name at the ROOT (per-machine, so not inside a bag) and refuses a digest-shaped id: a
+│           │                                        #   key-derived one orphans an edge's history on rotation AND is a confirmation oracle.
+│           │                                        #   capture_filter.py removes named credential shapes AT APPEND, before any byte reaches the
+│           │                                        #   root — not at seal, which would change written events. emit.py is the boundary: write-ahead
+│           │                                        #   ordering (intent, then the store write, then the completion carrying the store's address),
+│           │                                        #   the four write-failure cases, and case (d)'s two channels WITH their readers. It is
+│           │                                        #   registered by open_run_bag rather than threaded through forty signatures, and that trade is
+│           │                                        #   stated at register_emitter — an optional emit is a skipped emit. It reaches FLEET-CODE
+│           │                                        #   writes only; the model-issued half is Phase 10's post-exit harvest
 │           ├── scripts/                             # Kickoff entrypoints, until an SDK path replaces them — plus preflight.py,
 │           │                                        #   validate_bag.py, verify_citations.py, compare_run_config.py, dispatch_identity.py
 │           │                                        #   and dispatch_context.py,
@@ -856,15 +874,17 @@ claude-dot-files/
 │                   │                                #   and no store function at all, so an import-only check is blind to every one.
 │                   │                                #   Families 1 and 2 each hold a fleet idiom, which is what makes them likely rather
 │                   │                                #   than exotic: a journal submodule bound as a name (journal_activities as journal in
-│                   │                                #   every entrypoint, verify and validate in the two operator tools — eighteen call
+│                   │                                #   every entrypoint, verify and validate in the two operator tools, emit in
+│                   │                                #   assistant_activities — nineteen call
 │                   │                                #   sites, and content_store is not among them) and from .. import journal, the workflow
 │                   │                                #   tree's dominant relative import. The package matcher binds by import SEMANTICS,
 │                   │                                #   never by the identifier text `journal`: `alias.name` is matched and never the asname,
 │                   │                                #   BOUNDARY_PARENT rejects a `journal` imported from a sibling, and an asname binds
 │                   │                                #   exactly the module named, so import modules.assistant as ma reaches nothing. The
-│                   │                                #   eighteen call sites trip the first two at once, so neither can be observed through
+│                   │                                #   nineteen call sites trip the first two at once, so neither can be observed through
 │                   │                                #   them and neither costs a false positive — measured, deleting either flags nothing on
-│                   │                                #   a clean tree, because those call sites only reach open_run_bag. Both are therefore
+│                   │                                #   a clean tree, because those call sites reach only open_run_bag and the emit
+│                   │                                #   boundary. Both are therefore
 │                   │                                #   asserted directly on _package_bindings, by the shapes that isolate one check each,
 │                   │                                #   plus a synthetic module the tree does not contain: reading "no instance here" as "no
 │                   │                                #   control can express it" is what left family 3 unenumerated, twice. The name checks
@@ -875,8 +895,8 @@ claude-dot-files/
 │                   │                                #   nothing passes every assertion, which is today's fleet. Its vacuity control
 │                   │                                #   asserts a floor PER swept directory after a mutation showed a single total floor
 │                   │                                #   of fifty stayed green with all 22 modules under scripts/ dropped from the
-│                   │                                #   population, modules/ alone holding 60 of the 82. EVERY FIGURE IN ITS OWN PROSE IS
-│                   │                                #   DERIVED and asserted — the ten shapes, the eighteen call sites, 60/22/82 — and each
+│                   │                                #   population, modules/ alone holding 61 of the 83. EVERY FIGURE IN ITS OWN PROSE IS
+│                   │                                #   DERIVED and asserted — the ten shapes, the nineteen call sites, 61/22/83 — and each
 │                   │                                #   enumerated shape must have a fixture that writes it, so a shape added to the prose
 │                   │                                #   without a control goes red rather than reading as covered
 │                   ├── test_content_store.py        # PMP Phase 2 r7(b)/r7(d) — the on-disk path is a function of the COMPUTED DIGEST and

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -297,6 +297,17 @@ claude-dot-files/
 │           │                                        #   registered by open_run_bag rather than threaded through forty signatures, and that trade is
 │           │                                        #   stated at register_emitter — an optional emit is a skipped emit. It reaches FLEET-CODE
 │           │                                        #   writes only; the model-issued half is Phase 10's post-exit harvest
+│           ├── modules/__init__.py                  # The package marker, and nothing else — every module under modules/ is
+│           │                                        #   imported by its own path, so this file exports nothing and re-exports nothing
+│           ├── modules/vocabulary.py                # ONE DECLARATION per concept the typed exit record and the journal event share
+│           │                                        #   (PMP Phase 3 r3) — Outcome, HoldKind, Disposition, TerminalState, plus
+│           │                                        #   SHARED_CONCEPTS, which a conformance test walks rather than re-typing. A LEAF AT
+│           │                                        #   modules/ belonging to NEITHER package, and that is the whole placement argument:
+│           │                                        #   modules/journal/ may import no workflow module (Phase 6's reader would otherwise
+│           │                                        #   drag in temporalio) and exit_record.py is dependency-free by design, so beside
+│           │                                        #   either one it would break the other. Two contracts, one spelling — two enums
+│           │                                        #   spelled alike compare UNEQUAL member-to-member while both still serialise to the
+│           │                                        #   same string, so a rebuild diffing them reports a difference that is not one
 │           ├── scripts/                             # Kickoff entrypoints, until an SDK path replaces them — plus preflight.py,
 │           │                                        #   validate_bag.py, verify_citations.py, compare_run_config.py, dispatch_identity.py
 │           │                                        #   and dispatch_context.py,
@@ -827,6 +838,15 @@ claude-dot-files/
 │                   │                                #   non-zero examined count, because a walk that scoped itself wrongly reports a clean sweep over
 │                   │                                #   nothing. The discriminators are the point: a gh READ must not emit, and the case-(d) report
 │                   │                                #   must not emit while an ORDINARY comment must — the exception is narrow or it is a hole
+│                   ├── test_shared_vocabulary_is_declared_once.py # PMP Phase 3 r3 as a test, and it exists because
+│                   │                                #   vocabulary.py CITED it while it did not — the module whose whole job is one spelling was
+│                   │                                #   held by prose, and SHARED_CONCEPTS was imported by nothing. Identity, never value: two
+│                   │                                #   enums spelled alike compare UNEQUAL member-to-member while every string test keeps
+│                   │                                #   passing, so a value assertion goes green on exactly the drift this catches. Walks
+│                   │                                #   SHARED_CONCEPTS rather than re-typing it, asks the SYNTAX TREE whether either contract
+│                   │                                #   re-declares a concept (an import binds the same name, so hasattr cannot tell), and binds
+│                   │                                #   the third consumer — convergence.py's open/closed partition, where an unlisted
+│                   │                                #   disposition silently counts as OPEN and the loop never converges
 │                   ├── test_dispatch_context.py     # The run context's behaviour: the worktree name follows the workflow key (every key,
 │                   │                                #   because the drift was in a single runner), the object is frozen, the echo is gated on
 │                   │                                #   `is_the_run` rather than on `minted` — a retry supplies its name and is exactly the

--- a/docs/file_structure.txt
+++ b/docs/file_structure.txt
@@ -874,14 +874,14 @@ claude-dot-files/
 │                   │                                #   and no store function at all, so an import-only check is blind to every one.
 │                   │                                #   Families 1 and 2 each hold a fleet idiom, which is what makes them likely rather
 │                   │                                #   than exotic: a journal submodule bound as a name (journal_activities as journal in
-│                   │                                #   every entrypoint, verify and validate in the two operator tools, emit in
-│                   │                                #   assistant_activities — nineteen call
+│                   │                                #   every entrypoint, verify and validate in the two operator tools, emit in the four
+│                   │                                #   PMP-Phase-3 write paths — twenty-two call
 │                   │                                #   sites, and content_store is not among them) and from .. import journal, the workflow
 │                   │                                #   tree's dominant relative import. The package matcher binds by import SEMANTICS,
 │                   │                                #   never by the identifier text `journal`: `alias.name` is matched and never the asname,
 │                   │                                #   BOUNDARY_PARENT rejects a `journal` imported from a sibling, and an asname binds
 │                   │                                #   exactly the module named, so import modules.assistant as ma reaches nothing. The
-│                   │                                #   nineteen call sites trip the first two at once, so neither can be observed through
+│                   │                                #   the twenty-two call sites trip the first two at once, so neither can be observed through
 │                   │                                #   them and neither costs a false positive — measured, deleting either flags nothing on
 │                   │                                #   a clean tree, because those call sites reach only open_run_bag and the emit
 │                   │                                #   boundary. Both are therefore
@@ -896,7 +896,7 @@ claude-dot-files/
 │                   │                                #   asserts a floor PER swept directory after a mutation showed a single total floor
 │                   │                                #   of fifty stayed green with all 22 modules under scripts/ dropped from the
 │                   │                                #   population, modules/ alone holding 61 of the 83. EVERY FIGURE IN ITS OWN PROSE IS
-│                   │                                #   DERIVED and asserted — the ten shapes, the nineteen call sites, 61/22/83 — and each
+│                   │                                #   DERIVED and asserted — the ten shapes, the twenty-two call sites, 61/22/83 — and each
 │                   │                                #   enumerated shape must have a fixture that writes it, so a shape added to the prose
 │                   │                                #   without a control goes red rather than reading as covered
 │                   ├── test_content_store.py        # PMP Phase 2 r7(b)/r7(d) — the on-disk path is a function of the COMPUTED DIGEST and

--- a/scripts/helpers/measure/run_log.py
+++ b/scripts/helpers/measure/run_log.py
@@ -53,8 +53,10 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 # --- the surface -------------------------------------------------------------
 
 # THE MEMBER SET. Adding a fourth event type means adding it here, and
-# `test_run_log_surface.py` fails in BOTH directions — an undeclared writer, and
-# a declared type nobody writes.
+# `test_run_log.py` fails in BOTH directions — an undeclared writer, and a
+# declared type nobody writes. (This line named a surface-suffixed module that
+# has never existed in this tree; the assertions are in `test_run_log.py`, which
+# reads `MEMBER_EVENT_TYPES` at three sites.)
 MEMBER_EVENT_TYPES = frozenset({"parent_route", "run_resources", "convergence"})
 
 # THE JOIN KEY. All three members carry it. Its VALUE was out of conformance

--- a/scripts/helpers/tests/unit/test_sibling_checkouts.py
+++ b/scripts/helpers/tests/unit/test_sibling_checkouts.py
@@ -30,6 +30,16 @@ def _repo(root: Path, name: str) -> Path:
     subprocess.run(["git", "init", "-q", "--bare", "-b", "main", str(origin)], check=True)
     d = root / name
     subprocess.run(["git", "clone", "-q", str(origin), str(d)], check=True)
+    # ⚠ THE LOCAL BRANCH IS NAMED EXPLICITLY, BECAUSE `init.defaultBranch` IS A
+    # PROPERTY OF THE MACHINE. Cloning an empty bare repo leaves an unborn
+    # branch named by the host's git config — `main` on a workstation that sets
+    # it, `master` on a stock GitHub runner. This fixture then pushed `HEAD:main`
+    # and set origin's head to `main`, so on the runner the checkout WAS off its
+    # default branch and the sweep correctly reported it: `test_a_CLEAN_
+    # WORKSPACE_PASSES` failed on every CI run while passing locally. The test
+    # was asserting a fact about the author's git config.
+    subprocess.run(["git", "-C", str(d), "symbolic-ref", "HEAD",
+                    "refs/heads/main"], check=True)
     subprocess.run(["git", "-C", str(d), "config", "user.email", "t@t"], check=True)
     subprocess.run(["git", "-C", str(d), "config", "user.name", "t"], check=True)
     (d / "f.txt").write_text("x\n", encoding="utf-8")

--- a/scripts/workflows/temporal/modules/assistant/assistant_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/assistant_activities.py
@@ -1330,8 +1330,8 @@ class _GhWriteFailed(RuntimeError):
         self.result = result
 
 
-def gh_attempt(args: list[str],
-               repo_root: Path | None) -> subprocess.CompletedProcess:
+def gh_attempt(args: list[str], repo_root: Path | None, *,
+               case_d_report: bool = False) -> subprocess.CompletedProcess:
     """`gh`, retried past transient server-side failures, returned UNJUDGED.
 
     THIS FUNCTION NEVER RAISES ON A NON-ZERO EXIT, and that is the whole reason
@@ -1365,19 +1365,28 @@ def gh_attempt(args: list[str],
     what failed, how it was classified, and how long the pause is; a run that
     eventually succeeded prints which attempt did it. Silent retries are how
     nobody ever learns whether the answer to "is it GitHub or us?" is on record.
+
+    ⚠ `case_d_report=True` IS THE ONE STORE WRITE PERMITTED WITH NO PRECEDING
+    EMIT — the phase doc's requirement 4 case (d), stated as an exception because
+    case (b) and requirement 1 otherwise cancel each other. That write IS the
+    durable report that the journal is unwritable, so requiring an intent to land
+    first would make this component's own ordering rule suppress the only durable
+    signal that the component is broken. It is the invariant's boundary
+    condition, not a hole in it.
+
+    ⚠ AND IT IS A FLAG THE CALLER SETS, NEVER A SHAPE READ OFF THE CONTENT. The
+    first implementation gated the exception on
+    `unwritable_journal_in_text(content)` — a substring test against the body
+    being published. Every `gh` mutation whose text happened to contain the
+    marker therefore skipped the journal entirely, with no error and no record:
+    a run quoting a previous failure, a bug report describing this component, or
+    a review comment naming the marker. A bypass of a completeness control must
+    be asserted by the code that knows it is the exception, not inferred from
+    attacker- or author-supplied bytes.
     """
     emitter = journal_emit.current_emitter()
-    if emitter is not None and not _gh_is_read_only(args):
+    if emitter is not None and not case_d_report and not _gh_is_read_only(args):
         content = _gh_authored_content(args, repo_root)
-        # ⚠ THE ONE STORE WRITE PERMITTED WITH NO PRECEDING EMIT — the phase
-        # doc's requirement 4 case (d), stated as an exception because case (b)
-        # and requirement 1 otherwise cancel each other. This IS the durable
-        # report that the journal is unwritable, so requiring an intent to land
-        # first would make this component's own ordering rule suppress the only
-        # durable signal that the component is broken. It is the invariant's
-        # boundary condition, not a hole in it.
-        if journal_emit.unwritable_journal_in_text(content):
-            return _gh_attempt_unwrapped(args, repo_root)
         try:
             return emitter.paired_write(
                 write_path=_gh_write_path(args),

--- a/scripts/workflows/temporal/modules/assistant/assistant_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/assistant_activities.py
@@ -24,6 +24,8 @@ from pathlib import Path
 
 from . import resource_telemetry
 from . import routing
+from ..journal import emit as journal_emit
+from ..journal.events import Destination, Provenance
 
 _WORKFLOWS = Path(__file__).resolve().parents[3]          # scripts/workflows
 _SHARED_PROMPTS = Path(__file__).resolve().parent / "prompts"
@@ -1252,6 +1254,82 @@ def _gh_timed_out_line(label: str, spent: int, attempts: int,
     return line
 
 
+#: The noun/verb pairs whose authored CONTENT this fleet emits. Every `gh`
+#: mutation is emitted; this table is only about which ones carry prose worth
+#: recording verbatim, and it exists so a new mutation verb defaults to being
+#: emitted rather than to being forgotten.
+_GH_AUTHORED_FLAGS = ("--body-file", "--body", "--comment", "--title")
+
+
+def _gh_write_path(args: list[str]) -> str:
+    """A stable name for one `gh` mutation, as `gh:<noun>:<verb>`.
+
+    THE SAME POSITIONAL READ `_gh_is_read_only` USES, and deliberately so: two
+    different parses of one argument list would let a call be classified a write
+    by one and named by the other, which is how a write path gets an emit under a
+    name nothing can join on. The imprecision is identical and runs the same
+    direction — an unparsed shape yields a vaguer name, never a missing emit.
+    """
+    verbs = [a for a in args if not a.startswith("-")]
+    noun = verbs[0] if verbs else "?"
+    verb = verbs[1] if len(verbs) >= 2 else "?"
+    return f"gh:{noun}:{verb}"
+
+
+def _gh_authored_content(args: list[str], repo_root: Path | None) -> str:
+    """The prose this invocation is about to publish, verbatim.
+
+    READ FROM `--body-file` RATHER THAN LEFT AS A PATH, because the phase's rule
+    is *the authored content, VERBATIM*, and a path is a pointer to bytes that
+    live outside the journal — the exact thing `payload_symlinks` exists to
+    report as uncovered. This fleet's own guidance tells every workflow to write
+    a comment to a temp file and pass `--body-file`, so a path-only record would
+    make the record empty for the majority of what a run authors.
+
+    ⚠ A `--body-file` THAT CANNOT BE READ YIELDS A NAMED PLACEHOLDER, NOT A
+    RAISE. This runs before the store write, so raising here would turn an
+    unreadable temp file into a stopped run — converting a recording problem into
+    a work-stopping one on the path whose whole job is to record. The placeholder
+    is distinguishable from an empty body, which is what a reader needs.
+
+    IT DOES NOT REACH A BODY ON STDIN. `gh` accepts `--body-file -`, and nothing
+    in this fleet uses it; a run that did would emit the placeholder rather than
+    the content, which is visible in the record rather than silent.
+    """
+    parts: list[str] = []
+    for index, token in enumerate(args):
+        if token not in _GH_AUTHORED_FLAGS or index + 1 >= len(args):
+            continue
+        value = args[index + 1]
+        if token != "--body-file":
+            parts.append(value)
+            continue
+        path = Path(value)
+        if not path.is_absolute() and repo_root is not None:
+            path = repo_root / path
+        try:
+            parts.append(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError) as exc:
+            parts.append(f"[BODY-FILE UNREADABLE: {value} — {type(exc).__name__}]")
+    return "\n".join(parts)
+
+
+class _GhWriteFailed(RuntimeError):
+    """A `gh` mutation exited non-zero, raised only so `paired_write` can see it.
+
+    `gh_attempt` RETURNS a failure rather than raising — two callers depend on
+    that and `test_gh_attempt_RETURNS_a_failure_rather_than_raising_it` pins it.
+    But `Emitter.paired_write` learns that a store write failed by catching an
+    exception, so the non-zero result is raised INSIDE the callable and the
+    result is carried on the exception for the caller to return unchanged. The
+    external contract is untouched; only the inside of one closure raises.
+    """
+
+    def __init__(self, result: subprocess.CompletedProcess) -> None:
+        super().__init__(f"gh exited {result.returncode}")
+        self.result = result
+
+
 def gh_attempt(args: list[str],
                repo_root: Path | None) -> subprocess.CompletedProcess:
     """`gh`, retried past transient server-side failures, returned UNJUDGED.
@@ -1287,6 +1365,69 @@ def gh_attempt(args: list[str],
     what failed, how it was classified, and how long the pause is; a run that
     eventually succeeded prints which attempt did it. Silent retries are how
     nobody ever learns whether the answer to "is it GitHub or us?" is on record.
+    """
+    emitter = journal_emit.current_emitter()
+    if emitter is not None and not _gh_is_read_only(args):
+        content = _gh_authored_content(args, repo_root)
+        # ⚠ THE ONE STORE WRITE PERMITTED WITH NO PRECEDING EMIT — the phase
+        # doc's requirement 4 case (d), stated as an exception because case (b)
+        # and requirement 1 otherwise cancel each other. This IS the durable
+        # report that the journal is unwritable, so requiring an intent to land
+        # first would make this component's own ordering rule suppress the only
+        # durable signal that the component is broken. It is the invariant's
+        # boundary condition, not a hole in it.
+        if journal_emit.unwritable_journal_in_text(content):
+            return _gh_attempt_unwrapped(args, repo_root)
+        try:
+            return emitter.paired_write(
+                write_path=_gh_write_path(args),
+                destination=Destination(store="github"),
+                content=content,
+                provenance=Provenance.FLEET_AUTHORED,
+                perform=lambda: _gh_raise_on_failure(
+                    _gh_attempt_unwrapped(args, repo_root)),
+                # THE STORE-ASSIGNED ADDRESS, which does not exist until the
+                # object does — the third thing one event per write cannot
+                # carry. `gh` prints the created object's URL on stdout for
+                # `pr create`, `issue create` and `pr comment`; a verb that
+                # prints nothing yields an empty address, which is honest
+                # rather than invented.
+                address_of=lambda r: r.stdout.strip().splitlines()[-1]
+                if r.stdout.strip() else "")
+        except journal_emit.StoreWriteFailed as recorded:
+            # ⚠ THE EXTERNAL CONTRACT IS UNCHANGED: this function RETURNS a
+            # failed `gh` rather than raising it, and two callers depend on that
+            # (`gh issue list` degrading to a note, and `ci_verdict` classifying
+            # by parsing a non-zero `gh pr checks`). The raise exists only so
+            # `paired_write` can see the store write fail and record a
+            # `store_write_failure` event — which it has now done — so the
+            # result is unwrapped and returned exactly as before.
+            cause = recorded.__cause__
+            if isinstance(cause, _GhWriteFailed):
+                return cause.result
+            raise
+    return _gh_attempt_unwrapped(args, repo_root)
+
+
+def _gh_raise_on_failure(
+        result: subprocess.CompletedProcess) -> subprocess.CompletedProcess:
+    """Turn a non-zero `gh` into the exception `paired_write` reads as a failure."""
+    if result.returncode != 0:
+        raise _GhWriteFailed(result)
+    return result
+
+
+def _gh_attempt_unwrapped(args: list[str],
+                          repo_root: Path | None) -> subprocess.CompletedProcess:
+    """`gh_attempt`'s retry loop, with no journal emit around it.
+
+    SPLIT OUT SO THE EMIT IS A WRAPPER RATHER THAN A BRANCH INSIDE THE LOOP. The
+    retry loop already has three exits and adding an emit to each is how one of
+    them ends up without it — which is precisely the write path with no emit that
+    requirement 1 exists to forbid. Wrapping means every exit is covered by
+    construction, and it means the intent is written once per CALL rather than
+    once per ATTEMPT: a transient 503 retried three times is one write of one
+    comment, and three intents for it would be three rows in a Phase 4 rebuild.
     """
     label = _one_line(" ".join(args))
     attempts = len(_GH_RETRY_BACKOFF_SECONDS) + 1

--- a/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
+++ b/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
@@ -58,6 +58,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from ...journal import emit as journal_emit
+from ...journal.events import Destination, Provenance
 from .. import routing
 from ..assistant_activities import ci_verdict
 from ..review_pr import review_pr_activities as review_act
@@ -181,11 +183,50 @@ def merge_one(pr: str, repo_root: Path, *, dry_run: bool = False) -> str | None:
     """
     if dry_run:
         return None
-    try:
+
+    # PMP PHASE 3: A MERGE IS A STORE WRITE AND IT EMITS LIKE EVERY OTHER ONE.
+    # This call site does NOT go through `assistant_activities.gh_attempt` — it
+    # cannot, because that function retries and a merge must never be retried —
+    # so the emit is applied here rather than inherited. That divergence is
+    # exactly why requirement 9's inventory enumerates call sites rather than
+    # trusting one choke point: a path that had a good reason to bypass the choke
+    # point is a path with no emit, and nothing goes red.
+    #
+    # THE CONTENT IS THE INVOCATION, NOT PROSE. A merge authors nothing; what the
+    # record needs is WHICH PR was merged, under which options, by which run. An
+    # empty `content` would make the event indistinguishable from a write whose
+    # body could not be read.
+    def _merge() -> None:
         subprocess.run(["gh", "pr", "merge", pr, "--squash", "--delete-branch"],
                        cwd=repo_root, capture_output=True, text=True,
                        check=True, timeout=300)
+
+    emitter = journal_emit.current_emitter()
+    try:
+        if emitter is None:
+            _merge()
+        else:
+            emitter.paired_write(
+                write_path="gh:pr:merge",
+                destination=Destination(store="github"),
+                content=f"gh pr merge {pr} --squash --delete-branch",
+                provenance=Provenance.FLEET_AUTHORED,
+                perform=_merge)
         return None
+    except journal_emit.StoreWriteFailed as recorded:
+        # The `store_write_failure` event is already appended; the ORIGINAL `gh`
+        # failure is what the two handlers below are written against, so it is
+        # re-raised into them rather than replaced by the wrapper's own class.
+        cause = recorded.__cause__
+        if isinstance(cause, BaseException):
+            exc = cause
+        else:                                   # pragma: no cover - unreachable
+            raise
+        if isinstance(exc, subprocess.CalledProcessError):
+            return _merge_outcome_after_failure(exc, pr, repo_root)
+        if isinstance(exc, (subprocess.SubprocessError, OSError)):
+            return str(exc)
+        raise
     except subprocess.CalledProcessError as exc:
         # THE EXIT CODE COVERS THE CLEANUP TOO, AND THE CLEANUP IS NOT THE MERGE.
         # `--delete-branch` fails when the branch is checked out in a worktree —
@@ -194,13 +235,25 @@ def merge_one(pr: str, repo_root: Path, *, dry_run: bool = False) -> str | None:
         # MERGED and this reported "merge failed: failed to delete local branch".
         # A tool that says a completed merge failed is worse than one that says
         # nothing, so the OUTCOME is asked rather than the exit code trusted.
-        detail = (exc.stderr or exc.stdout or "gh pr merge failed").strip()
-        view = _gh_json(["pr", "view", pr, "--json", "state"], repo_root)
-        if view is not None and view.get("state") == "MERGED":
-            return None                      # merged; only the cleanup failed
-        return detail
+        return _merge_outcome_after_failure(exc, pr, repo_root)
     except (subprocess.SubprocessError, OSError) as exc:
         return str(exc)
+
+
+def _merge_outcome_after_failure(exc: subprocess.CalledProcessError, pr: str,
+                                 repo_root: Path) -> str | None:
+    """ONE definition of "did it actually merge?", called from two handlers.
+
+    Split out when the emit wrapper gave this question a second caller. Two
+    copies of it would drift, and the direction they would drift in is the one
+    the comment inside it is about: a tool that reports a completed merge as
+    failed is worse than one that says nothing.
+    """
+    detail = (exc.stderr or exc.stdout or "gh pr merge failed").strip()
+    view = _gh_json(["pr", "view", pr, "--json", "state"], repo_root)
+    if view is not None and view.get("state") == "MERGED":
+        return None                          # merged; only the cleanup failed
+    return detail
 
 
 def run_merge(prs: list[str], repo_root: Path, *, stores_root: Path | None = None,

--- a/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
+++ b/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from ...journal import emit as journal_emit
 from ...journal.events import Destination, Provenance
 from .. import routing
+from .. import assistant_activities as act
 from ..assistant_activities import ci_verdict
 from ..review_pr import review_pr_activities as review_act
 from ..review_pr import review_pr_helper as review_helper
@@ -103,16 +104,41 @@ class _MergeRefused(RuntimeError):
 
     So the outcome is resolved BEFORE `perform` returns or raises, and this class
     is how the resolved detail reaches the caller without being re-derived: one
-    `gh pr view`, one answer, carried rather than recomputed.
+    bounded `gh pr view` re-ask, one answer, carried rather than recomputed.
+
+    ⚠ AND THE ANSWER MAY BE "UNREAD", WHICH IS NOT "NOT MERGED". A detail
+    carrying `UNRESOLVED_MERGE_PREFIX` means the verdict was never read; the run
+    still fails toward "did not merge", and the operator is told to look.
     """
 
 
 def _gh_json(args: list[str], repo_root: Path) -> dict | None:
-    """A `gh` read, or None when it could not be read. None is never 'fine'."""
+    """A `gh` read, or None when it could not be read. None is never 'fine'.
+
+    IT GOES THROUGH THE FLEET'S BOUNDED WRAPPER, AND IT WAS THE ONE `gh` READ
+    THAT DID NOT. `gh_attempt` retries a transient server-side failure on a
+    read-only verb and refuses to retry anything else; this function used to
+    call `subprocess.run` directly, so a 503 or a throttle on either of its two
+    callers was one attempt and then a `None`. Measured over `modules/`: this
+    was the only such read — the other direct launch is the merge itself, which
+    must NOT be retried because repeating it may act on a different state.
+
+    `gh pr view` is read-only, so `gh_attempt` neither retries a write nor emits
+    a journal event for one; the retries here are free of consequence.
+
+    ⚠ `None` IS NOT AN ANSWER, AND THE TWO CALLERS OWE IT OPPOSITE DIRECTIONS.
+    `pr_view` fails SAFE — an unreadable answer becomes a refusal to merge, which
+    costs a re-run. `_merge_state` does not, and `_merge_outcome_after_failure`
+    says so at length below. (`thread_verdict` above reaches `gh` through
+    `review_act.pr_review_blocks` rather than through here, and fails safe on its
+    own; it is named because an earlier draft of this paragraph counted it as a
+    caller of this function, which it has never been.)
+    """
     try:
-        out = subprocess.run(["gh", *args], cwd=repo_root, capture_output=True,
-                             text=True, check=True, timeout=120).stdout
-        parsed = json.loads(out)
+        result = act.gh_attempt(list(args), repo_root)
+        if result.returncode != 0:
+            return None
+        parsed = json.loads(result.stdout)
         return parsed if isinstance(parsed, dict) else None
     except (subprocess.SubprocessError, OSError, json.JSONDecodeError):
         return None
@@ -182,6 +208,33 @@ def refusals(pr: str, repo_root: Path) -> list[str]:
 #: for the states that are real.
 UNKNOWN_RETRIES = 3
 UNKNOWN_WAIT_SECONDS = 2.0
+
+#: How many times to re-ask "did it actually merge?" when the answer cannot be
+#: READ, and how long to wait. SEPARATE FROM `UNKNOWN_RETRIES` ABOVE BECAUSE IT
+#: ANSWERS A DIFFERENT QUESTION: that one re-asks a field GitHub has answered
+#: with `UNKNOWN`, this one re-asks a call that did not answer at all.
+#:
+#: `gh_attempt` retries a transient failure that names an HTTP status, and it
+#: deliberately treats a status-less one as terminal — a timeout and a transport
+#: error both present with no status and are both left un-retried there. Those
+#: are exactly the shapes a network blip produces, so the read that decides a
+#: PERMANENT journal record gets its own bounded re-ask on top.
+#:
+#: THE TWO COMPOSE, AND THE WORST CASE IS STATED RATHER THAN LEFT TO BE
+#: DISCOVERED. A persistently 503-ing read costs `gh_attempt`'s attempts inside
+#: each of these, so at most 3 x (1 + len(_GH_RETRY_BACKOFF_SECONDS)) `gh pr view`
+#: invocations and the sum of both backoffs before the outcome is called unread.
+#: That is bounded, it happens only after a merge has already failed, and the
+#: alternative — one attempt — is what journaled a landed merge as a failure.
+OUTCOME_RETRIES = 3
+OUTCOME_WAIT_SECONDS = 2.0
+
+#: The prefix an operator-facing detail carries when the merge verdict was never
+#: READ. It is not decoration: the string it replaces was `gh pr merge`'s own
+#: stderr, which describes the CLEANUP that failed and says nothing about whether
+#: the merge landed. Presenting it as the verdict is how "the branch could not be
+#: deleted" reads as "the PR did not merge".
+UNRESOLVED_MERGE_PREFIX = "MERGE OUTCOME UNREAD"
 
 
 def pr_view(pr: str, repo_root: Path) -> dict | None:
@@ -273,7 +326,8 @@ def merge_one(pr: str, repo_root: Path, *, dry_run: bool = False) -> str | None:
     except _MergeRefused as exc:
         # The emitter was absent, so `_merge` was called directly. Same answer:
         # the outcome was resolved inside it and the detail is carried, not
-        # recomputed — one `gh pr view` per failed merge, on either path.
+        # recomputed — one bounded `gh pr view` re-ask per failed merge, on
+        # either path.
         return str(exc)
     except (subprocess.SubprocessError, OSError) as exc:
         return str(exc)
@@ -291,12 +345,63 @@ def _merge_outcome_after_failure(exc: subprocess.CalledProcessError, pr: str,
 
     `None` means MERGED. A returned string is the operator-facing detail, and the
     caller carries it out on `_MergeRefused` rather than re-deriving it.
+
+    ⚠ THREE OUTCOMES, NOT TWO, AND COLLAPSING THE THIRD INTO "NOT MERGED" IS THE
+    DEFECT THIS PARAGRAPH EXISTS FOR. The read can say MERGED, say something
+    else, or FAIL — and a failed read used to return `detail`, which is
+    `gh pr merge`'s own stderr. On this path that stderr is almost always
+    `failed to delete local branch`: a sentence about the CLEANUP, presented as
+    the merge verdict, on the one path where the verdict decides a permanent
+    append-only record. One transient `gh` failure on the read was therefore
+    enough to journal a merge that LANDED as a `store_write_failure` — the exact
+    outcome moving this question inside `perform` exists to prevent, surviving on
+    the path that move created.
     """
     detail = (exc.stderr or exc.stdout or "gh pr merge failed").strip()
-    view = _gh_json(["pr", "view", pr, "--json", "state"], repo_root)
-    if view is not None and view.get("state") == "MERGED":
+    state = _merge_state(pr, repo_root)
+    if state == "MERGED":
         return None                          # merged; only the cleanup failed
+    if state is None:
+        # UNREAD, AND SAID SO. The direction is still "did not merge" — that is
+        # the fail-safe half of this module's thesis and it does not change here
+        # — but the DETAIL must not claim a verdict nobody read. An operator
+        # seeing this line has one job: look at the PR, because if it merged, the
+        # journal now carries a `store_write_failure` for a write that landed and
+        # the journal is append-only.
+        return (f"{UNRESOLVED_MERGE_PREFIX}: `gh pr merge` exited non-zero and "
+                f"`gh pr view {pr} --json state` did not return a readable "
+                f"`state` in {OUTCOME_RETRIES} attempts, so whether PR {pr} "
+                f"merged is UNKNOWN and is being recorded as NOT MERGED. Check "
+                f"the PR by hand. `gh pr merge` said: {detail}")
     return detail
+
+
+def _merge_state(pr: str, repo_root: Path) -> str | None:
+    """The PR's `state`, re-asking a read that did not answer. `None` means UNREAD.
+
+    `None` IS NOT `"OPEN"`, and the whole value of this function is keeping those
+    two apart for its caller. `_gh_json` returns `None` for an unreadable answer
+    and a readable `{"state": "OPEN"}` is a different fact — the first says the
+    question was not answered, the second answers it.
+
+    A REPLY THAT PARSES BUT CARRIES NO `state` IS ALSO UNREAD, and it is folded
+    in here rather than left to the caller: `{}` decodes cleanly, and
+    `view.get("state")` on it returns the same `None` an unreadable call does. A
+    caller that read those two as one fact would report "could not be read" for
+    a shape defect, or worse, read a missing field as an answer.
+
+    BOUNDED, AND EXHAUSTING THE RE-ASKS IS NOT THE SAME AS THE PR BEING OPEN. The
+    caller must still say the outcome was unread, which is what
+    `UNRESOLVED_MERGE_PREFIX` is for.
+    """
+    for attempt in range(OUTCOME_RETRIES):
+        view = _gh_json(["pr", "view", pr, "--json", "state"], repo_root)
+        state = view.get("state") if view is not None else None
+        if isinstance(state, str) and state:
+            return state
+        if attempt < OUTCOME_RETRIES - 1:
+            time.sleep(OUTCOME_WAIT_SECONDS)
+    return None
 
 
 def run_merge(prs: list[str], repo_root: Path, *, stores_root: Path | None = None,

--- a/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
+++ b/scripts/workflows/temporal/modules/assistant/merge/merge_pr.py
@@ -81,6 +81,32 @@ class MergeReport:
         return not self.refused and self.drain_error is None
 
 
+class _MergeRefused(RuntimeError):
+    """`gh pr merge` failed AND the PR is not merged — the store write truly failed.
+
+    RAISED FROM INSIDE `perform`, WHICH IS THE WHOLE POINT. `gh pr merge --squash
+    --delete-branch` is ONE process whose exit code covers the merge AND the
+    cleanup, and the cleanup fails routinely here — `--delete-branch` cannot
+    remove a branch checked out in a worktree, and this fleet dispatches from
+    `.claude/worktrees/`. Measured on the first real invocation: PR #166 MERGED
+    and `gh` exited non-zero.
+
+    Before PMP Phase 3 that only cost a wrong console message, which
+    `_merge_outcome_after_failure` already corrected in a handler. With the emit
+    wired, correcting it in a handler is TOO LATE: `paired_write` sees `perform`
+    raise, appends a `store_write_failure` event, and the journal is append-only —
+    so a merge that LANDED is recorded, permanently and uncorrectably, as a write
+    that did not. `applied_intents` then declines that intent forever, and a Phase
+    4 rebuild concludes the merge never happened while the run's own report says
+    it did. The record exists to be trusted over the report, so it is the record
+    that has to be right.
+
+    So the outcome is resolved BEFORE `perform` returns or raises, and this class
+    is how the resolved detail reaches the caller without being re-derived: one
+    `gh pr view`, one answer, carried rather than recomputed.
+    """
+
+
 def _gh_json(args: list[str], repo_root: Path) -> dict | None:
     """A `gh` read, or None when it could not be read. None is never 'fine'."""
     try:
@@ -197,9 +223,27 @@ def merge_one(pr: str, repo_root: Path, *, dry_run: bool = False) -> str | None:
     # empty `content` would make the event indistinguishable from a write whose
     # body could not be read.
     def _merge() -> None:
-        subprocess.run(["gh", "pr", "merge", pr, "--squash", "--delete-branch"],
-                       cwd=repo_root, capture_output=True, text=True,
-                       check=True, timeout=300)
+        # ⚠ THE EXIT CODE COVERS THE CLEANUP TOO, AND THE CLEANUP IS NOT THE
+        # MERGE — so this callable asks the OUTCOME before it returns or raises,
+        # rather than letting a handler correct it afterwards. `--delete-branch`
+        # fails when the branch is checked out in a worktree, which it always is
+        # here; measured on PR #166, which MERGED while `gh` exited non-zero.
+        #
+        # THE PLACEMENT IS THE FIX AND NOT A STYLE CHOICE. `paired_write` writes
+        # the journal from whether `perform` raises, and the journal is
+        # append-only — so resolving this one handler-frame later records a
+        # completed merge as a `store_write_failure` that can never be corrected,
+        # and `applied_intents` declines it forever.
+        try:
+            subprocess.run(["gh", "pr", "merge", pr, "--squash",
+                            "--delete-branch"],
+                           cwd=repo_root, capture_output=True, text=True,
+                           check=True, timeout=300)
+        except subprocess.CalledProcessError as exc:
+            detail = _merge_outcome_after_failure(exc, pr, repo_root)
+            if detail is None:
+                return          # MERGED; only `--delete-branch` failed
+            raise _MergeRefused(detail) from exc
 
     emitter = journal_emit.current_emitter()
     try:
@@ -214,40 +258,39 @@ def merge_one(pr: str, repo_root: Path, *, dry_run: bool = False) -> str | None:
                 perform=_merge)
         return None
     except journal_emit.StoreWriteFailed as recorded:
-        # The `store_write_failure` event is already appended; the ORIGINAL `gh`
-        # failure is what the two handlers below are written against, so it is
-        # re-raised into them rather than replaced by the wrapper's own class.
+        # The `store_write_failure` event is already appended, and by the time we
+        # are here that is the RIGHT record: `_merge` returned normally for every
+        # case where the PR actually merged, so a raise reaching this point means
+        # the merge did not land. The ORIGINAL failure is what the branches below
+        # are written against, so it is unwrapped rather than replaced by the
+        # emit wrapper's own class.
         cause = recorded.__cause__
-        if isinstance(cause, BaseException):
-            exc = cause
-        else:                                   # pragma: no cover - unreachable
-            raise
-        if isinstance(exc, subprocess.CalledProcessError):
-            return _merge_outcome_after_failure(exc, pr, repo_root)
-        if isinstance(exc, (subprocess.SubprocessError, OSError)):
-            return str(exc)
+        if isinstance(cause, _MergeRefused):
+            return str(cause)
+        if isinstance(cause, (subprocess.SubprocessError, OSError)):
+            return str(cause)
         raise
-    except subprocess.CalledProcessError as exc:
-        # THE EXIT CODE COVERS THE CLEANUP TOO, AND THE CLEANUP IS NOT THE MERGE.
-        # `--delete-branch` fails when the branch is checked out in a worktree —
-        # which it always is, because this fleet dispatches from
-        # `.claude/worktrees/`. Measured on the first real invocation: PR #166
-        # MERGED and this reported "merge failed: failed to delete local branch".
-        # A tool that says a completed merge failed is worse than one that says
-        # nothing, so the OUTCOME is asked rather than the exit code trusted.
-        return _merge_outcome_after_failure(exc, pr, repo_root)
+    except _MergeRefused as exc:
+        # The emitter was absent, so `_merge` was called directly. Same answer:
+        # the outcome was resolved inside it and the detail is carried, not
+        # recomputed — one `gh pr view` per failed merge, on either path.
+        return str(exc)
     except (subprocess.SubprocessError, OSError) as exc:
         return str(exc)
 
 
 def _merge_outcome_after_failure(exc: subprocess.CalledProcessError, pr: str,
                                  repo_root: Path) -> str | None:
-    """ONE definition of "did it actually merge?", called from two handlers.
+    """ONE definition of "did it actually merge?", asked INSIDE `perform`.
 
-    Split out when the emit wrapper gave this question a second caller. Two
-    copies of it would drift, and the direction they would drift in is the one
-    the comment inside it is about: a tool that reports a completed merge as
-    failed is worse than one that says nothing.
+    It was split out when the emit wrapper gave the question a second caller, and
+    it now has one again — because the answer moved to the only place it can be
+    correct. Asked from a handler, it corrects the console message after the
+    journal has already recorded the opposite; asked from inside `perform`, the
+    journal and the report are derived from one answer and cannot disagree.
+
+    `None` means MERGED. A returned string is the operator-facing detail, and the
+    caller carries it out on `_MergeRefused` rather than re-deriving it.
     """
     detail = (exc.stderr or exc.stdout or "gh pr merge failed").strip()
     view = _gh_json(["pr", "view", pr, "--json", "state"], repo_root)

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_activities.py
@@ -52,6 +52,8 @@ import re
 from pathlib import Path
 from typing import NamedTuple
 
+from ....journal import emit as journal_emit
+from ....journal.events import Destination, Provenance
 from .. import plan_activities as act
 
 # Strips the leading marker so a section name is just its name.
@@ -377,10 +379,46 @@ def scaffold_candidate_components(worktree: Path, candidates_path: Path) -> Scaf
         # a narrow locale fails before anything exists; a write that fails leaves
         # the directory `mkdir` just made, half-built and indistinguishable from
         # a component somebody is working on.
-        (pool / "synthesis.md").write_text(_seed(row, slug), encoding="utf-8")
+        _write_seed(pool / "synthesis.md", _seed(row, slug))
         result.created.append(slug)
 
     return result
+
+
+def _write_seed(path: Path, text: str) -> None:
+    """Seed one research pool, emitting the intent before the file exists.
+
+    PMP PHASE 3 REQUIREMENT 1: this is a fleet-code write to a store — the
+    planning corpus — so it emits. It is the only such write in the plan family
+    and it is easy to miss precisely because it does not look like one: no `gh`,
+    no `tracked/` item, just a `write_text` inside a loop. That is the class
+    requirement 9's enumeration exists to find, and Phase 4's rebuild test is
+    what keeps it found after this phase closes.
+
+    ⚠ THE DIRECTORY IS CREATED BEFORE THIS RUNS AND IS NOT WITHHELD BY A FAILED
+    EMIT, which is a real if small hole in write-ahead ordering, stated rather
+    than papered over. `pool.mkdir(parents=True)` happens above, so a journal
+    failure here leaves an empty directory the record does not mention. The
+    caller's own comment already names that half-built state as the failure it
+    cares about; moving the `mkdir` inside the emit would be the correct fix and
+    it changes this function's caller rather than this function, so it is left
+    for whoever next touches that loop rather than done blind here.
+    """
+    def _perform() -> Path:
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    emitter = journal_emit.current_emitter()
+    if emitter is None:
+        _perform()
+        return
+    emitter.paired_write(
+        write_path="planning:research-pool:seed",
+        destination=Destination(store="planning_corpus"),
+        content=text,
+        provenance=Provenance.FLEET_AUTHORED,
+        perform=_perform,
+        address_of=lambda written: str(written))
 
 
 def _is_unresearched(pool: Path) -> bool:

--- a/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_activities.py
+++ b/scripts/workflows/temporal/modules/assistant/plan/plan_project/plan_project_activities.py
@@ -373,12 +373,9 @@ def scaffold_candidate_components(worktree: Path, candidates_path: Path) -> Scaf
             else:
                 result.extends.append((row.id, slug))
             continue
-        pool.mkdir(parents=True)
-        # `encoding` explicitly: the seed carries em dashes, and this is the one
-        # place in the family that WRITES rather than reads. A read that fails on
-        # a narrow locale fails before anything exists; a write that fails leaves
-        # the directory `mkdir` just made, half-built and indistinguishable from
-        # a component somebody is working on.
+        # THE `mkdir` IS INSIDE THE EMIT, NOT ABOVE IT — see `_write_seed`. Run
+        # here, it produced a directory a failed journal write could not
+        # withhold, which is the half-built state the comment below is about.
         _write_seed(pool / "synthesis.md", _seed(row, slug))
         result.created.append(slug)
 
@@ -395,16 +392,19 @@ def _write_seed(path: Path, text: str) -> None:
     requirement 9's enumeration exists to find, and Phase 4's rebuild test is
     what keeps it found after this phase closes.
 
-    ⚠ THE DIRECTORY IS CREATED BEFORE THIS RUNS AND IS NOT WITHHELD BY A FAILED
-    EMIT, which is a real if small hole in write-ahead ordering, stated rather
-    than papered over. `pool.mkdir(parents=True)` happens above, so a journal
-    failure here leaves an empty directory the record does not mention. The
-    caller's own comment already names that half-built state as the failure it
-    cares about; moving the `mkdir` inside the emit would be the correct fix and
-    it changes this function's caller rather than this function, so it is left
-    for whoever next touches that loop rather than done blind here.
+    ⚠ THE DIRECTORY IS CREATED INSIDE `perform`, WHICH IS THE POINT. Created by
+    the caller, it was a write-ahead hole: a failed journal write left an empty
+    pool directory the record does not mention, half-built and
+    indistinguishable from a component somebody is working on — the caller's own
+    comment named that state as the failure it cares about. Inside `perform`,
+    nothing on disk moves unless the intent landed first.
+
+    `encoding` EXPLICITLY: the seed carries em dashes and this is the one place
+    in the plan family that WRITES rather than reads, so a narrow locale would
+    fail here rather than before anything existed.
     """
     def _perform() -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(text, encoding="utf-8")
         return path
 

--- a/scripts/workflows/temporal/modules/assistant/research/research_draft/research_draft_workflow.py
+++ b/scripts/workflows/temporal/modules/assistant/research/research_draft/research_draft_workflow.py
@@ -35,7 +35,7 @@ so a second cycle against the same pool leaves two papers with nothing
 rolling them up — and a planner told not to read raw papers wholesale reports "no
 synthesis" and plans from priors while both papers sit unread. The contract is
 `draft.md`'s sizing section, the work happens in its SYNTHESIZE stage, and
-`tests/unit/test_research_minor.py::test_the_minor_cycle_writes_a_SYNTHESIS` pins
+`tests/unit/test_research_draft.py::test_the_minor_cycle_writes_a_SYNTHESIS` pins
 it in the opposite direction from the bullet this replaced.
 
 WHAT IS DELIBERATELY PRESENT. Every §3 obligation that makes a paper

--- a/scripts/workflows/temporal/modules/assistant/review_pr/exit_record.py
+++ b/scripts/workflows/temporal/modules/assistant/review_pr/exit_record.py
@@ -47,6 +47,8 @@ import json
 from dataclasses import dataclass
 from enum import Enum
 
+from ... import vocabulary
+from ...vocabulary import HoldKind, Outcome
 from .. import routing
 
 __all__ = [
@@ -76,24 +78,14 @@ SUPPORTED_SCHEMA_VERSIONS = frozenset({"1"})
 SCHEMA_BYTE_BOUND = 4096
 
 
-class Outcome(str, Enum):
-    """What the CHILD asserts about the work. Never written by a parent."""
-
-    MERGE = "merge"
-    HOLD = "hold"
-
-
-class HoldKind(str, Enum):
-    """The sub-kind every parent branches on — `hold` alone does not route.
-
-    NEEDS_RULING is the ASSERTED abstention arm: the evaluation completed and
-    the answer is that a human must decide. It stays a model assertion by
-    construction — a predicate that could detect "this needs a human" would be
-    the ground truth it is asking for.
-    """
-
-    REDISPATCH = "redispatch"
-    NEEDS_RULING = "needs_ruling"
+# `Outcome` AND `HoldKind` ARE DECLARED IN `modules/vocabulary.py` AND IMPORTED
+# HERE, not re-declared. Persistent Memory Protocol Phase 3 r3: the journal event
+# is a SEPARATE contract from this record — `exit-protocol.md` §2 forbids a field
+# added for a consumer that does not exist and §2.5 bounds this record at 4096
+# bytes, and a journal event adds six such fields and carries content verbatim —
+# so the two cannot be one contract, and the only thing that keeps them from
+# drifting is that every concept they share is spelled once. Re-exported through
+# `__all__` below so every existing `exit_record.Outcome` caller is unchanged.
 
 
 class RoutedOutcome(str, Enum):
@@ -211,10 +203,18 @@ CHILD_SCHEMA: dict = {
                 "required": ["id", "disposition"],
                 "properties": {
                     "id": {"type": "string"},
+                    # DERIVED FROM `vocabulary.Disposition`, NEVER RE-TYPED.
+                    # This list and `convergence.py`'s open/closed partition are
+                    # the same vocabulary read by two consumers, and a journal
+                    # event replaying a finding row is now a third — so the
+                    # spelling is taken from the one declaration rather than
+                    # written out again. `sorted` for a stable schema string:
+                    # `schema_argument()` is bounded at `SCHEMA_BYTE_BOUND` and
+                    # an order that moved between runs would make that bound's
+                    # test depend on enum iteration order.
                     "disposition": {
                         "type": "string",
-                        "enum": ["hold", "fixed", "deferred", "rejected",
-                                 "noted", "escalated", "dissolved"],
+                        "enum": sorted(m.value for m in vocabulary.Disposition),
                     },
                 },
             },

--- a/scripts/workflows/temporal/modules/assistant/tracked/intake.py
+++ b/scripts/workflows/temporal/modules/assistant/tracked/intake.py
@@ -111,7 +111,14 @@ def _gh(*args: str, cwd: Path | None = None) -> str:
     an unreadable repo rather than as a bad address. `run_bounded` also supplies
     the wall-clock ceiling that keeps a hung `gh` from parking the dispatch.
     """
-    done = shared.run_bounded(["gh", *args], cwd=cwd)
+    # THROUGH `gh_attempt` RATHER THAN `run_bounded` DIRECTLY, as of PMP Phase 3.
+    # `gh_attempt` is where the fleet's `gh` mutations acquire their journal emit
+    # (requirement 1) — and it is also where a transient 503 on a READ is retried
+    # and a transient one on a WRITE is refused rather than repeated. This module
+    # closes intake issues, which is a mutation, so both properties were missing
+    # here for the same reason: it reached one layer below the choke point.
+    # `run_bounded`'s wall-clock ceiling is unchanged — `gh_attempt` calls it.
+    done = shared.gh_attempt(list(args), cwd)
     if done.returncode != 0:
         raise IntakeError(f"`gh {' '.join(args)}` failed: {done.stderr.strip()}")
     return done.stdout

--- a/scripts/workflows/temporal/modules/assistant/tracked/tracked_items.py
+++ b/scripts/workflows/temporal/modules/assistant/tracked/tracked_items.py
@@ -35,6 +35,16 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
+# PMP PHASE 3's EMIT RULE REACHES THIS MODULE, and this import is the whole
+# coupling it costs. This file was stdlib-only, which was a property worth
+# keeping and is not worth keeping at the price of the four `tracked/` stores
+# being written with nothing recording it: requirement 1 is *if any store gets
+# it, the journal gets it*, and these three functions ARE the fleet's write path
+# to those stores. The journal package imports no workflow module, so the edge
+# runs one way and nothing circular is created.
+from ...journal import emit as journal_emit
+from ...journal.events import Destination, Provenance
+
 # §7. Bumped upstream when §2 or §3 change; a consumer that writes a different
 # shape than the standard declares is detectable at dispatch instead of at
 # failure, which is the whole reason the number exists. `candidates.md` changed
@@ -219,6 +229,51 @@ def render(fields: dict[str, str], body: str) -> str:
     return f"---\n{lines}\n---\n{body}"
 
 
+def _write_item(path: Path, text: str, *, write_path: str,
+                store_name: str) -> Path:
+    """Write one item file, emitting the intent BEFORE the file exists.
+
+    PMP PHASE 3 REQUIREMENT 4 CASE (b), APPLIED TO THE `tracked/` STORES. The
+    ordering is what makes requirement 1's invariant self-enforcing: the intent
+    lands first, so a journal failure means the file is never written and NEITHER
+    side happened. Written the other way round, the store would hold an item the
+    record does not — which is the state Phase 4's rebuild cannot distinguish
+    from a row somebody deleted.
+
+    THE ADDRESS IS THE PATH, AND IT LANDS ON THE COMPLETION. Unlike a GitHub
+    comment the path is knowable in advance here — but putting it on the intent
+    would say the file exists before it does, and `JournalEvent` refuses an
+    intent carrying an address for exactly that reason. The completion is the
+    event that asserts the write happened.
+
+    ⚠ `provenance` IS `FLEET_AUTHORED` ON ALL THREE WRITERS, INCLUDING THE ONES
+    DRIVEN BY AN INTAKE ISSUE. The body of an intake-harvested item was authored
+    by a `review-pr` dispatch, which is fleet code; an item a HUMAN edits by hand
+    never passes through this function at all, because `tracked/operations/`
+    admits no machine write and the operator edits the other three in an editor.
+    So there is no operator-authored write on this path to mislabel.
+
+    OUTSIDE A RUN THE WRITE IS PERFORMED UNWRAPPED. `current_emitter()` answers
+    `None` for a unit test or a helper script, and that is a real state rather
+    than an error — manufacturing an emitter here would write a bag for a process
+    that is not a run, under a `run_id` nobody minted.
+    """
+    def _perform() -> Path:
+        path.write_text(text)
+        return path
+
+    emitter = journal_emit.current_emitter()
+    if emitter is None:
+        return _perform()
+    return emitter.paired_write(
+        write_path=write_path,
+        destination=Destination(store=f"tracked_{store_name}"),
+        content=text,
+        provenance=Provenance.FLEET_AUTHORED,
+        perform=_perform,
+        address_of=lambda written: str(written))
+
+
 def file_item(
     root: Path,
     store: Store,
@@ -267,8 +322,9 @@ def file_item(
     path = directory / f"{new_id}.md"
     if path.exists():
         raise FileExistsError(f"{path} already exists — ids are never reused (§2)")
-    path.write_text(render(fields, body if body.startswith("\n") else "\n" + body))
-    return path
+    return _write_item(
+        path, render(fields, body if body.startswith("\n") else "\n" + body),
+        write_path=f"tracked:{store.name}:file", store_name=store.name)
 
 
 def expand(path: Path, note: str, body_text: str, *, today: date | None = None) -> None:
@@ -293,7 +349,9 @@ def expand(path: Path, note: str, body_text: str, *, today: date | None = None) 
         body = body.rstrip("\n") + f"\n\n{block}"
     else:
         body = body.rstrip("\n") + f"\n\n{section}\n\n{block}"
-    path.write_text(render(fields, body))
+    _write_item(path, render(fields, body),
+                write_path=f"tracked:{store_of(fields['id']).name}:expand",
+                store_name=store_of(fields["id"]).name)
 
 
 def increment(path: Path, note: str, *, today: date | None = None) -> int:
@@ -322,5 +380,7 @@ def increment(path: Path, note: str, *, today: date | None = None) -> int:
     else:
         body = body.rstrip("\n") + f"\n\n## Recurrences\n\n{stamped}\n"
 
-    path.write_text(render(fields, body))
+    _write_item(path, render(fields, body),
+                write_path=f"tracked:{store_of(fields['id']).name}:increment",
+                store_name=store_of(fields["id"]).name)
     return int(fields["count"])

--- a/scripts/workflows/temporal/modules/journal/__init__.py
+++ b/scripts/workflows/temporal/modules/journal/__init__.py
@@ -15,6 +15,28 @@ rather than where it lands and how it is read, it is in the wrong phase.
                              installer's own symlink set (Workflow
                              Decomposition Phase 5)
 
+PHASE 3 ADDS THE EMIT RULE — *whenever a run writes anything to any store, it
+also writes a copy into the journal* — and it is four more files under this same
+package, for the reason Phase 2's five are here: they write into a bag's payload,
+so they are the journal's own I/O rather than a capability sitting beside it.
+
+  `events.py`              — the event contract: five kinds, four admission
+                             fields, and the replay rules (dedupe on identity,
+                             apply only an intent that has a completion)
+  `edge_id.py`             — the machine's stable name, persisted, and
+                             independent of every credential (r6)
+  `capture_filter.py`      — named credential shapes kept out at APPEND time,
+                             before any byte reaches the root (r10)
+  `emit.py`                — the emit boundary: write-ahead ordering, the four
+                             write-failure cases, and case (d)'s two channels
+                             WITH their readers (r4, r11, r12)
+
+THE EVENT CONTRACT IS SEPARATE FROM THE TYPED EXIT RECORD'S AND SHARES ONE
+VOCABULARY WITH IT (r3). `modules/vocabulary.py` is that vocabulary — a leaf at
+`modules/` belonging to neither package, because this package may not import
+`modules.assistant` and `exit_record.py` is dependency-free by design. The full
+argument is in `vocabulary.py`'s own docstring.
+
 PHASE 2 ADDS THE CONTENT STORE, and it is five more files under this same package
 rather than a new child of `modules/`. That placement is a deliberate answer to a
 question the roadmap flagged as this phase's trigger: whether `modules/<capability>/`
@@ -91,9 +113,20 @@ from .citations import (CAPTURE_HARVEST, CAPTURE_READ_TIME, Citation,
 # `AttributeError` on a function object, which is how every other submodule in
 # this package can be reached. Callers take it by its full path:
 # `from modules.journal.config_digest import config_digest`.
+from .capture_filter import (RULES, FilterResult, Rule, filter_capture,
+                             placeholder_for)
 from .config_digest import (LABEL_CONFIG_DIGEST, ConfigDigest,
                             ConfigDigestError, installer_targets,
                             parse_tag_value, unavailable_tag_value)
+from .edge_id import (EDGE_ID_FILE, NO_CREDENTIAL_EPOCH, EdgeIdError,
+                      adopt_edge_id, read_edge_id, resolve_edge_id)
+from .emit import (UNWRITABLE_JOURNAL_MARKER, EmitFailed, Emitter,
+                   JournalUnwritable, StoreWriteFailed, gap_class_for,
+                   unwritable_journal_in_text, unwritable_journal_report)
+from .events import (EVENTS_FILE, Destination, EventError, EventKind, GapClass,
+                     JournalEvent, Lineage, Provenance, applied_intents,
+                     decode_event, dedupe_on_identity, encode_event,
+                     event_identity, gap_event, redaction_placeholder_event)
 from .content_activities import (capture_code_citation, capture_fetched_source,
                                  capture_source, resolve_citation)
 from .content_store import (ContentStoreError, digest_of_bytes, load_object,
@@ -106,16 +139,26 @@ from .validate import BagReport, render_report, validate_bag
 from .verify import CitationResult, VerifyReport, verify_bag, verify_citation
 
 __all__ = [
-    "CAPTURE_HARVEST", "CAPTURE_READ_TIME", "JOURNAL_SCHEMA_VERSION",
-    "LABEL_CONFIG_DIGEST", "Bag", "BagError", "BagReport", "Citation",
-    "CitationError", "CitationResult", "ConfigDigest", "ConfigDigestError",
-    "ContentStoreError", "FetchPolicy", "FetchRefused", "JournalRootError",
-    "VerifyReport", "capture_code_citation", "capture_fetched_source",
-    "capture_source", "digest_of_bytes", "evidence_set_hash", "fetch_source",
-    "installer_targets", "load_journal_config", "load_object", "mint_run_id",
-    "new_citation", "object_relpath", "open_bag", "open_run_bag",
-    "parse_tag_value", "read_citations", "read_tag_file", "record_citation",
-    "render_report", "resolve_citation", "resolve_journal_root",
-    "stage_evidence_hashes", "store_bytes", "unavailable_tag_value", "utc_now",
-    "validate_bag", "verify_bag", "verify_citation",
+    "CAPTURE_HARVEST", "CAPTURE_READ_TIME", "EDGE_ID_FILE", "EVENTS_FILE",
+    "JOURNAL_SCHEMA_VERSION", "LABEL_CONFIG_DIGEST", "NO_CREDENTIAL_EPOCH",
+    "RULES", "UNWRITABLE_JOURNAL_MARKER", "Bag", "BagError", "BagReport",
+    "Citation", "CitationError", "CitationResult", "ConfigDigest",
+    "ConfigDigestError", "ContentStoreError", "Destination", "EdgeIdError",
+    "EmitFailed", "Emitter", "EventError", "EventKind", "FetchPolicy",
+    "FetchRefused", "FilterResult", "GapClass", "JournalEvent",
+    "JournalRootError", "JournalUnwritable", "Lineage", "Provenance", "Rule",
+    "StoreWriteFailed", "VerifyReport", "adopt_edge_id", "applied_intents",
+    "capture_code_citation", "capture_fetched_source", "capture_source",
+    "decode_event", "dedupe_on_identity", "digest_of_bytes", "encode_event",
+    "event_identity", "evidence_set_hash", "fetch_source", "filter_capture",
+    "placeholder_for",
+    "gap_class_for", "gap_event", "installer_targets", "load_journal_config",
+    "load_object", "mint_run_id", "new_citation", "object_relpath", "open_bag",
+    "open_run_bag", "parse_tag_value", "read_citations", "read_edge_id",
+    "read_tag_file", "record_citation", "redaction_placeholder_event",
+    "render_report", "resolve_citation", "resolve_edge_id",
+    "resolve_journal_root", "stage_evidence_hashes", "store_bytes",
+    "unavailable_tag_value", "unwritable_journal_in_text",
+    "unwritable_journal_report", "utc_now", "validate_bag", "verify_bag",
+    "verify_citation",
 ]

--- a/scripts/workflows/temporal/modules/journal/__init__.py
+++ b/scripts/workflows/temporal/modules/journal/__init__.py
@@ -28,8 +28,9 @@ so they are the journal's own I/O rather than a capability sitting beside it.
   `capture_filter.py`      — named credential shapes kept out at APPEND time,
                              before any byte reaches the root (r10)
   `emit.py`                — the emit boundary: write-ahead ordering, the four
-                             write-failure cases, and case (d)'s two channels
-                             WITH their readers (r4, r11, r12)
+                             write-failure cases, and case (d)'s reporting
+                             channels — `CASE_D_CHANNELS` declares which of the
+                             three actually has a producer (r4, r11, r12)
 
 THE EVENT CONTRACT IS SEPARATE FROM THE TYPED EXIT RECORD'S AND SHARES ONE
 VOCABULARY WITH IT (r3). `modules/vocabulary.py` is that vocabulary — a leaf at

--- a/scripts/workflows/temporal/modules/journal/bag.py
+++ b/scripts/workflows/temporal/modules/journal/bag.py
@@ -46,13 +46,15 @@ from its bag entirely.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import hashlib
 import os
 import posixpath
 import re
 import shutil
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -71,7 +73,9 @@ __all__ = ["JOURNAL_SCHEMA_VERSION", "BAGIT_VERSION", "TAG_FILE_ENCODING",
            "RUN_ID_MAX_LENGTH", "validated_run_id", "folds_a_tag_line",
            "LABEL_SCHEMA_VERSION", "LABEL_REDACTION", "LABEL_INCOMPLETE",
            "LABEL_GAP", "LABEL_SEALED_AT", "BagState", "bag_state",
-           "lifecycle_of"]
+           "lifecycle_of", "JOURNAL_LABEL_PREFIX", "RESERVED_JOURNAL_LABELS",
+           "DESCRIPTIVE_JOURNAL_LABELS", "known_journal_label",
+           "unrecognised_journal_labels"]
 
 # THE EVENT SCHEMA VERSION. Bumping it is a deliberate act with a written rule
 # beside it (see the module docstring and the phase doc's § Schema versioning):
@@ -111,6 +115,108 @@ LABEL_REDACTION = "Journal-Redaction"              # zero or more; presence => r
 LABEL_INCOMPLETE = "Journal-Incomplete"            # zero or one; "true" => incomplete
 LABEL_GAP = "Journal-Gap"                          # zero or more; what was lost
 LABEL_SEALED_AT = "Journal-Sealed-At"              # exactly one, once sealed
+
+# ---------------------------------------------------------------------------
+# THE `Journal-` TAG NAMESPACE — Phase 3 requirement 13, four questions.
+#
+# (a) WHO MAY ADD ONE, answered separately for the namespace's TWO TRUST
+#     CLASSES, because a flat rule over the prefix either blocks a legitimate
+#     descriptive tag or opens the integrity space.
+#
+#       * LIFECYCLE labels are FACTS ABOUT WHAT HAPPENED to a run — Phase 4,
+#         Phase 6 and Phase 7 branch on them — and they are written by this
+#         module alone, from `seal`, `redact` and `mark_incomplete`. They are
+#         not something a run's opener declares, so `RESERVED_JOURNAL_LABELS`
+#         refuses them on the contribution path below.
+#       * DESCRIPTIVE labels say WHAT THE RUN WAS — its workflow key, its origin
+#         repo, that repo's remote and commit, its worktree, the configuration
+#         digest it absorbed. Any component may contribute one.
+#
+# (b) WHAT A READER DOES WITH ONE IT DOES NOT RECOGNISE: it VALIDATES and is
+#     REPORTED. Not refused (RFC 8493 permits arbitrary `bag-info.txt` labels
+#     and a bag carrying a newer fleet's tag is a valid bag), and not silently
+#     dropped (which is how a contributed field stops existing without anyone
+#     learning). `unrecognised_journal_labels` is that reader half, and
+#     `validate_bag` surfaces it — as a REPORT and never as a finding, because
+#     `BagReport.ok` is a verdict about the BYTES.
+#
+# (c) WHETHER BAG METADATA CARRIES A VERSION OF ITS OWN, distinct from the
+#     per-event one, IS DELIBERATELY NOT RULED HERE and this comment is the
+#     ruling that it stays open. The fleet declares ONE version field today and
+#     Phase 1 describes it two ways — "the event schema version" and "the
+#     bag-level version". A tag addition changes bag metadata and changes no
+#     event, so *"bump it"* and *"do not"* are both wrong answers to a question
+#     with an ambiguous subject. Nobody has verified that a bump is needed, and
+#     settling it here would manufacture a decision no run has made.
+#
+# (d) BY WHAT MECHANISM AN OUTSIDE COMPONENT CONTRIBUTES ONE: `Bag.add_tag`,
+#     and nothing else. THE RULE NAMES THE WRITER, NOT JUST THE OWNER, because
+#     the controls that actually hold this namespace are code and not prose —
+#     the reserved-label refusal and `_refuse_folded_value` run on the bag-open
+#     path and nowhere else. A component that composes a `bag-info.txt` line
+#     itself, or reaches `_append_tag_line` directly, bypasses every one of
+#     them, which is how the value-forging class comes back through a second
+#     author. This module's own history is the argument: the rule stayed prose
+#     and leaked twice more, and its conclusion was that a rule has to become a
+#     function and a sweep rather than a sentence.
+#
+# TRIGGER: Workflow Decomposition Phase 5 r1 — a sixth `Journal-` tag beside the
+# five that exist, and the first field this bag has ever taken from outside.
+# Until now the namespace was closed BY CONSTRUCTION: every label is a literal
+# inside this package and callers supply values, never labels.
+# ---------------------------------------------------------------------------
+JOURNAL_LABEL_PREFIX = "Journal-"
+
+#: The lifecycle class. Written by this module alone; refused from outside.
+#: `LABEL_SCHEMA_VERSION` is in the set despite not carrying the prefix, because
+#: it is the same KIND of thing — a fact about the record rather than about the
+#: run — and a reserved set that a reader has to remember one exception to is a
+#: reserved set with a hole in it.
+RESERVED_JOURNAL_LABELS = frozenset({
+    LABEL_SCHEMA_VERSION, LABEL_REDACTION, LABEL_INCOMPLETE, LABEL_GAP,
+    LABEL_SEALED_AT,
+})
+
+#: The descriptive class this fleet writes today. NOT a permitted-set — a label
+#: outside it is contributable and is merely UNRECOGNISED to a reader, per (b).
+#: It exists so `unrecognised_journal_labels` has something to be the complement
+#: of, and so the five WD-Phase-5 already depends on are enumerated somewhere a
+#: contributor can find them.
+DESCRIPTIVE_JOURNAL_LABELS = frozenset({
+    "Journal-Workflow", "Journal-Origin-Repo", "Journal-Origin-Remote",
+    "Journal-Origin-Commit", "Journal-Worktree", "Journal-Config-Digest",
+})
+
+
+def known_journal_label(label: str) -> bool:
+    """Whether this fleet's code knows what a given `Journal-` label means."""
+    return label in RESERVED_JOURNAL_LABELS or label in DESCRIPTIVE_JOURNAL_LABELS
+
+
+def unrecognised_journal_labels(
+        entries: Sequence[tuple[str, str]]) -> tuple[str, ...]:
+    """The reader half of (b), as a function rather than as a rule in prose.
+
+    Every `Journal-`-prefixed label in `entries` that this fleet has no code for,
+    de-duplicated and in file order. A caller does something INFORMATIVE with the
+    result — `validate_bag` prints it — and never refuses on it: a bag written by
+    a newer fleet is a valid bag, and refusing it would make the namespace's
+    stated extensibility false the first time anyone used it.
+
+    IT IGNORES NON-`Journal-` LABELS ENTIRELY, including RFC 8493's own reserved
+    elements. Those are the standard's namespace and this fleet does not police
+    them; `Payload-Oxum` appearing here would be a report that the RFC exists.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for label, _ in entries:
+        if not label.startswith(JOURNAL_LABEL_PREFIX):
+            continue
+        if known_journal_label(label) or label in seen:
+            continue
+        seen.add(label)
+        out.append(label)
+    return tuple(out)
 
 # `\A…\Z` AND NOT `^…$`: `$` also matches immediately BEFORE a trailing
 # newline, so an anchored-looking validator silently accepts one. Both
@@ -455,6 +561,80 @@ def _refuse_folded_value(label: str, value: str) -> None:
             f"EIGHT more characters that method breaks on went through it.")
 
 
+@contextlib.contextmanager
+def _tag_file_lock(path: Path) -> Iterator[None]:
+    """Serialise every writer of one tag file, across processes.
+
+    ⚠ THIS CLOSES A RACE PHASE 1 COULD NOT REACH AND PHASE 3 CREATES. Phase 1
+    gives each writer its own payload subfolder so no two writers share a file —
+    but **every writer shares `bag-info.txt`**, and `_set_tag_line` is a
+    read-modify-write that truncates. Nothing called `seal()` outside tests, so
+    the race was unreachable until emitters existed; the day they do, a gap
+    record appended while the parent seals is **lost along with the `incomplete`
+    flag**, and the bag then validates clean. That is precisely the *"a bag that
+    lost data reads as complete"* outcome Phase 1's four-state design exists to
+    prevent, arriving through the one file its per-writer isolation does not
+    cover.
+
+    THE LOCK IS TAKEN ON THE CONTAINING DIRECTORY, NOT ON THE FILE. `flock`
+    attaches to an INODE, and the atomic rewrite below replaces the file with a
+    new one — so a lock held on `bag-info.txt` would be a lock on an inode the
+    next writer no longer opens, which is a lock that reads as working and
+    protects nothing. The directory's inode is stable for the life of the bag.
+    It also means one lock covers `bag-info.txt` and `manifest-sha256.txt`
+    together, which is what a reseal actually needs: `seal` writes both, and a
+    reader between them would see a manifest that does not match the Oxum.
+
+    NOT REENTRANT. Nothing nests today — `redact` and `mark_incomplete` compose
+    and validate their line, then call the writers in sequence — and a reentrant
+    wrapper for a nesting nobody performs is machinery guarding a hypothetical.
+    A future caller that nests will deadlock loudly at its first run rather than
+    corrupting a record, which is the failure this package prefers.
+
+    ⚠ IT IS AN ADVISORY LOCK, so it binds only writers that take it. That is the
+    same reason `Bag.add_tag` exists: a component composing a `bag-info.txt`
+    line itself bypasses this exactly as it bypasses the reserved-label refusal.
+    """
+    fd = os.open(str(path.parent), os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(fd)
+
+
+def _replace_tag_file(path: Path, lines: list[str]) -> None:
+    """`_write_tag_file`'s atomic twin: a reader never sees a half-written file.
+
+    WRITE-TEMP-PLUS-`os.replace`, in the same directory so the rename stays
+    within one filesystem and is therefore a single atomic syscall. The
+    truncate-then-write `_write_tag_file` performs has a window in which
+    `bag-info.txt` is EMPTY — and a concurrent `Bag.incomplete` reading that
+    window gets `false` for a bag that is flagged, which is this component's
+    worst output. The lock above serialises WRITERS; this is what protects a
+    READER, which takes no lock at all.
+
+    `_write_tag_file` IS KEPT AND STILL USED for the manifest and the redaction
+    marker: both are written once by a caller already holding the lock, neither
+    is read concurrently by a flag check, and routing them through a rename
+    would add a temp file to the bag root for no property gained.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tag-", suffix=".tmp")
+    try:
+        body = "".join(ln if ln.endswith("\n") else ln + "\n" for ln in lines)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(body)
+        os.chmod(tmp, FILE_MODE)
+        os.replace(tmp, str(path))
+    except BaseException:
+        # NAMED RATHER THAN SWALLOWED: the temp file is this function's own
+        # litter, and leaving it behind would put an unlisted file in the bag
+        # root that no reader has a rule for. The original exception propagates.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
 def _write_tag_file(path: Path, lines: list[str]) -> None:
     """Write a tag file at `FILE_MODE`, with the mode set at creation.
 
@@ -492,10 +672,17 @@ def _append_tag_line(path: Path, label: str, value: str) -> None:
     # `record_citation` was caught creating a file with neither rule, and fixed
     # here rather than reported, because a sweep that names a second member and
     # leaves it is not a sweep.
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
-                 FILE_MODE)
-    with os.fdopen(fd, "a", encoding="utf-8") as handle:
-        handle.write(f"{label}: {value}\n")
+    # UNDER THE DIRECTORY LOCK because `_set_tag_line` truncates. `O_APPEND` is
+    # atomic against another `O_APPEND`, which is why this line was safe on its
+    # own; it is NOT atomic against a read-modify-write, and a gap record
+    # appended into the window where `seal` has read the file and not yet
+    # written it back is a record that never existed.
+    with _tag_file_lock(path):
+        fd = os.open(str(path),
+                     os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
+                     FILE_MODE)
+        with os.fdopen(fd, "a", encoding="utf-8") as handle:
+            handle.write(f"{label}: {value}\n")
 
 
 def _set_tag_line(path: Path, label: str, value: str) -> None:
@@ -520,22 +707,26 @@ def _set_tag_line(path: Path, label: str, value: str) -> None:
     reach for it with a free-text label whose value could.
     """
     _refuse_folded_value(label, value)
-    lines = path.read_text(encoding="utf-8").splitlines()
-    replacement = f"{label}: {value}"
-    kept: list[str] = []
-    written = False
-    for line in lines:
-        match = _LABEL_RE.match(line)
-        if match is not None and match.group(1).strip() == label:
-            if written:
-                continue          # drop a duplicate written before this rule existed
+    # THE READ AND THE WRITE ARE ONE CRITICAL SECTION. Split, this is the
+    # read-modify-write that drops any line appended between them — which for
+    # this file means a gap record and the `Journal-Incomplete` flag beside it.
+    with _tag_file_lock(path):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        replacement = f"{label}: {value}"
+        kept: list[str] = []
+        written = False
+        for line in lines:
+            match = _LABEL_RE.match(line)
+            if match is not None and match.group(1).strip() == label:
+                if written:
+                    continue      # drop a duplicate written before this rule existed
+                kept.append(replacement)
+                written = True
+                continue
+            kept.append(line)
+        if not written:
             kept.append(replacement)
-            written = True
-            continue
-        kept.append(line)
-    if not written:
-        kept.append(replacement)
-    _write_tag_file(path, kept)
+        _replace_tag_file(path, kept)
 
 
 def read_tag_file(path: Path) -> list[tuple[str, str]]:
@@ -771,6 +962,100 @@ class Bag:
             f"could not allocate a payload subfolder for {name!r} in "
             f"{self.payload_dir}: 9999 names are taken. That is not a collision, "
             f"it is a loop writing one directory per iteration.")
+
+    def add_tag(self, label: str, value: str) -> None:
+        """THE ONE MECHANISM by which anything contributes a `bag-info.txt` tag.
+
+        REQUIREMENT 13(d), AND IT NAMES THE WRITER RATHER THAN ONLY THE OWNER.
+        The controls that hold the `Journal-` namespace are code, not prose: the
+        reserved-label refusal here and `_refuse_folded_value`'s forged-label and
+        folded-value refusals. A component that composes a tag line itself, or
+        reaches `_append_tag_line` directly, bypasses all three — which is how
+        the value-forging class comes back through a second author. This
+        package's own history is the argument for a function rather than a
+        sentence; see § *And the rule stayed prose, so it leaked twice more*.
+
+        THE LIFECYCLE LABELS ARE REFUSED, THE DESCRIPTIVE ONES ARE NOT. A
+        lifecycle label is a FACT about what happened to this run — Phase 4,
+        Phase 6 and Phase 7 branch on it — and is written by this module from
+        `seal`, `redact` and `mark_incomplete`. Letting an outside contributor
+        assert one would let it declare a run complete, or declare a gap that
+        never happened, which is the integrity space requirement 13(a) draws the
+        line around.
+
+        APPENDS RATHER THAN SETS, so a repeatable descriptive label stays
+        repeatable. `_set_tag_line` is for the three RFC-reserved elements that
+        describe the bag AS IT STANDS and must be replaced on a reseal; a
+        contributed tag is a statement made once.
+
+        ⚠ IT DOES NOT REFUSE A SEALED BAG. A tag is not payload: it is outside
+        the manifest by design (see the module docstring on why there is no
+        `tagmanifest-sha256.txt`), so adding one after a seal invalidates
+        nothing. Refusing here would make a redaction tombstone — which is
+        exactly a post-seal tag write — a special case in a rule that has none.
+        """
+        if label in RESERVED_JOURNAL_LABELS:
+            raise BagError(
+                f"{label!r} is a reserved lifecycle label and is written by the "
+                f"journal package alone (Phase 3 r13a). It is a fact about what "
+                f"happened to this run — Phase 4, Phase 6 and Phase 7 branch on "
+                f"it — not something a contributor declares. Reserved: "
+                f"{sorted(RESERVED_JOURNAL_LABELS)}.\n"
+                f"  a gap is recorded by `mark_incomplete`, a redaction by "
+                f"`redact`, and the sealed-at stamp by `seal`.")
+        _append_tag_line(self.info_path, label, value)
+
+    def write_payload(self, relpath: str, data: str | bytes) -> Path:
+        """Write one payload file through the bag, at `FILE_MODE`.
+
+        THIS PHASE IS WHAT MAKES `config.yaml`'s *"payload files are 0600"* TRUE
+        OR A LIE. Phase 1 applied `FILE_MODE` only to the tag files it wrote
+        itself, because nothing wrote payload yet — so an emitter reaching for
+        `Path.write_text` would land `0644` transcripts under a `0700` root. That
+        is harmless exactly until Phase 7 tars a bag and lands them somewhere the
+        root's mode is not protecting them, at which point the fix is a
+        bucket-wide operation rather than a mode argument.
+
+        THE MODE IS SET AT CREATION, not by a following `chmod`, for the reason
+        `_write_tag_file` and the root's directory mode both give: an `open()`
+        then `chmod` leaves a window in which a world-readable file holding
+        transcript bytes exists on a multi-user host.
+
+        CONTAINMENT AND SYMLINK REFUSAL ARE THE CALLER-SUPPLIED-PATH RULES THIS
+        MODULE ALREADY OWNS, reused rather than re-derived —
+        `_contained_payload_target` is the same function `redact` proves its own
+        path with, and it carries both halves the validator must not have.
+
+        `O_EXCL`: A PAYLOAD FILE IS WRITTEN ONCE. The journal is append-only, so
+        overwriting one is the immutability rule being broken from inside the
+        writer that is supposed to enforce it. An emitter appending to a growing
+        file opens it itself with `O_APPEND` — see `emit.py` — which is a
+        different operation with a different guarantee, and conflating the two
+        behind one method is how the append path would silently acquire a
+        truncate.
+        """
+        if Path(relpath).parts[:1] != (PAYLOAD_DIR,):
+            raise BagError(
+                f"cannot write {relpath}: payload goes under {PAYLOAD_DIR}/. A "
+                f"path outside it is either a tag file — which the bag writes "
+                f"itself — or an escape.")
+        target = self._contained_payload_target(relpath)
+        target.parent.mkdir(mode=DIR_MODE, parents=True, exist_ok=True)
+        body = data.encode("utf-8") if isinstance(data, str) else data
+        try:
+            fd = os.open(str(target),
+                         os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                         FILE_MODE)
+        except FileExistsError as exc:
+            raise BagError(
+                f"cannot write {relpath}: it already exists in {self.path}. A "
+                f"payload file is written once — overwriting one is the "
+                f"immutability rule being broken from inside the writer that "
+                f"enforces it. A redaction is the one sanctioned replacement.",
+            ) from exc
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(body)
+        return target
 
     def seal(self) -> Path:
         """Write `manifest-sha256.txt` over the payload. The bag becomes `sealed`.

--- a/scripts/workflows/temporal/modules/journal/bag.py
+++ b/scripts/workflows/temporal/modules/journal/bag.py
@@ -614,10 +614,15 @@ def _replace_tag_file(path: Path, lines: list[str]) -> None:
     worst output. The lock above serialises WRITERS; this is what protects a
     READER, which takes no lock at all.
 
-    `_write_tag_file` IS KEPT AND STILL USED for the manifest and the redaction
-    marker: both are written once by a caller already holding the lock, neither
-    is read concurrently by a flag check, and routing them through a rename
-    would add a temp file to the bag root for no property gained.
+    `_write_tag_file` IS KEPT FOR THE REDACTION MARKER AND FOR BAG CREATION —
+    a payload file each redaction writes once, and the two tag files a staging
+    directory gets before anything can reach it. Neither is read concurrently by
+    a flag check, and neither is a shared file two writers reach.
+    **The manifest is NOT one of them**: `seal` routes it through this function,
+    under the lock, because `validate_bag` reads it while a reseal may be
+    rewriting it. An earlier version of this paragraph claimed both the manifest
+    and the marker were "written once by a caller already holding the lock", and
+    that was false of both callers — `seal` held no lock at all.
     """
     fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tag-", suffix=".tmp")
     try:
@@ -711,22 +716,40 @@ def _set_tag_line(path: Path, label: str, value: str) -> None:
     # read-modify-write that drops any line appended between them — which for
     # this file means a gap record and the `Journal-Incomplete` flag beside it.
     with _tag_file_lock(path):
-        lines = path.read_text(encoding="utf-8").splitlines()
-        replacement = f"{label}: {value}"
-        kept: list[str] = []
-        written = False
-        for line in lines:
-            match = _LABEL_RE.match(line)
-            if match is not None and match.group(1).strip() == label:
-                if written:
-                    continue      # drop a duplicate written before this rule existed
-                kept.append(replacement)
-                written = True
-                continue
-            kept.append(line)
-        if not written:
+        _set_tag_line_locked(path, label, value)
+
+
+def _set_tag_line_locked(path: Path, label: str, value: str) -> None:
+    """`_set_tag_line`'s body, for a caller that ALREADY HOLDS the lock.
+
+    THE LOCK IS NOT REENTRANT — it is a `flock` on the containing directory, and
+    taking it twice on one thread deadlocks. `seal` writes four files that have
+    to move together, so it holds the lock once and calls this; every other
+    caller takes the wrapper. Split rather than made reentrant for the reason
+    `_tag_file_lock` states: a reentrant wrapper for a nesting nobody performs is
+    machinery guarding a hypothetical, and the one caller that does nest is right
+    here where a reader can see it.
+
+    `_refuse_folded_value` STILL RUNS IN THE WRAPPER and is not repeated here:
+    the composed line is validated before the lock is taken, so a refusal never
+    happens while a bag's tag file is held.
+    """
+    lines = path.read_text(encoding="utf-8").splitlines()
+    replacement = f"{label}: {value}"
+    kept: list[str] = []
+    written = False
+    for line in lines:
+        match = _LABEL_RE.match(line)
+        if match is not None and match.group(1).strip() == label:
+            if written:
+                continue          # drop a duplicate written before this rule existed
             kept.append(replacement)
-        _replace_tag_file(path, kept)
+            written = True
+            continue
+        kept.append(line)
+    if not written:
+        kept.append(replacement)
+    _replace_tag_file(path, kept)
 
 
 def read_tag_file(path: Path) -> list[tuple[str, str]]:
@@ -1078,13 +1101,30 @@ class Bag:
         """
         files = payload_files(self.path)
         lines = [f"{sha256_of(self.path / rel)}  {rel.as_posix()}" for rel in files]
-        _write_tag_file(self.manifest_path, lines)
-
         octets = sum((self.path / rel).stat().st_size for rel in files)
         sealed_at = utc_now()
-        _set_tag_line(self.info_path, "Payload-Oxum", f"{octets}.{len(files)}")
-        _set_tag_line(self.info_path, "Bagging-Date", sealed_at[:10])
-        _set_tag_line(self.info_path, LABEL_SEALED_AT, sealed_at)
+
+        # ⚠ ONE LOCK OVER ALL FOUR WRITES, AND IT USED NOT TO BE. The manifest
+        # was written OUTSIDE the lock, through the truncating `_write_tag_file`,
+        # while the three tag lines each took and released the lock separately —
+        # so `_tag_file_lock`'s own claim that "one lock covers `bag-info.txt`
+        # and `manifest-sha256.txt` together, which is what a reseal actually
+        # needs" was false about the function it was written for. Two concurrent
+        # reseals — and `mark_incomplete` reseals, which Phase 3 makes reachable
+        # from every emitter on a disk-full — could interleave two truncating
+        # writes of one manifest, and a reader between the manifest and the Oxum
+        # saw a manifest that did not match it.
+        #
+        # THE MANIFEST GOES THROUGH `_replace_tag_file` FOR THE READER's SAKE:
+        # the lock serialises writers, and `validate_bag` takes no lock at all,
+        # so only the atomic rename keeps it from reading a half-written
+        # manifest and reporting a bag that lost data.
+        with _tag_file_lock(self.info_path):
+            _replace_tag_file(self.manifest_path, lines)
+            _set_tag_line_locked(self.info_path, "Payload-Oxum",
+                                 f"{octets}.{len(files)}")
+            _set_tag_line_locked(self.info_path, "Bagging-Date", sealed_at[:10])
+            _set_tag_line_locked(self.info_path, LABEL_SEALED_AT, sealed_at)
         return self.manifest_path
 
     def _contained_payload_target(self, payload_relpath: str) -> Path:

--- a/scripts/workflows/temporal/modules/journal/capture_filter.py
+++ b/scripts/workflows/temporal/modules/journal/capture_filter.py
@@ -84,8 +84,21 @@ class Rule:
 
 #: The shapes this fleet actually handles, and nothing speculative. Each is a
 #: PREFIXED, self-identifying credential format — which is the class a pattern
-#: filter can catch honestly, and the class this repo's own `.env`, `gh` auth and
-#: 1Password references are drawn from. An entropy heuristic was considered and
+#: filter can catch honestly.
+#:
+#: ⚠ AN EARLIER VERSION OF THIS SENTENCE CITED *"this repo's own `.env`, `gh`
+#: auth and 1Password references"*, AND TWO OF THE THREE ARE NOT HERE: the tree
+#: holds no `.env` and no `op://` reference or 1Password token anywhere outside
+#: prose (checked by grep on 2026-09-10). What this repo actually handles is the
+#: `gh` CLI's own credential and whatever the environment supplies to a
+#: dispatch, which is why the GitHub shapes lead the list. The rest are the
+#: widely-published formats a transcript can pick up from a command line — they
+#: are here because they are catchable, not because a file in this tree holds
+#: one. **A control's provenance claim is checked like any other citation**;
+#: this one was not, and a filter that cites material nobody has is a filter
+#: whose coverage nobody can audit.
+#:
+#: An entropy heuristic was considered and
 #: rejected: it fires on git SHAs, on `sha256` manifest lines and on every
 #: `event_id` in the journal's own events, so it would filter the record's own
 #: identity fields and report a leak on every bag.

--- a/scripts/workflows/temporal/modules/journal/capture_filter.py
+++ b/scripts/workflows/temporal/modules/journal/capture_filter.py
@@ -1,0 +1,172 @@
+"""Secrets are kept out at APPEND time — before any byte reaches the journal root.
+
+REQUIREMENT 10, AND THE TIMING IS THE REQUIREMENT. The journal is immutable and
+nothing removes a file from inside a bag except a redaction, so **capture is the
+only point in the lifecycle where a secret can be cheaply kept out.** After Phase
+4 wires the rebuild test to a gate, removing a payload file is a gate change;
+after Phase 7 it is a bucket-wide purge. Phase 5's retention budget is not a
+control here — it is a size limit, not an age limit, so how long a leaked byte
+survives is unknown rather than bounded.
+
+⚠ "AT APPEND" AND NOT "BEFORE SEALED", AND THE DISTINCTION IS LOAD-BEARING UNDER
+WRITE-AHEAD ORDERING. `exit_record._redact` already drops tool input *"at READ
+TIME, so there is no copy to leak"* — but that control guards a DISPLAY surface.
+The journal is a durable one, and under write-ahead ordering it receives every
+payload FIRST. Filtering "before sealed" would therefore leave unfiltered bytes
+sitting in appended event files for the whole life of the run; and filtering them
+AT seal time would change written events, which requirement 8 forbids outright.
+
+**THE FILTER CANNOT RUN RETROACTIVELY.** Redaction (Phase 1's event class) is the
+only after-the-fact path, and it is for what gets through. This is the cheap
+gate; that is the incident response.
+
+**IT EMITS A PLACEHOLDER**, so the record stays complete about the *fact* of a
+removal rather than silently shorter. `events.redaction_placeholder_event` is
+that record, and it carries the byte count and the RULE NAME — never what the
+rule matched, which is the secret.
+
+⚠ WHAT THIS DOES NOT LOOK AT, stated in the module rather than discovered later.
+A pattern filter sees the shapes it was given. It does not see a credential with
+no distinguishing shape (a bare password, an eight-character API key), it does
+not see one split across two lines by a wrapping terminal, and it does not see
+one that is base64 of something it would otherwise catch. It is a floor, and the
+component's real control for what gets past it is Phase 1's redaction. Any claim
+stronger than "these named shapes do not reach the root" is a claim this module
+cannot support.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = ["Rule", "RULES", "FilterResult", "filter_capture",
+           "placeholder_for"]
+
+def placeholder_for(rule: str) -> str:
+    """What a matched span is replaced BY.
+
+    Self-describing: a reader of a journal event must be able to tell "a filter
+    fired here" from "the run authored the literal word REDACTED", and a marker
+    naming the RULE that fired is what makes the first readable without leaking
+    the second.
+
+    A FUNCTION AND NOT A STRING TEMPLATE, because `test_journal_tag_lines.py`
+    sweeps this package for tag-line composition and refuses the `str` templating
+    method outright — such a call is invisible to a sweep that reads f-strings,
+    and this package's rule is that a composition the sweep cannot see does not
+    get to exist. The sweep is aimed at `bag-info.txt` lines and this is not one;
+    the refusal is still correct, because "it happens not to be a tag line today"
+    is precisely the reasoning that lets the next one in.
+
+    ⚠ AND THE SPELLING IS AVOIDED IN THIS DOCSTRING TOO, which is not fussiness:
+    the sweep reads the whole file, so naming the method literally here would
+    keep this module red while the code was already correct — the assertion's
+    population including the text that makes the claim about it.
+    """
+    return f"[FILTERED:{rule}]"
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One named credential shape.
+
+    THE NAME IS PUBLISHED AND THE MATCH IS NOT. A placeholder and a placeholder
+    event both carry `name`; neither ever carries the matched text. That is what
+    lets an operator distinguish "a GitHub token pattern fired" from "an
+    over-broad rule is eating legitimate content" without the record carrying
+    either.
+    """
+
+    name: str
+    pattern: re.Pattern[str]
+
+
+#: The shapes this fleet actually handles, and nothing speculative. Each is a
+#: PREFIXED, self-identifying credential format — which is the class a pattern
+#: filter can catch honestly, and the class this repo's own `.env`, `gh` auth and
+#: 1Password references are drawn from. An entropy heuristic was considered and
+#: rejected: it fires on git SHAs, on `sha256` manifest lines and on every
+#: `event_id` in the journal's own events, so it would filter the record's own
+#: identity fields and report a leak on every bag.
+#:
+#: `\A…\Z` IS NOT USED HERE ON PURPOSE — unlike every other regex in this
+#: package, these are SEARCHED within a body of text rather than matched against
+#: a whole line, so an anchor would make every one of them dead. That is the
+#: opposite of the `test_journal_regex_anchors.py` case, which is about
+#: validators that look anchored and are not; these do not look anchored.
+RULES: tuple[Rule, ...] = (
+    Rule("github-token", re.compile(r"gh[pousr]_[A-Za-z0-9]{16,255}")),
+    Rule("github-pat", re.compile(r"github_pat_[A-Za-z0-9_]{20,255}")),
+    Rule("aws-access-key", re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}")),
+    Rule("openai-key", re.compile(r"sk-[A-Za-z0-9_-]{20,}")),
+    Rule("anthropic-key", re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}")),
+    Rule("slack-token", re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}")),
+    Rule("google-api-key", re.compile(r"AIza[A-Za-z0-9_-]{35}")),
+    Rule("private-key-block",
+         re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?"
+                    r"-----END [A-Z ]*PRIVATE KEY-----")),
+    Rule("bearer-header",
+         re.compile(r"(?i:authorization:\s*bearer\s+)[A-Za-z0-9._~+/=-]{12,}")),
+    Rule("url-embedded-credential",
+         re.compile(r"(?i:https?://)[^\s:/@]+:[^\s:/@]+@")),
+)
+
+
+@dataclass(frozen=True)
+class FilterResult:
+    """What came out, what was removed, and by which rules.
+
+    `removed_bytes` IS MEASURED ON THE INPUT, NOT ON THE DIFFERENCE. A
+    placeholder is usually shorter than the secret it replaced but it need not
+    be, and a length difference would report a NEGATIVE removal for a short
+    token — a number that reads as "the filter added content". The question the
+    record has to answer is *how many bytes of original content did not reach
+    the journal*, which is the sum of the matched spans.
+    """
+
+    text: str
+    removed_bytes: int
+    rules_fired: tuple[str, ...]
+
+    @property
+    def fired(self) -> bool:
+        """DERIVED, NEVER STORED, for the reason `BagReport.ok` is derived: a
+        stored flag makes a result constructible that disagrees with its own
+        contents, and the disagreement this one would hide is "the filter fired
+        and the record says it did not"."""
+        return bool(self.rules_fired)
+
+
+def filter_capture(text: str) -> FilterResult:
+    """Replace every known credential shape, and report what was removed.
+
+    TOTAL OVER ITS INPUT — it never raises, and that is a requirement rather than
+    a convenience. This runs on the append path of a component whose entire
+    thesis is that a failed write must not be silent; a filter that raised on
+    some input would convert a leak into a crash on the one path that is supposed
+    to keep running. Every failure mode here is "a rule did not match", which is
+    the honest boundary stated in the module docstring.
+
+    RULES ARE APPLIED IN ORDER AND THE ORDER IS LOAD-BEARING FOR EXACTLY ONE
+    PAIR: `anthropic-key` is a prefix-extension of `openai-key`'s `sk-` shape, so
+    the more specific one is listed second and would never fire if the general
+    one had already consumed its text. It is applied to the OUTPUT of the
+    previous rule, so `sk-ant-…` is reported as `openai-key`. That is a KNOWN
+    MISLABEL rather than a leak — both rules remove the same span, so no byte
+    reaches the root either way — and it is stated because the alternative
+    (matching all rules against the original text and merging spans) buys a
+    better label at the cost of overlap arithmetic on the failure path.
+    """
+    fired: list[str] = []
+    removed = 0
+    out = text
+    for rule in RULES:
+        matches = list(rule.pattern.finditer(out))
+        if not matches:
+            continue
+        fired.append(rule.name)
+        removed += sum(len(m.group(0)) for m in matches)
+        out = rule.pattern.sub(placeholder_for(rule.name), out)
+    return FilterResult(text=out, removed_bytes=removed,
+                        rules_fired=tuple(fired))

--- a/scripts/workflows/temporal/modules/journal/edge_id.py
+++ b/scripts/workflows/temporal/modules/journal/edge_id.py
@@ -1,0 +1,313 @@
+"""The machine's stable name, persisted, and independent of every credential.
+
+REQUIREMENT 6, AND THE HALF OF IT THAT IS BUILDABLE IN THIS REPO TODAY. The
+requirement was SPLIT at review because its two halves have different evidence
+bars: a stable, persisted `edge_id` independent of any credential is buildable
+here and closes on its own; the **key→id mapping** lives in the upstream
+Django/Temporal pair, a system outside this repo with no edge API key in this
+fleet's configuration to point at, so it can only be closed by assertion. That
+half is deferred on the named trigger *"the upstream pair authenticates an
+edge."* The no-key-in-events constraint rides on the buildable half, deliberately
+— which is why `NO_CREDENTIAL_EPOCH` below is a real value rather than an absence.
+
+⚠ AN API KEY IS A CREDENTIAL, NOT AN IDENTIFIER, AND THIS IS THE WHOLE POINT.
+The upstream pair has to know every edge, and the API key already associated with
+one is the natural carrier — it is how the edge authenticates today. But
+credentials rotate, and **a journal keyed by API key orphans an edge's entire
+history the day the key is rotated.** The key authenticates; it MAPS TO a stable
+edge id that never rotates. One line of design now, an unrecoverable
+data-modelling mess later.
+
+THIS IS A BINDING RULE RATHER THAN THIS COMPONENT'S PREFERENCE. Temporal Standard
+§7.5 *Identities are explicit, never derived* states it generally — wherever a
+resource is located or targeted by an identity, the identity is an explicit
+input, not a derivation — and `edge_id` is one instance of it.
+
+⚠ AND `hash(api_key)` IS RULED OUT TWICE OVER, so nobody re-derives it as the
+clever answer. It changes on rotation, which is the orphaning bug above; and a
+stored hash of a live credential is an offline confirmation oracle. An event
+carrying a key, or a value derived from one in a way that survives rotation, is a
+defect and not a convenience. `_refuse_credential_derived` below is that rule as
+code rather than as this paragraph.
+
+WHAT THIS MODULE DOES NOT DECIDE — the SHAPE. Whether the identity is a UUID, a
+host-scoped name, an operator-assigned label or something the orchestrator
+already issues is a JOINT design with the Temporal Integration component, which
+addresses workers, task queues and schedules and has its own reasons to name a
+machine. That component names no machine or edge id today, so the question is
+open on both sides and gets settled once rather than twice. **What this component
+needs is three constraints and they are all it needs:** stable across credential
+rotation, never derived from a key, present on every event. A generated UUID
+satisfies all three and commits to nothing — `adopt_edge_id` below is the seam
+where an operator-assigned or orchestrator-issued value replaces it with no
+schema change and no orphaned history.
+
+⚠ AND STABILITY IS NOT TRUSTWORTHINESS. These three constraints make an identity
+DURABLE; they say nothing about whether it is trustworthy. `events.py` states the
+other half: `edge_id` is SELF-REPORTED until an authenticating ingest exists, and
+no amount of stability fixes that. Two separate properties; this file supplies
+only the first.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+
+__all__ = ["EDGE_ID_FILE", "NO_CREDENTIAL_EPOCH", "EdgeIdError",
+           "resolve_edge_id", "adopt_edge_id", "read_edge_id",
+           "EDGE_ID_PERMITTED"]
+
+#: Where the id is persisted: at the journal root, beside the bags rather than
+#: inside any of them. AT THE MACHINE, which is what requirement 6 says — a file
+#: inside a bag would be per-run, and an id that changed per run is not an id.
+#: The root is already resolved once per run, already proven writable and
+#: correctly-moded by `root.py`, and already the one place this fleet keeps
+#: per-machine state, so putting it anywhere else would introduce a second
+#: machine-state location for one value.
+EDGE_ID_FILE = "edge-id"
+
+#: The `key_epoch` an edge with no credential carries. A VALUE, NOT AN ABSENCE,
+#: and `JournalEvent` refuses an empty one so this cannot be skipped by accident.
+#: Requirement 7(c) needs every event to answer *under which credential epoch was
+#: this authored*, and "none" is a real answer for this fleet today — it
+#: authenticates to no upstream pair. An empty string would be indistinguishable
+#: from a field somebody forgot to fill, which is the state a replay scoped past
+#: a leaked credential cannot act on.
+NO_CREDENTIAL_EPOCH = "none"
+
+#: `\A…\Z` and not `^…$`, for the reason `bag._RUN_ID_RE` states: `$` also
+#: matches before a trailing newline, so an anchored-looking validator silently
+#: accepts one. `test_journal_regex_anchors.py` fails on any `^`/`$` added
+#: anywhere in this package.
+EDGE_ID_PERMITTED = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
+
+#: The three digest lengths a key-derived id would arrive as — md5, sha1,
+#: sha256 rendered hex. COMPILED TO A CONSTANT rather than inlined at the call,
+#: because `test_journal_regex_anchors.py` sweeps this package for `\A…\Z`
+#: anchoring and can only see patterns it can find; an inline `re.fullmatch(r"…")`
+#: is invisible to it. Anchoring is supplied by `fullmatch` here rather than by
+#: the pattern, which is why the sweep has to be able to read it and rule.
+_DIGEST_SHAPE_RE = re.compile(r"[0-9a-fA-F]{32}|[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+
+#: File mode for the id. Not a secret — it appears in every event — but the
+#: journal root is `0700` and a `0644` file inside it would be the one
+#: inconsistency a reader has to stop and think about.
+_EDGE_ID_MODE = 0o600
+
+
+class EdgeIdError(RuntimeError):
+    """The edge id could not be read, created or adopted.
+
+    `RuntimeError` so it joins the `except RuntimeError` clause every entrypoint
+    already carries around its preconditions, exactly as `JournalRootError` and
+    `BagError` do.
+    """
+
+
+def _refuse_credential_derived(value: str, *, source: str) -> None:
+    """Refuse an id that looks like it was derived from a secret.
+
+    ⚠ THIS IS A SHAPE CHECK AND IT CANNOT PROVE THE NEGATIVE — stated here rather
+    than left for a reader to over-read. Nothing can look at a 64-character hex
+    string and know whether it is `sha256(api_key)` or a random token; what this
+    catches is the SHAPE somebody reaches for when they implement the ruled-out
+    answer, which is a bare hex digest of a standard digest length. A determined
+    caller can defeat it by base64-ing the same hash.
+
+    So why have it at all: because the failure mode is not an attacker, it is a
+    future implementer who reads *"the key maps to a stable id"*, reaches for
+    `hashlib.sha256(key).hexdigest()` as the obvious mapping, and ships it. That
+    person is stopped by an error that names the rule; they are not stopped by a
+    paragraph in a docstring, and this component's own thesis — stated three
+    times in the phase doc — is that a rule written only as prose has not once
+    prevented the thing it forbids.
+
+    WHAT IT DOES NOT LOOK AT: the id already persisted at this machine. This runs
+    on ADOPTION, which is the moment a value arrives from outside; re-checking a
+    value already written would make a machine whose id happens to be 64 hex
+    characters unable to start, and the remedy for that is not available to the
+    run that hits it.
+    """
+    if _DIGEST_SHAPE_RE.fullmatch(value):
+        raise EdgeIdError(
+            f"refusing an edge id from {source} that has the shape of a bare "
+            f"digest ({len(value)} hex characters). Requirement 6 rules out a "
+            f"key-derived id twice over: it changes on rotation, which orphans "
+            f"this edge's entire history the day the key rotates, and a stored "
+            f"hash of a live credential is an offline confirmation oracle.\n"
+            f"  if this is genuinely a random token rather than a digest, "
+            f"prefix or hyphenate it so it does not read as one — the shape is "
+            f"what a later reader will judge it by.")
+
+
+def _validate(value: str, *, source: str) -> str:
+    """The id's own contract: non-empty, single-line, and safe in a path or a tag.
+
+    THE SAME CHARACTER SET `validated_run_id` USES, and for one of the same
+    reasons plus one more. It goes into `bag-info.txt` as a tag value, so
+    anything `str.splitlines()` breaks on would fold the line into what reads as
+    a second label — the forging class `bag.folds_a_tag_line` exists to close.
+    And it goes into every event, where a value that reads back differently from
+    the value written breaks the one property the journal has.
+    """
+    stripped = value.strip()
+    if not stripped:
+        raise EdgeIdError(
+            f"the edge id from {source} is empty. Every event carries one "
+            f"(requirement 6), and a field absent from version-1 events is "
+            f"absent forever — so there is no recovering this later.")
+    if stripped != value:
+        raise EdgeIdError(
+            f"the edge id from {source} carries surrounding whitespace: "
+            f"{value!r}. It is written into `bag-info.txt` as a tag value and "
+            f"read back stripped, so it would be a DIFFERENT string from the "
+            f"one written. Refused rather than trimmed: the space is part of a "
+            f"name somebody chose, and choosing for them is how a machine gets "
+            f"two ids.")
+    if not EDGE_ID_PERMITTED.match(stripped):
+        raise EdgeIdError(
+            f"the edge id from {source} is not `[A-Za-z0-9._-]{{1,128}}`: "
+            f"{value!r}. It appears in a tag line and in every event, so the "
+            f"permitted set is the intersection of what survives both.")
+    return stripped
+
+
+def read_edge_id(root: Path) -> str | None:
+    """The id persisted at this root, or `None` if this machine has none yet.
+
+    `None` IS NOT AN ERROR AND IS NOT A DEFAULT. It means *not yet minted*, which
+    is the true state of a machine on its first run, and it is the caller's to
+    resolve — `resolve_edge_id` mints, and a read-only consumer (a validator, a
+    Phase 6 sweep) wants to know the difference between "this edge has no id" and
+    "I made one up". Returning a fresh UUID from a READ would give every such
+    consumer a different answer for one machine.
+    """
+    path = root / EDGE_ID_FILE
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except UnicodeDecodeError as exc:
+        # NAMED SEPARATELY BECAUSE `UnicodeDecodeError` IS A `ValueError`, not an
+        # `OSError` — so an `except OSError` alone catches the failure everybody
+        # thinks of and lets this one escape while LOOKING handled. This file is
+        # written by this module and holds ASCII, so a non-UTF-8 byte in it means
+        # a hand-edit or a corrupted filesystem, and neither is recoverable by
+        # guessing an encoding: every event this machine ever wrote carries the
+        # value that is supposed to be in here.
+        raise EdgeIdError(
+            f"the edge id at {path} is not valid UTF-8 ({exc.reason} at byte "
+            f"{exc.start}). It was written by this module as ASCII, so this is a "
+            f"hand-edit or a corrupted file — and it cannot be guessed, because "
+            f"every event under this root carries the value it should hold.") from exc
+    except OSError as exc:
+        raise EdgeIdError(
+            f"the edge id at {path} could not be read — {exc.strerror}. The "
+            f"journal root is resolved and proven writable before this point, "
+            f"so a failure here is the root becoming unusable mid-run, which is "
+            f"requirement 4 case (d) and not a missing id.") from exc
+    return _validate(raw.strip("\n"), source=str(path))
+
+
+def resolve_edge_id(root: Path) -> str:
+    """This machine's id, minted on first call and stable for every call after.
+
+    MINTED AS A UUID4 WITH AN `edge-` PREFIX. The prefix is not decoration: it is
+    what keeps a generated id from reading as the bare digest
+    `_refuse_credential_derived` refuses, and it makes an id greppable in a
+    journal full of other 32-character hex identities (`event_id` is one).
+
+    CREATE-EXCLUSIVE, SO TWO CONCURRENT FIRST RUNS CANNOT MINT TWO IDS. `O_EXCL`
+    means the loser of the race gets `FileExistsError` and re-reads the winner's
+    value rather than overwriting it. This is the same failure this fleet already
+    survives at `Bag.writer_dir` by letting `os.mkdir` win or lose — and it is
+    reachable here for the same reason: a parent and its children can start
+    within the same second on a machine that has never run before.
+
+    ⚠ THE RE-READ CAN STILL RETURN `None` IF THE WINNER HAS CREATED THE FILE AND
+    NOT YET WRITTEN IT. That window is one `os.write` wide and the remedy is to
+    say so rather than to loop: a retry loop here would spin on a genuinely
+    empty file (a previous run killed between create and write), which is a state
+    a human has to clear. The error names the file and the remedy.
+    """
+    existing = read_edge_id(root)
+    if existing is not None:
+        return existing
+
+    minted = f"edge-{uuid.uuid4().hex}"
+    path = root / EDGE_ID_FILE
+    try:
+        fd = os.open(str(path),
+                     os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                     _EDGE_ID_MODE)
+    except FileExistsError:
+        raced = read_edge_id(root)
+        if raced is None:
+            raise EdgeIdError(
+                f"{path} exists and is empty. A previous run was killed between "
+                f"creating this file and writing it, and an empty id cannot be "
+                f"guessed — every event this machine has ever written carries "
+                f"the value that belongs here.\n"
+                f"  remedy: if this machine has bags under {root}, take the "
+                f"`edge_id` from any event in one and write it into this file; "
+                f"if it has none, delete the file and the next run mints one.")
+        return raced
+    except OSError as exc:
+        raise EdgeIdError(
+            f"the edge id could not be written at {path} — {exc.strerror}. The "
+            f"root was proven writable before this point, so this is the root "
+            f"becoming unusable (requirement 4 case (d)), not a permissions "
+            f"misconfiguration.") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(minted + "\n")
+    return minted
+
+
+def adopt_edge_id(root: Path, value: str, *, source: str = "caller") -> str:
+    """Take an id assigned from outside — the seam the joint design lands on.
+
+    THIS IS WHERE AN OPERATOR-ASSIGNED LABEL OR AN ORCHESTRATOR-ISSUED NAME
+    REPLACES THE MINTED UUID, and it exists now so that landing it later is a
+    call rather than a migration. The Temporal Integration component has its own
+    reasons to name a machine; whichever of the two is being built when the
+    question comes up settles it, and the other cites it.
+
+    ⚠ IT REFUSES TO REPLACE AN ID THIS MACHINE HAS ALREADY USED, and that refusal
+    is the requirement rather than caution. Every event already written carries
+    the old value; adopting a new one would split this machine's history into two
+    edges that look like two machines, which is the exact orphaning failure the
+    no-credential rule exists to prevent — arriving through the front door
+    instead. Adopting the SAME value is a no-op and returns it, so a caller that
+    passes the configured id on every run is correct and idempotent.
+    """
+    candidate = _validate(value, source=source)
+    _refuse_credential_derived(candidate, source=source)
+
+    existing = read_edge_id(root)
+    if existing is not None and existing != candidate:
+        raise EdgeIdError(
+            f"this machine is already {existing!r} and cannot become "
+            f"{candidate!r}. Every event under {root} carries the first value, "
+            f"so adopting the second would split one machine's history into two "
+            f"edges — the same orphaned-history failure a credential-derived id "
+            f"causes, reached deliberately instead of by rotation.\n"
+            f"  remedy: an edge that must be renamed is a migration over the "
+            f"existing bags, not a write to this file.")
+    if existing == candidate:
+        return existing
+
+    path = root / EDGE_ID_FILE
+    try:
+        fd = os.open(str(path),
+                     os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                     _EDGE_ID_MODE)
+    except OSError as exc:
+        raise EdgeIdError(
+            f"the adopted edge id could not be written at {path} — "
+            f"{exc.strerror}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(candidate + "\n")
+    return candidate

--- a/scripts/workflows/temporal/modules/journal/edge_id.py
+++ b/scripts/workflows/temporal/modules/journal/edge_id.py
@@ -158,7 +158,13 @@ def _validate(value: str, *, source: str) -> str:
         raise EdgeIdError(
             f"the edge id from {source} is empty. Every event carries one "
             f"(requirement 6), and a field absent from version-1 events is "
-            f"absent forever — so there is no recovering this later.")
+            f"absent forever — so there is no recovering this later.\n"
+            f"  an EMPTY FILE here means a previous run was killed between "
+            f"creating it and writing it. The value cannot be guessed: every "
+            f"event this machine has written carries the one that belongs in "
+            f"it. Remedy: if this root holds bags, copy the `edge_id` from any "
+            f"event in one into the file; if it holds none, delete the file and "
+            f"the next run mints a new id.")
     if stripped != value:
         raise EdgeIdError(
             f"the edge id from {source} carries surrounding whitespace: "
@@ -227,11 +233,13 @@ def resolve_edge_id(root: Path) -> str:
     reachable here for the same reason: a parent and its children can start
     within the same second on a machine that has never run before.
 
-    ⚠ THE RE-READ CAN STILL RETURN `None` IF THE WINNER HAS CREATED THE FILE AND
-    NOT YET WRITTEN IT. That window is one `os.write` wide and the remedy is to
-    say so rather than to loop: a retry loop here would spin on a genuinely
-    empty file (a previous run killed between create and write), which is a state
-    a human has to clear. The error names the file and the remedy.
+    ⚠ THE RE-READ CAN STILL FIND THE FILE EMPTY IF THE WINNER HAS CREATED IT AND
+    NOT YET WRITTEN IT. That window is one `os.write` wide, and the answer is to
+    REFUSE with a remedy rather than to loop: a retry loop would spin forever on
+    the durable version of the same state — a previous run killed between create
+    and write — which no run can clear. `read_edge_id` raises that refusal, and
+    it is the same refusal either way because the two states are indistinguishable
+    from here and have the same fix.
     """
     existing = read_edge_id(root)
     if existing is not None:
@@ -244,17 +252,14 @@ def resolve_edge_id(root: Path) -> str:
                      os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
                      _EDGE_ID_MODE)
     except FileExistsError:
-        raced = read_edge_id(root)
-        if raced is None:
-            raise EdgeIdError(
-                f"{path} exists and is empty. A previous run was killed between "
-                f"creating this file and writing it, and an empty id cannot be "
-                f"guessed — every event this machine has ever written carries "
-                f"the value that belongs here.\n"
-                f"  remedy: if this machine has bags under {root}, take the "
-                f"`edge_id` from any event in one and write it into this file; "
-                f"if it has none, delete the file and the next run mints one.")
-        return raced
+        # THE RACE'S LOSER RE-READS THE WINNER'S VALUE rather than overwriting
+        # it. `read_edge_id` raises rather than returning `None` for a file that
+        # exists and is empty — which is the one-`os.write`-wide window between
+        # the winner's create and its write, and also the durable state a killed
+        # run leaves. Its message names the remedy, so there is nothing to add
+        # here; an `if raced is None` arm would be unreachable code carrying a
+        # second copy of that message.
+        return read_edge_id(root)  # type: ignore[return-value]
     except OSError as exc:
         raise EdgeIdError(
             f"the edge id could not be written at {path} — {exc.strerror}. The "

--- a/scripts/workflows/temporal/modules/journal/emit.py
+++ b/scripts/workflows/temporal/modules/journal/emit.py
@@ -1,0 +1,712 @@
+"""The emit — an ACTIVITY the orchestrator invokes, not a helper call sites remember.
+
+REQUIREMENT 12, AND IT IS THE SAME ARGUMENT PHASE 1 r11 MAKES, APPLIED WHERE THE
+FAILURE WOULD ACTUALLY HAPPEN. As a library, the emit rule is advice; this fleet
+has already lost three observables and one cross-fleet gate to advice. Made
+structural, the emit's ordering guarantee — the intent event *before* its paired
+store write — is something the boundary enforces rather than something a call
+site gets right.
+
+⚠ AND THIS IS PRECISELY WHERE THE ACTIVITY BOUNDARY STOPS HELPING, so the limit
+is stated rather than assumed. A wrapper reaches **fleet-code writes**: a call
+site in `scripts/` that writes to a store. It does not reach **model-issued
+writes** at all — when the child itself runs `gh pr comment`, there is no call
+site to wrap, and the mechanism for those is Phase 10's post-exit harvest rather
+than anything here. It does not reach a write path nobody wrapped in the first
+place; **Phase 4's rebuild test is the guard for that class**, and the two are
+complementary rather than redundant.
+
+WHAT AN ACTIVITY *IS* HERE IS A BOUNDARY THE TEMPORAL PORT ALSO OWNS. What this
+phase states is what it NEEDS — a recorded, retried step whose failure stops the
+run at a named boundary — rather than the mechanism. `events.event_identity` is
+the other half of that seam: an activity executes AT LEAST ONCE, so the journal
+is a side effect the port has to hold for, and dedupe-on-identity is what
+discharges Temporal Standard §7.1's idempotency rule here. **Layer placement,
+invocation and fail-stop are buildable today; orchestrator-driven retry and
+recorded execution are port-time**, exactly as `journal_activities.py` says of
+bag-open.
+
+---
+
+## The rule: a gap may exist; a silent gap may not
+
+Requirement 4, four cases, ordered because the first prevents most of the others.
+
+**(a) The root cannot be resolved, at the start of the run → the run does not
+start.** Phase 1 r9 owns this and it is already built (`root.resolve_journal_root`
+plus `open_run_bag`'s `OSError` boundary). Nothing here re-implements it; the
+cheapest failure is the one that already exists.
+
+**(b) A write that has a paired store write → the intent goes FIRST, and a
+failed intent means the store write does not happen.** `paired_write` below. This
+is the ordering that makes requirement 1's invariant self-enforcing: order the
+intent before the store write and a journal failure means NEITHER happened, so
+the invariant holds because both sides are absent. Order it after and the store
+has something the record does not, which is the state the component exists to
+prevent. The run then stops at that boundary with a named terminal state —
+`EmitFailed` — rather than continuing, because every subsequent step's record
+would be conditioned on a write nobody can see. *(This is a write-ahead log,
+which is what an append-only record that other stores are regenerated from is.
+Naming it is worth a sentence: the ordering constraint is not an invention of
+this plan.)*
+
+**(c) A write with no pairable store write → a typed gap event, and the bag is
+marked `incomplete`.** `unpairable_write` below. Write-ahead ordering has nothing
+to offer here — the content already exists and the only question is whether it
+lands — so the failure is RECORDED rather than prevented.
+
+**⚠ The transcript is the one member of case (c) that is not merely a
+completeness problem.** It is the fleet's only record of what commands ran, this
+fleet runs with permissions bypassed, and a run can itself create the disk-full
+condition that drops it. Losing it while the run proceeds to completion is
+evidence loss wearing a routine defect's clothes. So a failed transcript write is
+treated as case (b) — the run stops — via `stop_on_failure=True`, which is a
+PARAMETER rather than a special case inside the function, because the caller is
+what knows which member it is holding.
+
+**(d) The bootstrap case — the journal is unwritable, so the gap event cannot go
+in the journal either.** `unwritable_journal_report` below. It surfaces on two
+channels that are not the journal, and the second is why the first is not enough:
+the typed exit record plus a non-zero exit status carry it out of the process,
+**and both are invocation state — read within seconds and then gone.** The
+durable half is a pull-request comment: durable, addressable, and outside the
+journal root by construction. **Not the standup tracker** — that surface is
+`tracked/operations/`, which Tracked Items §1.2 makes human-in-the-loop only with
+no autonomous write ever, and offering it here would put a binding-standard
+violation on the one path that exists to report this component being broken.
+
+**⚠ CASE (d)'s DURABLE REPORT IS THE ONE STATED EXCEPTION TO REQUIREMENT 1's
+INVARIANT AND TO CASE (b)'s ORDERING.** The durable report is a STORE WRITE. Case
+(b) says a store write does not happen unless its intent landed first — and in
+case (d) the journal is unwritable by definition, so the intent can never land.
+Read literally, this component's own ordering rule suppresses the only durable
+signal that the component is broken. So: **the case-(d) failure report is the
+single store write permitted with no preceding emit, because the emit is
+precisely the thing that failed.** It is not a hole in the invariant; it is the
+invariant's boundary condition, and a build that implements case (b) as an
+unconditional wrapper without this exception ships the failure path silently
+broken. `unwritable_journal_report` does NOT route through `paired_write`, and
+that is why.
+
+**⚠ And case (d) is uncountable from the journal, by construction.** Phase 6 r6
+counts gaps by reading gap events; a run in case (d) produced no gap event, no
+bag and nothing to count. That is a stated limit of that measurement rather than
+a defect in it.
+
+## Requirement 11 — each signal ships with its reader, in this change
+
+The exit-record field has a named parent branch that reads it and the
+working-record line has a named consumer that surfaces it. Adding a field to a
+channel and leaving the reading to somebody later is how this fleet has already
+lost three observables, and the one channel this component's failure path depends
+on is the last place to repeat it. Both readers are `unwritable_journal_report`
+and `unwritable_journal_in_text` at the bottom of this module, and
+`test_the_unwritable_journal_signal_HAS_a_reader.py` is what holds them to the
+producers rather than this paragraph.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+from ..vocabulary import TerminalState
+from .bag import FILE_MODE, Bag, BagError
+from .capture_filter import filter_capture
+from .edge_id import NO_CREDENTIAL_EPOCH, resolve_edge_id
+from .events import (EVENTS_FILE, Destination, EventKind, GapClass,
+                     JournalEvent, Lineage, Provenance, encode_event,
+                     event_identity, gap_event, redaction_placeholder_event)
+
+__all__ = ["Emitter", "EmitFailed", "JournalUnwritable", "StoreWriteFailed",
+           "UNWRITABLE_JOURNAL_MARKER", "unwritable_journal_report",
+           "unwritable_journal_in_text", "gap_class_for", "register_emitter",
+           "current_emitter", "emitting_into"]
+
+T = TypeVar("T")
+
+#: The literal a durable working-record line carries, and the literal its reader
+#: greps for. ONE DECLARATION, because a producer and a consumer that each spell
+#: the marker themselves are two declarations of one contract — the defect
+#: `exit-protocol.md` §6 exists to forbid, and the one this fleet committed at
+#: `as_prose_verdict`. Distinctive enough not to appear in ordinary prose, and
+#: plain enough that a human scanning a PR thread sees it.
+UNWRITABLE_JOURNAL_MARKER = "JOURNAL-UNWRITABLE"
+
+
+class EmitFailed(RuntimeError):
+    """Case (b): the intent did not land, so the store write did not happen.
+
+    `RuntimeError` so it joins the `except RuntimeError` clause every entrypoint
+    already carries. THE RUN STOPS HERE — it does not retry indefinitely and it
+    does not carry on to the next step, because every subsequent step's record
+    would be conditioned on a write nobody can see.
+
+    ⚠ SEPARATE FROM `JournalUnwritable` AND THE SEPARATION IS THE REMEDY. This
+    one means the journal refused one write at a known boundary and the store
+    write was withheld — re-running the run is a correct response. That one
+    means the root itself is gone, and re-running writes nothing.
+    """
+
+    terminal_state = TerminalState.EMIT_FAILED
+
+
+class StoreWriteFailed(RuntimeError):
+    """The intent landed and the store write did not — a POSITIVE record exists.
+
+    Raised after a `store_write_failure` event has been appended, so a caller
+    catching this knows the journal already says the write did not land. That
+    asymmetry is what `events.applied_intents` reads: a `store_write_failure`
+    does NOT satisfy an intent, so replay leaves it unapplied — and a reader can
+    tell "the store write failed" from "the run died between the two events",
+    which are both unapplied but only one of which is a defect in this component.
+    """
+
+    terminal_state = TerminalState.STORE_WRITE_FAILED
+
+
+class JournalUnwritable(RuntimeError):
+    """Case (d): the journal is gone, so even the gap event cannot be written.
+
+    NOT STARTUP-ONLY. Case (a) catches the startup instance at
+    `resolve_journal_root`; this covers any point at which the journal stops
+    being writable mid-run.
+    """
+
+    terminal_state = TerminalState.JOURNAL_UNWRITABLE
+
+
+def gap_class_for(exc: OSError) -> GapClass:
+    """An `OSError` as one of four closed classes — never as its message.
+
+    THE MESSAGE IS DELIBERATELY DISCARDED. A gap event reports that content was
+    lost; a `why` carrying `exc.strerror` or `exc.filename` would put the failing
+    path — and, for some filesystems, a fragment of what was being written — into
+    the record that exists to say those bytes were dropped. Four classes, a byte
+    count and a timestamp cost a few hundred bytes and cannot leak.
+
+    THE OPERATOR STILL GETS THE MESSAGE — on stderr, and in the exception this
+    module raises. What is bounded is what reaches the DURABLE record, which is
+    the surface Phase 7 syncs to object storage and Phase 4 replays.
+    """
+    if exc.errno in (errno.ENOSPC, errno.EDQUOT):
+        return GapClass.DISK_FULL
+    if exc.errno in (errno.EROFS, errno.EACCES, errno.EPERM):
+        return GapClass.READ_ONLY
+    if exc.errno in (errno.ENOENT, errno.ENOTDIR, errno.ESTALE):
+        return GapClass.PATH_GONE
+    return GapClass.WRITE_FAILED
+
+
+@dataclass
+class Emitter:
+    """One run-and-writer's emit boundary. Every event this fleet writes goes here.
+
+    NOT FROZEN, unlike `Bag`, because it carries the per-write-path sequence
+    counters that make `event_identity` deterministic. The bag's identity is its
+    path and does not move; an emitter's whole job is to advance.
+
+    ONE EMITTER PER (bag, writer), AND THE WRITER'S SUBFOLDER IS THE ISOLATION.
+    Phase 1 r3 gives each writer its own payload directory precisely so no two
+    writers share a file, and this appends into that directory — so two
+    concurrent children each hold their own `events.jsonl` and neither can
+    interleave into the other's. The one file they DO share is `bag-info.txt`,
+    which `bag._tag_file_lock` now serialises.
+
+    THE SEQUENCE COUNTER IS THREAD-GUARDED AND PROCESS-LOCAL. Two threads in one
+    process emitting on one write path would otherwise derive one identity for
+    two writes — which dedupe would then collapse to one, losing a write
+    silently. Two PROCESSES cannot collide because they hold different writer
+    subfolders. A lock is cheap and the failure it prevents is the one this
+    component is named after.
+    """
+
+    bag: Bag
+    writer_dir: Path
+    run_id: str
+    edge_id: str
+    key_epoch: str = NO_CREDENTIAL_EPOCH
+    _sequences: dict[str, int] = None  # type: ignore[assignment]
+    _lock: threading.Lock = None       # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self._sequences = {}
+        self._lock = threading.Lock()
+
+    # --- construction --------------------------------------------------------
+
+    @classmethod
+    def for_run(cls, bag: Bag, *, writer: str | None,
+                journal_root: Path | None = None,
+                key_epoch: str = NO_CREDENTIAL_EPOCH) -> Emitter:
+        """Build the emitter for one invocation of one run.
+
+        `writer` HAS THE SAME MEANING IT HAS AT `open_run_bag` AND IS PASSED THE
+        SAME WAY — never inferred. `None` means this invocation IS the run and
+        its events go in a `parent` subfolder; a name means this invocation is a
+        MEMBER of the run and its events go in that member's own subfolder.
+        Inferring it from the environment is how a child silently becomes its own
+        run, which is one of the two wrong answers Phase 9 rejects.
+
+        ⚠ A MEMBER GETS A SUBFOLDER; AN INVOCATION THAT *IS* THE RUN DOES NOT.
+        `writer=None` emits into the payload root itself, because Phase 9 already
+        ruled that *"an invocation that IS the run takes no writer subfolder —
+        its records are the run's, not one member's"*, and
+        `test_a_STANDALONE_CHILD_produces_exactly_one_bag_and_NO_ORPHAN` holds
+        it. There is no contention: a parent writes `data/events.jsonl` and each
+        member writes `data/<writer>/events.jsonl`, so no two writers share a
+        file — which is the property `writer_dir` exists for.
+
+        ⚠ AND FOR A MEMBER IT ALLOCATES RATHER THAN ADOPTING, exactly as
+        `open_run_bag` did, so a retry of one member emits into `w-2` rather
+        than into the directory a concurrent sibling is writing. The cost is a
+        subfolder per attempt, visible in the bag rather than silent — and
+        dedupe-on-identity is what makes the duplicate events across the two
+        harmless on read.
+
+        THE EDGE ID IS RESOLVED FROM THE ROOT, WHICH IS THE BAG'S PARENT. It is
+        per-MACHINE state (requirement 6), so it lives beside the bags and not
+        inside one; taking `journal_root` explicitly lets a caller that already
+        resolved it — every entrypoint does, via `RunContext` — avoid resolving
+        it twice and disagreeing.
+        """
+        root = journal_root if journal_root is not None else bag.path.parent
+        return cls(bag=bag,
+                   writer_dir=bag.writer_dir(writer) if writer else bag.payload_dir,
+                   run_id=bag.run_id,
+                   edge_id=resolve_edge_id(root),
+                   key_epoch=key_epoch)
+
+    # --- the append boundary -------------------------------------------------
+
+    @property
+    def events_path(self) -> Path:
+        return self.writer_dir / EVENTS_FILE
+
+    def _next_sequence(self, write_path: str) -> int:
+        with self._lock:
+            nxt = self._sequences.get(write_path, 0)
+            self._sequences[write_path] = nxt + 1
+            return nxt
+
+    def _append(self, event: JournalEvent) -> None:
+        """The one place a byte reaches the journal root. Raises, never swallows.
+
+        `O_APPEND` AND NOT `write_payload`. A payload file is written once and
+        `Bag.write_payload` carries `O_EXCL` to hold that; this file GROWS, one
+        JSON line per emit, so it is a different operation with a different
+        guarantee. Conflating them behind one method is how the append path would
+        silently acquire a truncate.
+
+        THE MODE IS `FILE_MODE` AT CREATION, for the reason every other writer in
+        this package sets it there: an `open()` then `chmod` leaves a window in
+        which a world-readable file holding authored content — including
+        transcript bytes — exists on a multi-user host.
+
+        `flush` + `fsync` BEFORE RETURNING, AND THIS IS WHAT MAKES WRITE-AHEAD
+        ORDERING REAL RATHER THAN NOMINAL. Without it the intent sits in the
+        page cache while the store write goes out over the network, and a power
+        loss between them leaves exactly the state case (b) exists to forbid: the
+        store has content the record does not. Ordering two writes means nothing
+        if the first has not reached the disk.
+        """
+        line = encode_event(event) + "\n"
+        fd = os.open(str(self.events_path),
+                     os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
+                     FILE_MODE)
+        with os.fdopen(fd, "a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    def _build(self, *, kind: EventKind, write_path: str, sequence: int,
+               destination: Destination, content: str,
+               provenance: Provenance, lineage: Lineage) -> JournalEvent:
+        """Filter at capture, then construct. THE ORDER IS REQUIREMENT 10.
+
+        The filter runs BEFORE any byte reaches the journal root — not before the
+        bag is sealed, which under write-ahead ordering would leave unfiltered
+        bytes in appended event files for the life of the run, and not AT seal,
+        which would change written events and is what requirement 8 forbids.
+
+        WHEN IT FIRES, TWO EVENTS EXIST AND NOT ONE. The filtered content goes on
+        the real event, and a `redaction_placeholder` event records the FACT and
+        the byte count — so the record stays complete about the removal rather
+        than silently shorter. The placeholder gets its own sequence, because two
+        events sharing an identity is what an intent/completion PAIR means and a
+        placeholder is not one.
+        """
+        result = filter_capture(content)
+        if result.fired:
+            placeholder = redaction_placeholder_event(
+                run_id=self.run_id, edge_id=self.edge_id,
+                key_epoch=self.key_epoch, write_path=write_path,
+                sequence=self._next_sequence(write_path),
+                destination=destination, removed_bytes=result.removed_bytes,
+                rule=",".join(result.rules_fired), provenance=provenance)
+            self._append(placeholder)
+        return JournalEvent(
+            kind=kind,
+            event_id=event_identity(run_id=self.run_id, write_path=write_path,
+                                    sequence=sequence),
+            run_id=self.run_id, edge_id=self.edge_id, key_epoch=self.key_epoch,
+            provenance=provenance, write_path=write_path, sequence=sequence,
+            destination=destination, content=result.text,
+            content_bytes=len(result.text.encode("utf-8")), lineage=lineage)
+
+    # --- case (b): the paired write -----------------------------------------
+
+    def paired_write(self, *, write_path: str, destination: Destination,
+                     content: str, perform: Callable[[], T],
+                     address_of: Callable[[T], str] = lambda _r: "",
+                     provenance: Provenance = Provenance.FLEET_AUTHORED,
+                     lineage: Lineage | None = None) -> T:
+        """One unit, two events: intent → the store write → completion.
+
+        THE INVARIANT IS *IF ANY STORE GETS IT, THE JOURNAL GETS IT*, AND THIS
+        ORDERING IS WHAT MAKES IT SELF-ENFORCING. A journal failure means
+        `perform` is never called, so NEITHER side happened and the invariant
+        holds because both are absent.
+
+        `perform` IS A CALLABLE AND NOT A RESULT, WHICH IS THE WHOLE POINT. Taking
+        an already-performed result would mean the store write had already
+        happened by the time this function ran — the exact inversion case (b)
+        forbids, arriving as an API shape rather than as a bug. It cannot be
+        called wrongly, because there is no way to call it that performs the
+        write first.
+
+        `address_of` EXTRACTS THE STORE-ASSIGNED ADDRESS FROM THE RESULT. A
+        GitHub comment has no id or URL until after it is created, and
+        requirement 8 forbids changing the written intent — so the address lands
+        on the COMPLETION. That is the third thing one event per write cannot
+        carry.
+
+        THE STORE WRITE DERIVES ITS IDEMPOTENCY KEY FROM THE SAME IDENTITY the
+        two events share, and that identity is returned to the caller through
+        `perform`'s closure rather than passed in — a caller that needs it reads
+        `event_identity(run_id=…, write_path=…, sequence=…)` for the same inputs
+        and gets the same value, which is what "deterministic" buys. **A retry is
+        then a no-op on BOTH sides rather than on one**, which is the failure
+        row `events.applied_intents` cannot fix by itself: dedupe covers the
+        journal, and only an idempotency key covers the store.
+
+        ⚠ A FAILED STORE WRITE IS RECORDED AND RE-RAISED, never swallowed. The
+        `store_write_failure` event is what stops Phase 4 replaying an intent
+        into content nobody published — *the rebuild is supposed to restore what
+        happened, not complete what did not.*
+        """
+        sequence = self._next_sequence(write_path)
+        intent = self._build(kind=EventKind.INTENT, write_path=write_path,
+                             sequence=sequence, destination=destination,
+                             content=content, provenance=provenance,
+                             lineage=lineage or Lineage())
+        try:
+            self._append(intent)
+        except OSError as exc:
+            raise EmitFailed(
+                f"the intent event for {write_path} could not be written to "
+                f"{self.events_path} — {exc.strerror}. The store write was NOT "
+                f"performed, so neither side of this write happened and the "
+                f"record is short but not wrong.\n"
+                f"  the run stops here rather than continuing: every later "
+                f"step's record would be conditioned on a write nobody can see."
+            ) from exc
+
+        try:
+            result = perform()
+        except Exception as exc:
+            failure = JournalEvent(
+                kind=EventKind.STORE_WRITE_FAILURE, event_id=intent.event_id,
+                run_id=self.run_id, edge_id=self.edge_id,
+                key_epoch=self.key_epoch, provenance=provenance,
+                write_path=write_path, sequence=sequence,
+                destination=destination,
+                terminal_state=TerminalState.STORE_WRITE_FAILED)
+            try:
+                self._append(failure)
+            except OSError:
+                # THE ORIGINAL FAILURE IS WHAT THE CALLER NEEDS, and a second
+                # exception raised from this handler would mask it. So the bag
+                # is marked instead — the record then says a write is missing
+                # even though it could not say which.
+                try:
+                    self.bag.mark_incomplete(
+                        write_path, "store write failed and its failure event "
+                                    "could not be written")
+                except (OSError, BagError):
+                    # NAMED, NOT SWALLOWED SILENTLY: what is ignored is a failed
+                    # `incomplete` flag while already handling a failed store
+                    # write AND a failed failure-event. At that point the journal
+                    # is gone, `StoreWriteFailed` below is what the caller needs
+                    # to see, and case (d) reporting is the caller's to do from
+                    # the exception it is about to receive.
+                    pass
+            raise StoreWriteFailed(
+                f"the store write for {write_path} failed after its intent "
+                f"landed: {exc}. A store-write-failure event was recorded, so "
+                f"replay will not apply the intent — Phase 4 rebuilds what "
+                f"happened, not what did not."
+            ) from exc
+
+        completion = JournalEvent(
+            kind=EventKind.COMPLETION, event_id=intent.event_id,
+            run_id=self.run_id, edge_id=self.edge_id, key_epoch=self.key_epoch,
+            provenance=provenance, write_path=write_path, sequence=sequence,
+            destination=Destination(store=destination.store,
+                                    address=address_of(result)),
+            terminal_state=TerminalState.COMPLETED, lineage=intent.lineage)
+        try:
+            self._append(completion)
+        except OSError as exc:
+            # ⚠ THE STORE WRITE HAS ALREADY HAPPENED, so stopping the run would
+            # not un-happen it. What matters is that the record does not claim an
+            # applied write it cannot prove — and an intent with no completion is
+            # exactly that claim withheld. The gap is recorded and the run stops,
+            # because the journal has just refused a write and every later step
+            # would be conditioned on it.
+            self._record_gap(write_path=write_path, exc=exc,
+                             destination=destination,
+                             lost_bytes=len(content.encode("utf-8")))
+            raise EmitFailed(
+                f"the completion event for {write_path} could not be written — "
+                f"{exc.strerror}. The store write DID land; the journal cannot "
+                f"prove it, so replay will not apply the intent and the bag is "
+                f"marked incomplete."
+            ) from exc
+        return result
+
+    # --- case (c): the unpairable write -------------------------------------
+
+    def unpairable_write(self, *, write_path: str, destination: Destination,
+                         content: str,
+                         provenance: Provenance = Provenance.FLEET_AUTHORED,
+                         lineage: Lineage | None = None,
+                         stop_on_failure: bool = False) -> None:
+        """A write with no store write to withhold — recorded, not prevented.
+
+        The CLI transcript, the execution facts and Phase 10's post-exit harvest
+        are this case: the content already exists and the only question is
+        whether it lands, so write-ahead ordering has nothing to offer. A failure
+        produces a typed gap event and marks the bag `incomplete`, and everything
+        downstream then treats that bag as a known-gap input rather than a clean
+        one — Phase 4 reports gapped bags with a count and its denominator rather
+        than diffing them as complete, Phase 6 says so in its own report, and
+        Phase 7 ships the marking with the bag.
+
+        ⚠ `stop_on_failure` IS THE TRANSCRIPT'S ARM AND IT IS A PARAMETER RATHER
+        THAN A BRANCH INSIDE THIS FUNCTION. The transcript is the fleet's only
+        record of what commands ran, this fleet runs with permissions bypassed,
+        and a run can itself create the disk-full condition that drops it. Losing
+        it while the run proceeds to completion is evidence loss wearing a
+        routine defect's clothes, so a failed transcript write is treated as case
+        (b) — the run stops. The other two members (execution facts, post-exit
+        harvest) are gaps and the run continues. **The caller is what knows which
+        member it is holding**, so the caller passes the flag; deciding it in
+        here would need this function to pattern-match on `write_path`, which is
+        a rule about strings rather than about content.
+
+        THE MODEL-ISSUED HALF OF THE INVENTORY IS THIS CASE BY CONSTRUCTION, and
+        the docs must not imply otherwise: when the child runs `gh pr comment`
+        itself, the content exists before the fleet sees it, so the harvest emits
+        a COMPLETION WITH NO PRIOR INTENT — a legitimate typed shape rather than a
+        hole. That half is protected by *"a gap event names what was lost"*, not
+        by *"neither side is written"*, and it is a materially weaker guarantee.
+        """
+        sequence = self._next_sequence(write_path)
+        event = self._build(kind=EventKind.COMPLETION, write_path=write_path,
+                            sequence=sequence, destination=destination,
+                            content=content, provenance=provenance,
+                            lineage=lineage or Lineage())
+        try:
+            self._append(event)
+        except OSError as exc:
+            self._record_gap(write_path=write_path, exc=exc,
+                             destination=destination,
+                             lost_bytes=len(content.encode("utf-8")))
+            if stop_on_failure:
+                raise EmitFailed(
+                    f"{write_path} could not be written to the journal — "
+                    f"{exc.strerror} — and this write path stops the run. It is "
+                    f"the fleet's only record of what commands ran, under "
+                    f"bypassed permissions; continuing past it would be evidence "
+                    f"loss wearing a routine defect's clothes."
+                ) from exc
+
+    def _record_gap(self, *, write_path: str, exc: OSError,
+                    destination: Destination, lost_bytes: int) -> None:
+        """Case (c)'s record, and case (d) is what happens when even this fails.
+
+        TWO WRITES, AND EITHER CAN FAIL. The gap EVENT goes in the writer's own
+        `events.jsonl`; the `incomplete` FLAG plus its record go in
+        `bag-info.txt`. They are separate files with separate failure modes, and
+        the flag is the more important of the two — it is what Phase 4, Phase 6
+        and Phase 7 branch on — so it is attempted even when the event could not
+        be written.
+
+        **If BOTH fail, the journal is unwritable and this is case (d)**:
+        `JournalUnwritable` is raised, and the caller reports it on the two
+        channels that are not the journal. That is the case that makes (c)
+        circular if it is not answered.
+        """
+        gap = gap_event(run_id=self.run_id, edge_id=self.edge_id,
+                        key_epoch=self.key_epoch, write_path=write_path,
+                        sequence=self._next_sequence(write_path),
+                        gap_class=gap_class_for(exc), lost_bytes=lost_bytes,
+                        destination=destination)
+        event_written = True
+        try:
+            self._append(gap)
+        except OSError:
+            event_written = False
+
+        try:
+            self.bag.mark_incomplete(
+                write_path, f"emit failed: {gap_class_for(exc).value}")
+        except (OSError, BagError) as flag_exc:
+            if not event_written:
+                raise JournalUnwritable(
+                    f"the journal cannot be written and neither can the record "
+                    f"of that: {write_path} failed with {exc.strerror}, and the "
+                    f"gap event and the `incomplete` flag both failed after it.\n"
+                    f"  bag: {self.bag.path}\n"
+                    f"  this is requirement 4 case (d). It is reported on the "
+                    f"typed exit record and on a durable working-record surface, "
+                    f"because the journal is not available to report it."
+                ) from flag_exc
+
+
+# ---------------------------------------------------------------------------
+# Requirement 11 — the two channels case (d) reports on, WITH their readers.
+# ---------------------------------------------------------------------------
+
+def unwritable_journal_report(exc: JournalUnwritable, *,
+                              bag_path: Path | None = None) -> dict[str, str]:
+    """PRODUCER for both channels: the exit-record field and the durable line.
+
+    ONE FUNCTION FOR BOTH so the two cannot disagree about what happened. The
+    exit record is read within seconds and then gone; the durable half is a
+    pull-request comment, which is durable, addressable, and outside the journal
+    root by construction. **Both are needed and neither is sufficient** — the
+    first because a parent has to route on it in-process, the second because
+    every consumer this component builds reads the record long after the process
+    is gone.
+
+    `terminal_state` IS `TerminalState.JOURNAL_UNWRITABLE`, from
+    `modules/vocabulary.py` — the same declaration the journal event's own
+    `terminal_state` comes from. That is requirement 3 doing its job on the one
+    field that crosses both contracts on the failure path.
+    """
+    return {
+        "terminal_state": TerminalState.JOURNAL_UNWRITABLE.value,
+        "marker": UNWRITABLE_JOURNAL_MARKER,
+        "bag": str(bag_path) if bag_path is not None else "",
+        "detail": str(exc).splitlines()[0] if str(exc) else "",
+    }
+
+
+def unwritable_journal_in_text(text: str) -> bool:
+    """READER of the durable half. The named consumer requirement 11 demands.
+
+    A SUBSTRING TEST AGAINST THE ONE DECLARED MARKER, and it is deliberately not
+    a parse. The durable channel is a PR comment written by a run whose journal
+    has just failed; a structured format there would be one more thing that can
+    fail on the path that exists to report a failure. The marker is distinctive
+    enough not to occur in ordinary prose and plain enough for a human scanning
+    the thread.
+
+    ⚠ WHAT IT DOES NOT LOOK AT: whether the line was written by the run it names,
+    or by a person quoting one. A PR thread is an open surface — the same
+    property that makes `review_pr_helper` anchor its `pr_review:` block on a
+    fence rather than on a substring — so this answers *does this text report an
+    unwritable journal*, and never *did this run's journal fail*. The
+    authoritative answer to the second is the exit record's `terminal_state`,
+    which is in-process and unforgeable by a thread participant.
+    """
+    return UNWRITABLE_JOURNAL_MARKER in text
+
+
+# ---------------------------------------------------------------------------
+# The run's emit boundary, reachable from a write path that has no bag argument.
+# ---------------------------------------------------------------------------
+
+_CURRENT: Emitter | None = None
+_CURRENT_LOCK = threading.Lock()
+
+
+def register_emitter(emitter: Emitter | None) -> None:
+    """Make `emitter` the one every write path in this process emits through.
+
+    ⚠ THIS IS PROCESS-SCOPED STATE AND THAT IS A DELIBERATE TRADE, NOT AN
+    OVERSIGHT. Requirement 12 says the emit is *"an ACTIVITY, not a library call
+    each workflow remembers to make"* — and the fleet's write paths
+    (`assistant_activities.gh_attempt`, `tracked_items`) are reached from dozens
+    of call sites that hold no bag. The alternatives were each worse:
+
+      * **Thread a `Bag` through every caller.** Forty-odd signatures change, and
+        every one of them can be called without it — which is the optional
+        control this component's whole thesis says is a skipped control. It also
+        does not survive a new call site, which is the case that matters.
+      * **Have each write path open its own bag.** Two bags for one run, keyed by
+        the same `run_id`, with `open_bag` refusing the second. Worse than
+        ambient state: it fails at runtime rather than at review.
+
+    So the boundary is registered ONCE, by `open_run_bag`, where Phase 1 r11
+    already put the run's first I/O step — and a write path that finds no
+    registered emitter is a write path running OUTSIDE a run, which is a real
+    state (a unit test, a helper script, `validate_bag`) and not an error.
+
+    ⚠ WHAT THIS DOES NOT REACH, restated because ambient state invites the
+    assumption that it reaches everything: a MODEL-ISSUED write. When the child
+    process runs `gh pr comment` itself there is no call site in this process at
+    all, so no registry can see it. That half is Phase 10's post-exit harvest.
+
+    `None` UNREGISTERS, and a test that registers must unregister — otherwise one
+    test's emitter receives another test's writes, into a `tmp_path` that has
+    already been removed. `emitting_into` below is the context manager that makes
+    that automatic.
+    """
+    global _CURRENT
+    with _CURRENT_LOCK:
+        _CURRENT = emitter
+
+
+def current_emitter() -> Emitter | None:
+    """The registered emitter, or `None` outside a run.
+
+    `None` IS A LEGITIMATE ANSWER AND IS NOT DEFAULTED PAST. A caller wraps its
+    write when there is an emitter and performs it unwrapped when there is not —
+    which is what lets `gh` be called from a helper script with no journal at
+    all. Manufacturing a throwaway emitter here would write a bag for a process
+    that is not a run, under a `run_id` nobody minted.
+    """
+    with _CURRENT_LOCK:
+        return _CURRENT
+
+
+class emitting_into:
+    """Register an emitter for the duration of a block, then restore.
+
+    Lower-case because it reads as a statement at the call site, the same
+    convention `contextlib.suppress` uses. RESTORES THE PREVIOUS VALUE rather
+    than clearing, so a nested block — a helper that opens a second bag inside a
+    run — leaves the outer run's boundary intact instead of silently detaching
+    every later write path in the process.
+    """
+
+    def __init__(self, emitter: Emitter | None) -> None:
+        self._emitter = emitter
+        self._previous: Emitter | None = None
+
+    def __enter__(self) -> Emitter | None:
+        self._previous = current_emitter()
+        register_emitter(self._emitter)
+        return self._emitter
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        register_emitter(self._previous)
+        return False

--- a/scripts/workflows/temporal/modules/journal/emit.py
+++ b/scripts/workflows/temporal/modules/journal/emit.py
@@ -570,8 +570,9 @@ class Emitter:
         except (OSError, BagError) as flag_exc:
             if not event_written:
                 raise JournalUnwritable(
-                    f"the journal cannot be written and neither can the record "
-                    f"of that: {write_path} failed with {exc.strerror}, and the "
+                    f"{UNWRITABLE_JOURNAL_MARKER}: the journal cannot be "
+                    f"written and neither can the record of that. "
+                    f"{write_path} failed with {exc.strerror}, and the "
                     f"gap event and the `incomplete` flag both failed after it.\n"
                     f"  bag: {self.bag.path}\n"
                     f"  this is requirement 4 case (d). It is reported on the "
@@ -600,6 +601,14 @@ def unwritable_journal_report(exc: JournalUnwritable, *,
     `modules/vocabulary.py` — the same declaration the journal event's own
     `terminal_state` comes from. That is requirement 3 doing its job on the one
     field that crosses both contracts on the failure path.
+
+    ⚠ THE THIRD CHANNEL IS THE PROCESS EXIT, AND IT IS ALREADY WIRED BY
+    INHERITANCE RATHER THAN BY THIS FUNCTION. `JournalUnwritable` subclasses
+    `RuntimeError`, so every entrypoint's existing `except RuntimeError: return
+    refuse(exc)` prints its message and exits non-zero — and the message now
+    LEADS with `UNWRITABLE_JOURNAL_MARKER`, so `unwritable_journal_in_text`
+    reads the process's own output as well as a PR comment. One declared
+    literal, three surfaces, and no entrypoint edited to get it.
     """
     return {
         "terminal_state": TerminalState.JOURNAL_UNWRITABLE.value,

--- a/scripts/workflows/temporal/modules/journal/emit.py
+++ b/scripts/workflows/temporal/modules/journal/emit.py
@@ -65,15 +65,22 @@ PARAMETER rather than a special case inside the function, because the caller is
 what knows which member it is holding.
 
 **(d) The bootstrap case — the journal is unwritable, so the gap event cannot go
-in the journal either.** `unwritable_journal_report` below. It surfaces on two
-channels that are not the journal, and the second is why the first is not enough:
+in the journal either.** `unwritable_journal_report` below builds the payload;
+`CASE_D_CHANNELS` above declares which surfaces actually carry it, and
+`test_the_case_d_CHANNEL_TABLE_matches_the_tree` derives that table from the tree
+rather than from this paragraph. **Read that table, not this sentence** — an
+earlier version of this paragraph named the two channels that have no producer
+and omitted the one that does.
+
+The DESIGN calls for three, and the reasoning is why the table has three rows:
 the typed exit record plus a non-zero exit status carry it out of the process,
-**and both are invocation state — read within seconds and then gone.** The
-durable half is a pull-request comment: durable, addressable, and outside the
-journal root by construction. **Not the standup tracker** — that surface is
-`tracked/operations/`, which Tracked Items §1.2 makes human-in-the-loop only with
-no autonomous write ever, and offering it here would put a binding-standard
-violation on the one path that exists to report this component being broken.
+**and both are invocation state — read within seconds and then gone**, so a
+durable half is needed too, and that is a pull-request comment: durable,
+addressable, and outside the journal root by construction. **Not the standup
+tracker** — that surface is `tracked/operations/`, which Tracked Items §1.2 makes
+human-in-the-loop only with no autonomous write ever, and offering it here would
+put a binding-standard violation on the one path that exists to report this
+component being broken.
 
 **⚠ CASE (d)'s DURABLE REPORT IS THE ONE STATED EXCEPTION TO REQUIREMENT 1's
 INVARIANT AND TO CASE (b)'s ORDERING.** The durable report is a STORE WRITE. Case
@@ -93,15 +100,24 @@ counts gaps by reading gap events; a run in case (d) produced no gap event, no
 bag and nothing to count. That is a stated limit of that measurement rather than
 a defect in it.
 
-## Requirement 11 — each signal ships with its reader, in this change
+## Requirement 11 — each signal that SHIPPED shipped with its reader
 
-The exit-record field has a named parent branch that reads it and the
-working-record line has a named consumer that surfaces it. Adding a field to a
-channel and leaving the reading to somebody later is how this fleet has already
-lost three observables, and the one channel this component's failure path depends
-on is the last place to repeat it. Both readers are `unwritable_journal_report`
-and `unwritable_journal_in_text` at the bottom of this module, and
-`test_journal_emit.py` is what holds them to the producers rather than this
+Adding a field to a channel and leaving the reading to somebody later is how this
+fleet has already lost three observables, and the one channel this component's
+failure path depends on is the last place to repeat it. So the rule here is the
+inverse of the usual one: a channel ships only WITH its reader, and a channel
+whose reader would have to be written elsewhere does not ship at all.
+
+**ONE of the three channels ships in this change and the other two do not**, per
+`CASE_D_CHANNELS` above. The process exit carries the signal — `JournalUnwritable`
+subclasses `RuntimeError`, so every entrypoint's existing handler prints a message
+LEADING with `UNWRITABLE_JOURNAL_MARKER` — and `unwritable_journal_in_text` is its
+committed reader. The durable working-record line has its producer built
+(`gh_attempt(case_d_report=True)`) and **no caller**; the exit-record field is not
+built at all, because it needs a parent branch outside this change and a field
+with no branch is precisely the observable-with-no-reader this requirement forbids.
+
+`test_journal_emit.py` holds the shipped half to its reader rather than this
 paragraph — see `test_the_marker_is_ONE_declaration_shared_by_producer_and_reader`
 and the case-(d) tests beside it.
 """
@@ -125,7 +141,8 @@ from .events import (EVENTS_FILE, Destination, EventKind, GapClass,
                      event_identity, gap_event, redaction_placeholder_event)
 
 __all__ = ["Emitter", "EmitFailed", "JournalUnwritable", "StoreWriteFailed",
-           "UNWRITABLE_JOURNAL_MARKER", "unwritable_journal_report",
+           "UNWRITABLE_JOURNAL_MARKER", "CASE_D_CHANNELS",
+           "case_d_channel_sentence", "unwritable_journal_report",
            "unwritable_journal_in_text", "gap_class_for", "register_emitter",
            "current_emitter", "emitting_into"]
 
@@ -138,6 +155,54 @@ T = TypeVar("T")
 #: `as_prose_verdict`. Distinctive enough not to appear in ordinary prose, and
 #: plain enough that a human scanning a PR thread sees it.
 UNWRITABLE_JOURNAL_MARKER = "JOURNAL-UNWRITABLE"
+
+#: THE THREE CHANNELS CASE (d) COULD REPORT ON, AND WHICH OF THEM ACTUALLY HAS A
+#: PRODUCER — declared once, as data, because stating it in prose drifted at five
+#: sites on one branch. Every one of them said case (d) *"is reported on the typed
+#: exit record and on a durable working-record surface"*; NEITHER of those has a
+#: live producer, and the channel that does — the process exit — was the one none
+#: of them named. On the single failure path where this component cannot speak for
+#: itself, that sent an operator to two surfaces carrying nothing and away from the
+#: one carrying the signal, so they conclude the report was lost.
+#:
+#: THE SECOND FIELD IS DERIVED FROM THE TREE BY
+#: `test_the_case_d_CHANNEL_TABLE_matches_the_tree`, not asserted here. That is
+#: the point: the day somebody wires the exit-record field or gives
+#: `case_d_report=True` a production caller, the test goes red against this table
+#: and the message below changes with it — rather than five paragraphs quietly
+#: becoming true one at a time while nobody re-reads them.
+CASE_D_CHANNELS: tuple[tuple[str, bool], ...] = (
+    ("the process exit — a non-zero status whose message leads with "
+     f"`{UNWRITABLE_JOURNAL_MARKER}`, which `unwritable_journal_in_text` reads",
+     True),
+    ("a durable working-record surface — a pull-request comment via "
+     "`gh_attempt(case_d_report=True)`",
+     False),
+    ("the typed exit record — a `CHILD_SCHEMA` field a parent branches on",
+     False),
+)
+
+
+def case_d_channel_sentence() -> str:
+    """The case-(d) message's channel paragraph, COMPOSED from `CASE_D_CHANNELS`.
+
+    Composed rather than written out, so the operator-facing sentence and the
+    declared table cannot disagree. The unwired channels are NAMED rather than
+    omitted: an operator who has read the phase doc knows both are planned, and a
+    message that simply left them out would read as "the report went somewhere I
+    have not been told about" — which is the same dead end by a quieter route.
+    """
+    live = [name for name, wired in CASE_D_CHANNELS if wired]
+    dead = [name for name, wired in CASE_D_CHANNELS if not wired]
+    if live:
+        sentence = "reported on " + "; and on ".join(live)
+    else:
+        sentence = "NOT REPORTED ANYWHERE — every declared channel is unbuilt"
+    if dead:
+        sentence += (". NOT on " + "; nor on ".join(dead) +
+                     " — both are declared by requirement 11 and NEITHER has a "
+                     "producer yet, so nothing will appear on them")
+    return sentence
 
 
 class EmitFailed(RuntimeError):
@@ -480,17 +545,26 @@ class Emitter:
         try:
             result = perform()
         except Exception as exc:
-            failure = JournalEvent(
-                kind=EventKind.STORE_WRITE_FAILURE, event_id=intent.event_id,
-                run_id=self.run_id, edge_id=self.edge_id,
-                key_epoch=self.key_epoch, provenance=provenance,
-                write_path=write_path, sequence=sequence,
-                destination=destination,
-                terminal_state=TerminalState.STORE_WRITE_FAILED)
             recorded = "a store-write-failure event was recorded"
+            # INSIDE THE GUARD, same class as the completion below and the intent
+            # above: `JournalEvent.__post_init__` is an admission gate that
+            # raises, and this construction sits in a handler that is ALREADY
+            # recovering from one failure — an exception escaping here would
+            # replace the store failure the caller's handlers are written against
+            # with an untyped crash. `except Exception` for the reason the
+            # completion block gives: every failure to record this has one
+            # outcome, so they get one handler.
             try:
+                failure = JournalEvent(
+                    kind=EventKind.STORE_WRITE_FAILURE,
+                    event_id=intent.event_id,
+                    run_id=self.run_id, edge_id=self.edge_id,
+                    key_epoch=self.key_epoch, provenance=provenance,
+                    write_path=write_path, sequence=sequence,
+                    destination=destination,
+                    terminal_state=TerminalState.STORE_WRITE_FAILED)
                 self._append(failure)
-            except APPEND_FAILURES:
+            except Exception:
                 # THE ORIGINAL FAILURE IS WHAT THE CALLER NEEDS, and a second
                 # exception raised from this handler would mask it. So the bag
                 # is marked instead — the record then says a write is missing
@@ -524,16 +598,35 @@ class Emitter:
                 f"happened, not what did not."
             ) from exc
 
-        completion = JournalEvent(
-            kind=EventKind.COMPLETION, event_id=intent.event_id,
-            run_id=self.run_id, edge_id=self.edge_id, key_epoch=self.key_epoch,
-            provenance=provenance, write_path=write_path, sequence=sequence,
-            destination=Destination(store=destination.store,
-                                    address=address_of(result)),
-            terminal_state=TerminalState.COMPLETED, lineage=intent.lineage)
+        # ⚠ THE COMPLETION IS BUILT INSIDE THE GUARD FOR THE REASON THE INTENT IS,
+        # AND THIS SITE WAS THE ASYMMETRIC HALF OF THAT PAIR. `address_of` is
+        # CALLER-SUPPLIED — it parses a store reply — so it can raise anything,
+        # and `JournalEvent.__post_init__` is an admission gate that raises
+        # `EventError`. Evaluated above the `try`, either escaped `paired_write`
+        # bare, AFTER the store write had already landed and was therefore
+        # unrecoverable: no `EmitFailed`, no gap event, no `incomplete` flag, and
+        # — for an `address_of` raising `IndexError` or a JSON `ValueError` —
+        # past every entrypoint's `except RuntimeError` as well. The four callers
+        # this branch ships are all defensive, so the invariant held by their
+        # good manners rather than by construction; a fifth write path whose
+        # `address_of` parses a store reply is where that stops being true.
+        #
+        # `except Exception` AND NOT `APPEND_FAILURES`, DELIBERATELY. Once
+        # `perform()` has returned, every failure in this block has ONE outcome —
+        # the store write landed and the record cannot prove it — so they get one
+        # handler. Narrowing it to the append's own exception set is what left
+        # the caller-supplied callable outside the taxonomy in the first place.
         try:
+            completion = JournalEvent(
+                kind=EventKind.COMPLETION, event_id=intent.event_id,
+                run_id=self.run_id, edge_id=self.edge_id,
+                key_epoch=self.key_epoch,
+                provenance=provenance, write_path=write_path, sequence=sequence,
+                destination=Destination(store=destination.store,
+                                        address=address_of(result)),
+                terminal_state=TerminalState.COMPLETED, lineage=intent.lineage)
             self._append(completion)
-        except APPEND_FAILURES as exc:
+        except Exception as exc:
             # ⚠ THE STORE WRITE HAS ALREADY HAPPENED, so stopping the run would
             # not un-happen it. What matters is that the record does not claim an
             # applied write it cannot prove — and an intent with no completion is
@@ -626,8 +719,12 @@ class Emitter:
         be written.
 
         **IF THE FLAG FAILS, THIS IS CASE (d) — whether or not the event
-        landed**: `JournalUnwritable` is raised, and the caller reports it on the
-        two channels that are not the journal. That is the case that makes (c)
+        landed**: `JournalUnwritable` is raised, and it carries itself out on
+        whichever channels are not the journal — `CASE_D_CHANNELS` is the
+        authority on which of the three those are, and the message composes its
+        own answer from that table rather than naming them here. That is a SIXTH
+        site: the five that named the two channels with no producer were all
+        prose asserting the same unbuilt fact. That is the case that makes (c)
         circular if it is not answered. The raise is NOT conditioned on the event
         also having failed, because nothing downstream reads a writer's
         `events.jsonl` to decide whether a bag is clean — a gap event beside a
@@ -639,15 +736,22 @@ class Emitter:
         # today only because the function is pure, which is agreement by
         # accident rather than by construction.
         gap_class = gap_class_for(exc)
-        gap = gap_event(run_id=self.run_id, edge_id=self.edge_id,
-                        key_epoch=self.key_epoch, write_path=write_path,
-                        sequence=self._next_sequence(write_path),
-                        gap_class=gap_class, lost_bytes=lost_bytes,
-                        destination=destination)
         event_written = True
+        # THE EVENT IS BUILT INSIDE THE GUARD, third member of the same class as
+        # the two sites in `paired_write`. `gap_event` constructs a
+        # `JournalEvent`, whose `__post_init__` raises `EventError` — and this
+        # function's whole job is to run on the failure path, so an exception
+        # escaping it loses the gap record AND masks the failure it was called to
+        # record. `gap_class_for` stays outside because it cannot raise and the
+        # flag below reads the same derivation (ONE derivation, read twice).
         try:
+            gap = gap_event(run_id=self.run_id, edge_id=self.edge_id,
+                            key_epoch=self.key_epoch, write_path=write_path,
+                            sequence=self._next_sequence(write_path),
+                            gap_class=gap_class, lost_bytes=lost_bytes,
+                            destination=destination)
             self._append(gap)
-        except APPEND_FAILURES:
+        except Exception:
             event_written = False
 
         try:
@@ -672,29 +776,37 @@ class Emitter:
                 f"{UNWRITABLE_JOURNAL_MARKER}: the journal cannot be "
                 f"written and neither can the record of that. "
                 f"{write_path} failed with {failure_detail(exc)}, and the "
-                f"`incomplete` flag failed after it — {landed}.\n"
+                f"`incomplete` flag failed after it with "
+                f"{failure_detail(flag_exc)} — {landed}.\n"
                 f"  bag: {self.bag.path}\n"
-                f"  this is requirement 4 case (d). It is reported on the "
-                f"typed exit record and on a durable working-record surface, "
-                f"because the journal is not available to report it."
+                f"  this is requirement 4 case (d), and it is "
+                f"{case_d_channel_sentence()}."
             ) from flag_exc
 
 
 # ---------------------------------------------------------------------------
-# Requirement 11 — the two channels case (d) reports on, WITH their readers.
+# Requirement 11 — the case-(d) signal and its reader. `CASE_D_CHANNELS` above
+# is the authority on WHICH channels carry it; exactly one does today, and this
+# section builds the payload and the reader for all three so that wiring the
+# other two is a call site rather than a contract.
 # ---------------------------------------------------------------------------
 
 def unwritable_journal_report(exc: JournalUnwritable, *,
                               bag_path: Path | None = None) -> dict[str, str]:
-    """PRODUCER for both channels: the exit-record field and the durable line.
+    """The case-(d) payload, in the one shape all three channels would carry.
 
-    ONE FUNCTION FOR BOTH so the two cannot disagree about what happened. The
-    exit record is read within seconds and then gone; the durable half is a
-    pull-request comment, which is durable, addressable, and outside the journal
-    root by construction. **Both are needed and neither is sufficient** — the
-    first because a parent has to route on it in-process, the second because
-    every consumer this component builds reads the record long after the process
-    is gone.
+    ONE FUNCTION FOR ALL OF THEM so no two channels can disagree about what
+    happened. **It has NO PRODUCTION CALLER TODAY, and that is stated rather than
+    implied**: `CASE_D_CHANNELS` above is the authority, and the only channel with
+    a live producer is the process exit — which is wired by INHERITANCE (see the
+    warning below) and does not call this function. This exists so that wiring
+    either remaining channel is a call site rather than a contract.
+
+    The design needs all three and none is sufficient alone: the exit record
+    because a parent has to route on it in-process, the durable pull-request
+    comment because every consumer this component builds reads the record long
+    after the process is gone, and the exit status because it is the only one
+    that needs nothing built.
 
     `terminal_state` IS `TerminalState.JOURNAL_UNWRITABLE`, from
     `modules/vocabulary.py` — the same declaration the journal event's own
@@ -718,7 +830,9 @@ def unwritable_journal_report(exc: JournalUnwritable, *,
 
 
 def unwritable_journal_in_text(text: str) -> bool:
-    """READER of the durable half. The named consumer requirement 11 demands.
+    """READER for every channel that carries the marker — the named consumer
+    requirement 11 demands, and today that is the PROCESS OUTPUT rather than the
+    durable half, because the durable half has no producer (`CASE_D_CHANNELS`).
 
     A SUBSTRING TEST AGAINST THE ONE DECLARED MARKER, and it is deliberately not
     a parse. The durable channel is a PR comment written by a run whose journal

--- a/scripts/workflows/temporal/modules/journal/emit.py
+++ b/scripts/workflows/temporal/modules/journal/emit.py
@@ -188,9 +188,21 @@ def case_d_channel_sentence() -> str:
 
     Composed rather than written out, so the operator-facing sentence and the
     declared table cannot disagree. The unwired channels are NAMED rather than
-    omitted: an operator who has read the phase doc knows both are planned, and a
+    omitted: an operator who has read the phase doc knows they are planned, and a
     message that simply left them out would read as "the report went somewhere I
     have not been told about" — which is the same dead end by a quieter route.
+
+    ⚠ THE AGREEMENT IS DERIVED TOO, AND TAKING THE NAMES FROM THE TABLE WHILE
+    SPELLING THE COUNT BY HAND WAS THE DEFECT. This function used to compose the
+    names from `CASE_D_CHANNELS` and then hardcode *"both are declared … NEITHER
+    has a producer … appear on them"*. Driven with a one-dead-channel table it
+    emitted three false plurals about a single channel — and
+    `test_the_case_d_CHANNEL_TABLE_matches_the_tree` stayed green, because it
+    compares the table against the tree and never reads this sentence. The day
+    somebody wires one of the two, the table flips correctly and the message on
+    the one path where this component cannot speak for itself starts asserting an
+    unbuilt fact in the present tense: the precise defect `CASE_D_CHANNELS` was
+    declared to stop, surviving in the composer that reads it.
     """
     live = [name for name, wired in CASE_D_CHANNELS if wired]
     dead = [name for name, wired in CASE_D_CHANNELS if not wired]
@@ -199,9 +211,20 @@ def case_d_channel_sentence() -> str:
     else:
         sentence = "NOT REPORTED ANYWHERE — every declared channel is unbuilt"
     if dead:
-        sentence += (". NOT on " + "; nor on ".join(dead) +
-                     " — both are declared by requirement 11 and NEITHER has a "
-                     "producer yet, so nothing will appear on them")
+        # THE WHOLE CLAUSE IS SELECTED BY CARDINALITY, not assembled from three
+        # independently-agreeing fragments. Assembling it is how "NEITHER has a
+        # producer" becomes "IT has a producer" — a negation that inverts when its
+        # quantifier is swapped word-for-word.
+        if len(dead) == 1:
+            clause = ("it is declared by requirement 11 and has NO producer yet, "
+                      "so nothing will appear on it")
+        elif len(dead) == 2:
+            clause = ("both are declared by requirement 11 and NEITHER has a "
+                      "producer yet, so nothing will appear on them")
+        else:
+            clause = (f"all {len(dead)} are declared by requirement 11 and NONE "
+                      f"has a producer yet, so nothing will appear on them")
+        sentence += ". NOT on " + "; nor on ".join(dead) + f" — {clause}"
     return sentence
 
 

--- a/scripts/workflows/temporal/modules/journal/emit.py
+++ b/scripts/workflows/temporal/modules/journal/emit.py
@@ -101,8 +101,9 @@ channel and leaving the reading to somebody later is how this fleet has already
 lost three observables, and the one channel this component's failure path depends
 on is the last place to repeat it. Both readers are `unwritable_journal_report`
 and `unwritable_journal_in_text` at the bottom of this module, and
-`test_the_unwritable_journal_signal_HAS_a_reader.py` is what holds them to the
-producers rather than this paragraph.
+`test_journal_emit.py` is what holds them to the producers rather than this
+paragraph — see `test_the_marker_is_ONE_declaration_shared_by_producer_and_reader`
+and the case-(d) tests beside it.
 """
 
 from __future__ import annotations
@@ -181,8 +182,55 @@ class JournalUnwritable(RuntimeError):
     terminal_state = TerminalState.JOURNAL_UNWRITABLE
 
 
-def gap_class_for(exc: OSError) -> GapClass:
-    """An `OSError` as one of four closed classes — never as its message.
+#: What the append boundary converts into a typed case rather than letting
+#: escape. `OSError` is the DISK; `UnicodeError` is the CONTENT — a lone
+#: surrogate reaching `encode` raises `UnicodeEncodeError`, which is a
+#: `ValueError` and therefore joins none of this module's `except OSError`
+#: clauses. It escaped `paired_write` as an untyped crash, past all four cases
+#: and past every entrypoint's `except RuntimeError`, until a probe raised it on
+#: this branch. `edge_id.read_edge_id` had already met the same trap from the
+#: decode side, which is why it names `UnicodeDecodeError` separately.
+APPEND_FAILURES = (OSError, UnicodeError)
+
+
+def failure_detail(exc: BaseException) -> str:
+    """One line naming what failed, FOR AN EXCEPTION MESSAGE and never for the record.
+
+    `strerror` when there is one, the type and text when there is not — a
+    `UnicodeEncodeError` has no `strerror`, and reading the attribute off it
+    would raise a second exception out of the handler for the first.
+
+    THE RECORD STILL GETS NEITHER. `gap_class_for` below is what reaches the
+    journal, and it is a closed set for the reason stated there; this is the
+    operator-facing half the module docstring promises on stderr.
+
+    ⚠ THE TYPE AND THE TEXT ARE JOINED BY AN EM DASH, NOT BY A COLON, and that
+    is not cosmetic: `test_journal_tag_lines` sweeps this package for
+    `f"{value}: …"` and refuses any such composition whose value is not proven
+    unable to fold a tag line. This value is free text from an exception and CAN
+    carry a newline — it simply never reaches a tag line. Spelling it as a
+    label/value pair would either forge a false positive forever or need an
+    exemption row, and an exemption is the thing this package has learned not to
+    hand out: five forging escapes had exactly that shape.
+    """
+    detail = getattr(exc, "strerror", None)
+    return detail if detail else f"{type(exc).__name__} — {exc}"
+
+
+def utf8_len(text: str) -> int:
+    """Byte length that cannot itself raise, for use on the failure path.
+
+    `errors="replace"` because this is called while ALREADY handling a failed
+    write — including one caused by content that cannot be encoded at all. A
+    plain `.encode()` here would raise out of the handler and lose the gap
+    record, which is the silent loss this component exists to prevent. The
+    number is a report of magnitude, not a checksum.
+    """
+    return len(text.encode("utf-8", "replace"))
+
+
+def gap_class_for(exc: BaseException) -> GapClass:
+    """A failed append as one of four closed classes — never as its message.
 
     THE MESSAGE IS DELIBERATELY DISCARDED. A gap event reports that content was
     lost; a `why` carrying `exc.strerror` or `exc.filename` would put the failing
@@ -194,11 +242,12 @@ def gap_class_for(exc: OSError) -> GapClass:
     module raises. What is bounded is what reaches the DURABLE record, which is
     the surface Phase 7 syncs to object storage and Phase 4 replays.
     """
-    if exc.errno in (errno.ENOSPC, errno.EDQUOT):
+    code = getattr(exc, "errno", None)
+    if code in (errno.ENOSPC, errno.EDQUOT):
         return GapClass.DISK_FULL
-    if exc.errno in (errno.EROFS, errno.EACCES, errno.EPERM):
+    if code in (errno.EROFS, errno.EACCES, errno.EPERM):
         return GapClass.READ_ONLY
-    if exc.errno in (errno.ENOENT, errno.ENOTDIR, errno.ESTALE):
+    if code in (errno.ENOENT, errno.ENOTDIR, errno.ESTALE):
         return GapClass.PATH_GONE
     return GapClass.WRITE_FAILED
 
@@ -401,16 +450,27 @@ class Emitter:
         happened, not complete what did not.*
         """
         sequence = self._next_sequence(write_path)
-        intent = self._build(kind=EventKind.INTENT, write_path=write_path,
-                             sequence=sequence, destination=destination,
-                             content=content, provenance=provenance,
-                             lineage=lineage or Lineage())
+        # ⚠ `_build` IS INSIDE THE GUARD, NOT ABOVE IT, AND THAT PLACEMENT IS THE
+        # FIX FOR A REAL ESCAPE. `_build` appends a redaction placeholder of its
+        # own whenever the capture filter fires, and it encodes the content to
+        # count its bytes — so it performs I/O and it encodes, and BOTH can fail.
+        # Built above the `try`, a filter that fired on a read-only mount raised a
+        # bare `PermissionError` straight out of this function: no `EmitFailed`,
+        # no gap, no `incomplete` flag, and past every entrypoint's
+        # `except RuntimeError`. Demonstrated on this branch, against a real bag,
+        # with the same call succeeding as `EmitFailed` when the filter did not
+        # fire — which is what made the placeholder append the only difference.
         try:
+            intent = self._build(kind=EventKind.INTENT, write_path=write_path,
+                                 sequence=sequence, destination=destination,
+                                 content=content, provenance=provenance,
+                                 lineage=lineage or Lineage())
             self._append(intent)
-        except OSError as exc:
+        except APPEND_FAILURES as exc:
             raise EmitFailed(
                 f"the intent event for {write_path} could not be written to "
-                f"{self.events_path} — {exc.strerror}. The store write was NOT "
+                f"{self.events_path} — {failure_detail(exc)}. The store write "
+                f"was NOT "
                 f"performed, so neither side of this write happened and the "
                 f"record is short but not wrong.\n"
                 f"  the run stops here rather than continuing: every later "
@@ -427,28 +487,39 @@ class Emitter:
                 write_path=write_path, sequence=sequence,
                 destination=destination,
                 terminal_state=TerminalState.STORE_WRITE_FAILED)
+            recorded = "a store-write-failure event was recorded"
             try:
                 self._append(failure)
-            except OSError:
+            except APPEND_FAILURES:
                 # THE ORIGINAL FAILURE IS WHAT THE CALLER NEEDS, and a second
                 # exception raised from this handler would mask it. So the bag
                 # is marked instead — the record then says a write is missing
                 # even though it could not say which.
+                recorded = ("its store-write-failure event could NOT be written "
+                            "and the bag was marked incomplete instead")
                 try:
                     self.bag.mark_incomplete(
                         write_path, "store write failed and its failure event "
                                     "could not be written")
                 except (OSError, BagError):
-                    # NAMED, NOT SWALLOWED SILENTLY: what is ignored is a failed
-                    # `incomplete` flag while already handling a failed store
-                    # write AND a failed failure-event. At that point the journal
-                    # is gone, `StoreWriteFailed` below is what the caller needs
-                    # to see, and case (d) reporting is the caller's to do from
-                    # the exception it is about to receive.
-                    pass
+                    # ⚠ NEITHER THE EVENT NOR THE FLAG LANDED, so nothing in the
+                    # journal says this write is missing — which is case (d)
+                    # reached from the store-failure path. `StoreWriteFailed` is
+                    # still what the caller needs (its handlers are written
+                    # against the store failure), so the journal's death is
+                    # carried OUT on this message rather than replacing it, and
+                    # it LEADS with the one declared marker so
+                    # `unwritable_journal_in_text` reads it on the process
+                    # channel exactly as it reads a durable comment. Swallowing
+                    # it — which this did — left the single case where the
+                    # journal is gone and no surface says so.
+                    recorded = (f"{UNWRITABLE_JOURNAL_MARKER}: neither the "
+                                f"store-write-failure event nor the incomplete "
+                                f"flag could be written, so the journal says "
+                                f"nothing about this write at all")
             raise StoreWriteFailed(
                 f"the store write for {write_path} failed after its intent "
-                f"landed: {exc}. A store-write-failure event was recorded, so "
+                f"landed: {exc}. {recorded}, so "
                 f"replay will not apply the intent — Phase 4 rebuilds what "
                 f"happened, not what did not."
             ) from exc
@@ -462,7 +533,7 @@ class Emitter:
             terminal_state=TerminalState.COMPLETED, lineage=intent.lineage)
         try:
             self._append(completion)
-        except OSError as exc:
+        except APPEND_FAILURES as exc:
             # ⚠ THE STORE WRITE HAS ALREADY HAPPENED, so stopping the run would
             # not un-happen it. What matters is that the record does not claim an
             # applied write it cannot prove — and an intent with no completion is
@@ -471,10 +542,11 @@ class Emitter:
             # would be conditioned on it.
             self._record_gap(write_path=write_path, exc=exc,
                              destination=destination,
-                             lost_bytes=len(content.encode("utf-8")))
+                             lost_bytes=utf8_len(content))
             raise EmitFailed(
                 f"the completion event for {write_path} could not be written — "
-                f"{exc.strerror}. The store write DID land; the journal cannot "
+                f"{failure_detail(exc)}. The store write DID land; the journal "
+                f"cannot "
                 f"prove it, so replay will not apply the intent and the bag is "
                 f"marked incomplete."
             ) from exc
@@ -518,26 +590,31 @@ class Emitter:
         by *"neither side is written"*, and it is a materially weaker guarantee.
         """
         sequence = self._next_sequence(write_path)
-        event = self._build(kind=EventKind.COMPLETION, write_path=write_path,
-                            sequence=sequence, destination=destination,
-                            content=content, provenance=provenance,
-                            lineage=lineage or Lineage())
+        # INSIDE THE GUARD for the reason `paired_write` states — and it matters
+        # more here, because this case has no store write to withhold. A
+        # placeholder append that escaped uncaught would lose the content AND the
+        # gap record, which is the silent gap this whole component is named after.
         try:
+            event = self._build(kind=EventKind.COMPLETION, write_path=write_path,
+                                sequence=sequence, destination=destination,
+                                content=content, provenance=provenance,
+                                lineage=lineage or Lineage())
             self._append(event)
-        except OSError as exc:
+        except APPEND_FAILURES as exc:
             self._record_gap(write_path=write_path, exc=exc,
                              destination=destination,
-                             lost_bytes=len(content.encode("utf-8")))
+                             lost_bytes=utf8_len(content))
             if stop_on_failure:
                 raise EmitFailed(
                     f"{write_path} could not be written to the journal — "
-                    f"{exc.strerror} — and this write path stops the run. It is "
+                    f"{failure_detail(exc)} — and this write path stops the run. "
+                    f"It is "
                     f"the fleet's only record of what commands ran, under "
                     f"bypassed permissions; continuing past it would be evidence "
                     f"loss wearing a routine defect's clothes."
                 ) from exc
 
-    def _record_gap(self, *, write_path: str, exc: OSError,
+    def _record_gap(self, *, write_path: str, exc: BaseException,
                     destination: Destination, lost_bytes: int) -> None:
         """Case (c)'s record, and case (d) is what happens when even this fails.
 
@@ -548,37 +625,59 @@ class Emitter:
         and Phase 7 branch on — so it is attempted even when the event could not
         be written.
 
-        **If BOTH fail, the journal is unwritable and this is case (d)**:
-        `JournalUnwritable` is raised, and the caller reports it on the two
-        channels that are not the journal. That is the case that makes (c)
-        circular if it is not answered.
+        **IF THE FLAG FAILS, THIS IS CASE (d) — whether or not the event
+        landed**: `JournalUnwritable` is raised, and the caller reports it on the
+        two channels that are not the journal. That is the case that makes (c)
+        circular if it is not answered. The raise is NOT conditioned on the event
+        also having failed, because nothing downstream reads a writer's
+        `events.jsonl` to decide whether a bag is clean — a gap event beside a
+        missing flag is a bag that lost data and reads as complete, which is the
+        outcome this function exists to prevent.
         """
+        # ONE DERIVATION, READ TWICE. Computed once so the event's class and the
+        # flag's reason cannot disagree about what happened — two calls agree
+        # today only because the function is pure, which is agreement by
+        # accident rather than by construction.
+        gap_class = gap_class_for(exc)
         gap = gap_event(run_id=self.run_id, edge_id=self.edge_id,
                         key_epoch=self.key_epoch, write_path=write_path,
                         sequence=self._next_sequence(write_path),
-                        gap_class=gap_class_for(exc), lost_bytes=lost_bytes,
+                        gap_class=gap_class, lost_bytes=lost_bytes,
                         destination=destination)
         event_written = True
         try:
             self._append(gap)
-        except OSError:
+        except APPEND_FAILURES:
             event_written = False
 
         try:
             self.bag.mark_incomplete(
-                write_path, f"emit failed: {gap_class_for(exc).value}")
+                write_path, f"emit failed: {gap_class.value}")
         except (OSError, BagError) as flag_exc:
-            if not event_written:
-                raise JournalUnwritable(
-                    f"{UNWRITABLE_JOURNAL_MARKER}: the journal cannot be "
-                    f"written and neither can the record of that. "
-                    f"{write_path} failed with {exc.strerror}, and the "
-                    f"gap event and the `incomplete` flag both failed after it.\n"
-                    f"  bag: {self.bag.path}\n"
-                    f"  this is requirement 4 case (d). It is reported on the "
-                    f"typed exit record and on a durable working-record surface, "
-                    f"because the journal is not available to report it."
-                ) from flag_exc
+            # ⚠ A FAILED FLAG RAISES WHETHER OR NOT THE EVENT LANDED, and the
+            # earlier `if not event_written` guard here was the one hole in *a
+            # gap may exist; a silent gap may not*. The flag is the MORE
+            # important of the two writes — Phase 4, Phase 6 and Phase 7 branch
+            # on it, and none of them reads a writer's `events.jsonl` to decide
+            # whether a bag is clean. So a gap event that landed beside a flag
+            # that did not produced a bag which LOST DATA AND READS AS COMPLETE,
+            # returning normally with no signal to any caller: exactly the
+            # outcome Phase 1's four-state design exists to prevent, reached
+            # through the function that exists to prevent it.
+            landed = ("the gap event landed but nothing downstream reads it to "
+                      "decide a bag is clean"
+                      if event_written else
+                      "neither the gap event nor the flag landed")
+            raise JournalUnwritable(
+                f"{UNWRITABLE_JOURNAL_MARKER}: the journal cannot be "
+                f"written and neither can the record of that. "
+                f"{write_path} failed with {failure_detail(exc)}, and the "
+                f"`incomplete` flag failed after it — {landed}.\n"
+                f"  bag: {self.bag.path}\n"
+                f"  this is requirement 4 case (d). It is reported on the "
+                f"typed exit record and on a durable working-record surface, "
+                f"because the journal is not available to report it."
+            ) from flag_exc
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/workflows/temporal/modules/journal/events.py
+++ b/scripts/workflows/temporal/modules/journal/events.py
@@ -217,12 +217,27 @@ def event_identity(*, run_id: str, write_path: str, sequence: int) -> str:
     on which one got there first, so a retry of either would mint a new identity
     rather than re-deriving its own.
 
-    ⚠ WHAT THIS DOES NOT ESTABLISH: an ORDER across writers. Two children each
-    emitting `seq=1` are unordered relative to each other, and nothing here says
-    which came first. That is the same limit `Bag.writer_dir` states, and it is
-    survivable for the same reason: today parallel children are read-only critics
-    and a single analyst writes. The day two concurrent children write to one
-    store, this needs a sequence number that spans them.
+    ⚠ WHAT THIS DOES NOT ESTABLISH, AND THE CONSEQUENCE IS WORSE THAN "UNORDERED".
+    This paragraph used to say only that two children each emitting `seq=1` are
+    unordered relative to each other. They are — and they also derive the SAME
+    `event_id`, because the material is `(run_id, write_path, sequence)` and a
+    writer contributes nothing to it. `dedupe_on_identity` keys on
+    `(event_id, kind)` and keeps the FIRST, so on replay the second writer's
+    distinct, successfully-written completion is DROPPED: not an ambiguity about
+    order, real data loss, and precisely the silent gap cases (b) and (c) exist to
+    forbid. The counter is per-`Emitter` (`Emitter._sequences`), and
+    `Bag.writer_dir` gives each writer its own `events.jsonl` — so within one
+    writer this cannot happen and across two it is unguarded.
+
+    IT IS UNREACHABLE TODAY AND NOTHING ENFORCES THAT, which is also stated rather
+    than left implied. It needs two concurrent writers in ONE run emitting on the
+    SAME `write_path`; today parallel children are read-only critics and a single
+    analyst writes, so no second writer performs a store write at all. That is a
+    property of the current wiring, not an invariant this module holds.
+    **Trigger: the second concurrent writer that performs a store write.** The
+    remedy is a sequence number that spans writers — or a writer key in the
+    identity material — and it is a schema question, so it is named here rather
+    than reached for now.
     """
     if sequence < 0:
         raise EventError(

--- a/scripts/workflows/temporal/modules/journal/events.py
+++ b/scripts/workflows/temporal/modules/journal/events.py
@@ -1,0 +1,499 @@
+"""The journal event — one contract, four admission fields, never mutated.
+
+THIS IS PHASE 3's CONTRACT AND IT IS SEPARATE FROM THE TYPED EXIT RECORD'S, for
+a reason that is a standard rather than a preference. `exit-protocol.md` §2 says
+*"no field is added on behalf of a consumer that does not exist"* and §2.5 bounds
+that record's fixed part at 4096 bytes. Requirement 7 adds event identity, a
+credential epoch and a provenance class; requirements 1, 5 and 6 add destination,
+lineage and `edge_id`. **No parent branches on any of the six**, so the first rule
+rejects every one of them — and an event carries authored content verbatim, which
+one measured `research_minor` cycle put at 39,772 bytes against a 4096-byte bound.
+An extension is therefore not available; two contracts sharing one vocabulary is.
+`modules/vocabulary.py` is that vocabulary and this module imports it rather than
+respelling anything in it.
+
+THE DESTINATION IS A FIELD, NOT A FORMAT (requirement 2). git, SQLite, a GitHub
+object, an MQTT topic on an edge with no repo — the event is byte-identical in
+shape whichever it was, because that is what makes a record portable across edges
+and it is what Phase 7 depends on. `Destination` below carries the store's name
+and its address; nothing about the event's serialisation varies with it.
+
+AN EVENT RECORDS AN INTENT, AND A SECOND EVENT RECORDS THE FACT. Write-ahead
+ordering protects exactly one of the three ways a paired write can break, and the
+phase doc's § *Why one event per write is not enough* names the other two: a
+store write that fails after a successful emit makes the journal claim content
+the store never got — and Phase 4 would then REPLAY it, materialising unpublished
+content nobody approved — and a retried activity re-runs both side effects. A
+third thing one event cannot carry is the store's own address, which a GitHub
+comment does not have until after it exists and which requirement 8 forbids
+adding by editing the event. So a paired write is ONE UNIT WITH TWO EVENTS
+sharing one identity, and `applied_intents` below is the replay rule that makes
+the first two failures visible: **an intent with no completion is not applied**.
+
+EVERY EVENT CARRIES A SCHEMA VERSION AND NO WRITTEN EVENT IS EVER CHANGED
+(requirement 8). The version is `bag.JOURNAL_SCHEMA_VERSION`, declared there in
+Phase 1 and honoured here — not a second constant. A journal written under v1
+must still replay under v3 forever; the settled answer is version every event,
+never mutate a written one, upcast on read. The upcaster's mechanism is open
+(roadmap § *Open inputs* item 2) and this module does not close it — but an
+unversioned v1 event is unrecoverable, so the field ships now.
+
+⚠ `edge_id` IS SELF-REPORTED AND IS NOT AN ATTRIBUTION CONTROL. Requirement 7(b)
+is explicit: the target is an id assigned by an authenticating authority and
+bound at ingest, and there is no ingest tier in this design — Phase 7 syncs
+sealed bags straight to object storage and a receiver cannot rebind a field
+inside a sealed bag without invalidating its manifest. So until an authenticating
+ingest exists, any holder of a valid credential can author events attributed to
+another edge, and this doc says so rather than stating a guarantee nothing
+enforces. The control that DOES exist in this topology is Phase 7 r5's: a
+per-machine storage credential scoped to that machine's own prefix, with origin
+derived from the prefix and a prefix/`edge_id` disagreement reported as a
+finding. The field stays on the event because a reader needs something to filter
+on and because a later ingest tier can begin binding it with no schema change.
+
+⚠ AND NO EVENT EVER CARRIES A KEY OR A VALUE DERIVED FROM ONE. `key_epoch` is an
+opaque non-secret label — requirement 7(c) — explicitly not derived from the key
+it names. `hash(api_key)` is ruled out twice over: it changes on rotation, which
+is the bug `edge_id` exists to prevent, and a stored hash of a live credential is
+an offline confirmation oracle. `edge_id.py` holds that constraint at the point
+of derivation; this module holds it at the point of admission.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+from ..vocabulary import Outcome, TerminalState
+from .bag import JOURNAL_SCHEMA_VERSION, utc_now
+
+__all__ = ["EventKind", "Provenance", "Destination", "Lineage", "JournalEvent",
+           "EventError", "event_identity", "dedupe_on_identity",
+           "applied_intents", "gap_event", "redaction_placeholder_event",
+           "EVENTS_FILE", "encode_event", "decode_event", "GapClass"]
+
+
+#: The file one writer appends its events to, inside its own payload subfolder.
+#: JSON Lines: one event per line, appended, never rewritten. A line-oriented
+#: format is what makes "append-only" a property of the WRITE rather than a
+#: promise about the writer — a re-serialised array would rewrite every prior
+#: event on every append, which is exactly what requirement 8 forbids.
+EVENTS_FILE = "events.jsonl"
+
+
+class EventError(RuntimeError):
+    """An event could not be constructed or admitted.
+
+    `RuntimeError` for the reason `BagError` and `JournalRootError` are: every
+    entrypoint already carries `except RuntimeError` around its preconditions,
+    and the message is the diagnostic.
+    """
+
+
+class EventKind(str, Enum):
+    """What kind of record this event is. Five, and the set is closed.
+
+    `INTENT` and `COMPLETION` are the two halves of one paired write, sharing one
+    identity. `STORE_WRITE_FAILURE` takes the completion's place when the store
+    write failed after its intent landed — it is what stops Phase 4 replaying an
+    intent into content nobody published.
+
+    `GAP` is requirement 4 case (c): a write with no pairable store write whose
+    emit failed. It is a CLOSED TYPED FIELD SET and never free text — see
+    `gap_event` for why that is a security property and not a style rule.
+
+    `REDACTION_PLACEHOLDER` is requirement 10's: capture-time filtering removed
+    bytes before they reached the journal root, and the record stays complete
+    about the FACT of the removal rather than being silently shorter.
+    """
+
+    INTENT = "intent"
+    COMPLETION = "completion"
+    STORE_WRITE_FAILURE = "store_write_failure"
+    GAP = "gap"
+    REDACTION_PLACEHOLDER = "redaction_placeholder"
+
+
+class Provenance(str, Enum):
+    """What kind of thing this content is BY ORIGIN — requirement 7(d).
+
+    Three trust classes enter the journal and without a field every downstream
+    reader sees one undifferentiated stream. **Phase 8's poller is the consumer
+    that makes this sharp** — it reads a row and *starts work*, so the field it
+    filters on has to exist on the event and survive Phase 4's rebuild.
+
+    `FETCHED` is the one that carries the actual risk: bytes from the internet
+    arrive via tool results in the transcript and wholesale via Phase 2's content
+    store, and a poller that cannot tell them from fleet-authored prose is a
+    poller that can be instructed by a web page.
+
+    A field absent from version-1 events is absent forever, which is why this
+    lands here rather than at the phase that first needs it.
+    """
+
+    FLEET_AUTHORED = "fleet_authored"
+    OPERATOR_AUTHORED = "operator_authored"
+    FETCHED = "fetched"
+
+
+class GapClass(str, Enum):
+    """Why a gap happened, as a closed set — never an exception message.
+
+    THE CLOSED SET IS THE SECURITY PROPERTY. A gap event reports that content was
+    lost; if its `why` were derived from the content or from an exception string,
+    the report would become a side channel for exactly the bytes it exists to say
+    were dropped — and a gap event is written on the failure path, which is the
+    least-reviewed path there is. Four classes, a byte count and a timestamp cost
+    a few hundred bytes and cannot leak.
+    """
+
+    DISK_FULL = "disk_full"
+    READ_ONLY = "read_only"
+    PATH_GONE = "path_gone"
+    WRITE_FAILED = "write_failed"
+
+
+@dataclass(frozen=True)
+class Destination:
+    """WHERE the content went. Requirement 2 — a field, never a format.
+
+    `store` names the surface (`github`, `tracked_issues`, `git`, `filesystem`);
+    `address` is what identifies the object within it, and it is EMPTY ON AN
+    INTENT by construction. A GitHub comment has no id or URL until after it is
+    created, and requirement 8 forbids changing a written event — which is the
+    third reason a paired write needs two events rather than one.
+    """
+
+    store: str
+    address: str = ""
+
+
+@dataclass(frozen=True)
+class Lineage:
+    """Which input item produced this output item — requirement 5.
+
+    n8n's `pairedItem`, which records which output came from which input by
+    index. **A decision was made in session that this did not transfer, and it
+    was reversed against the evidence:** the argument was that our children run
+    in sequence, and the 2026-08-12 verify round dispatched two critics 21
+    seconds apart. Fan-out is real today, so *"which output came from which
+    input"* is a question about our own runs that we currently cannot answer.
+
+    `input_ref` is the identity of the producing event (or the opaque id of a
+    non-event input such as a task file); `input_index` is its position in the
+    fan-out, which is what makes a round traceable output-to-input rather than
+    merely output-to-parent. Both are optional because a run's FIRST emit has no
+    producing input, and a required field nobody can fill is the self-inflicted
+    absence `exit_record.CHILD_SCHEMA` already documents.
+    """
+
+    input_ref: str | None = None
+    input_index: int | None = None
+
+
+def event_identity(*, run_id: str, write_path: str, sequence: int) -> str:
+    """The deterministic identity every event carries — requirement 7(a).
+
+    AGAINST AN AT-LEAST-ONCE EXECUTION MODEL. Temporal executes an activity at
+    least once, which is why Temporal Standard §7.1 requires every activity to be
+    idempotent — a retried activity re-runs its side effects. An append-only
+    journal fed by retried activities accumulates duplicate events, and Phase 4's
+    replay then rebuilds a store with duplicated rows, or worse passes under a
+    normalisation that hides them.
+
+    DERIVED FROM `(run_id, write_path, sequence)` AND NOTHING ELSE — deliberately
+    NOT from the content. A content hash would give two identical comments posted
+    to two different PRs the same identity, and would give one comment re-authored
+    with a typo fix a different one; neither is the question. The question is
+    *which write of which run is this*, and the retry that this defends against
+    re-runs the same write of the same run, so it re-derives the same identity.
+
+    `sequence` IS PER `(run_id, write_path)`, NOT GLOBAL. A global counter would
+    need a single writer across a fan-out — precisely what `Bag.writer_dir`
+    exists to avoid — and would make two concurrent children's identities depend
+    on which one got there first, so a retry of either would mint a new identity
+    rather than re-deriving its own.
+
+    ⚠ WHAT THIS DOES NOT ESTABLISH: an ORDER across writers. Two children each
+    emitting `seq=1` are unordered relative to each other, and nothing here says
+    which came first. That is the same limit `Bag.writer_dir` states, and it is
+    survivable for the same reason: today parallel children are read-only critics
+    and a single analyst writes. The day two concurrent children write to one
+    store, this needs a sequence number that spans them.
+    """
+    if sequence < 0:
+        raise EventError(
+            f"sequence must be non-negative, got {sequence}. A negative "
+            f"sequence would let two writes of one path derive one identity, "
+            f"which is the duplicate this field exists to make impossible.")
+    material = f"{run_id}\x00{write_path}\x00{sequence}".encode()
+    return hashlib.sha256(material).hexdigest()[:32]
+
+
+@dataclass(frozen=True)
+class JournalEvent:
+    """One entry in the journal. Appended, never changed.
+
+    THE FOUR ADMISSION FIELDS ARE ONE DECISION, NOT FOUR (requirement 7):
+    `event_id` (identity, against at-least-once execution), `edge_id`
+    (authority — self-reported today, and stated as such), `key_epoch`
+    (credential epoch, so compromise has a boundary) and `provenance` (trust
+    class by origin). They land together in version-1 events because a field
+    absent from version-1 events is absent forever.
+
+    ⚠ `key_epoch` IS THE ONE ADMISSION FIELD WITH NO CONSUMER TODAY, and it is
+    stated the way Phase 1 r7's classification slot is rather than left to look
+    like an oversight. Its consumer is *a replay scoped to exclude an epoch*,
+    which nothing needs until a credential is known to have leaked.
+    **Trigger: the first credential revocation.** It lands now anyway because an
+    epoch that starts being recorded on the day of a leak cannot bound the events
+    written before it. Phase 6 r3's producer/consumer table records this as a
+    knowingly-empty cell WITH its trigger, not as a blank one.
+
+    `content` IS VERBATIM AND `content_bytes` IS ITS LENGTH AS WRITTEN. The two
+    are separate because a redaction placeholder replaces `content` and must
+    still report how much was dropped — a record that got shorter with no number
+    beside it is the silent gap this component exists to prevent.
+    """
+
+    kind: EventKind
+    event_id: str
+    run_id: str
+    edge_id: str
+    key_epoch: str
+    provenance: Provenance
+    write_path: str
+    sequence: int
+    destination: Destination
+    content: str = ""
+    content_bytes: int = 0
+    lineage: Lineage = field(default_factory=Lineage)
+    outcome: Outcome | None = None
+    terminal_state: TerminalState | None = None
+    recorded_at: str = field(default_factory=utc_now)
+    schema_version: int = JOURNAL_SCHEMA_VERSION
+    gap_class: GapClass | None = None
+
+    def __post_init__(self) -> None:
+        """Admission, at construction, so an inadmissible event cannot be written.
+
+        THE CHECKS ARE THE CONTRACT'S TEETH. Requirement 7 is *"the event
+        admission contract is SPECIFIED"* — and this component's own argument,
+        made three times in the phase doc, is that a rule written only as prose
+        has not once prevented the thing it forbids. Every one of these is a
+        rule the doc states; they are here rather than in a validator because a
+        validator runs on a bag that already contains the bad event.
+        """
+        if not self.run_id:
+            raise EventError(
+                "an event with no run_id cannot be joined to anything. The "
+                "journal is keyed by run id (Phase 1 r2), so this event would "
+                "land in a bag and be unreachable from the run that wrote it.")
+        if not self.edge_id:
+            raise EventError(
+                "an event with no edge_id cannot be filtered by origin. "
+                "Requirement 6: every event carries a stable edge_id. Absent "
+                "from a version-1 event, it is absent forever.")
+        if not self.key_epoch:
+            raise EventError(
+                "an event with no key_epoch cannot be excluded from a replay "
+                "scoped past a leaked credential (requirement 7c). Pass "
+                "`edge_id.NO_CREDENTIAL_EPOCH` to state that this edge "
+                "authenticates to nothing — that is a value, not an absence.")
+        if self.content_bytes < 0:
+            raise EventError(
+                f"content_bytes must be non-negative, got {self.content_bytes}")
+        if self.kind is EventKind.INTENT and self.destination.address:
+            raise EventError(
+                f"an intent event carries no store address, and this one carries "
+                f"{self.destination.address!r}. The store object does not exist "
+                f"yet — that is the whole reason a paired write needs a second "
+                f"event (see the module docstring). An address here means the "
+                f"emit ran AFTER its store write, which inverts write-ahead "
+                f"ordering and is the state requirement 1's invariant forbids.")
+        if self.kind is EventKind.GAP and self.gap_class is None:
+            raise EventError(
+                "a gap event names why it happened, from `GapClass`. Free text "
+                "is refused here rather than sanitised: the gap event reports "
+                "that content was lost, and a `why` derived from that content "
+                "or from an exception message is a side channel for the very "
+                "bytes it says were dropped.")
+        if self.kind is not EventKind.GAP and self.gap_class is not None:
+            raise EventError(
+                f"only a gap event carries a gap_class; this is a "
+                f"{self.kind.value}. A non-gap event reporting a gap class would "
+                f"be counted by Phase 6 r6's gap accounting as a loss that did "
+                f"not happen.")
+
+
+def encode_event(event: JournalEvent) -> str:
+    """One event as one JSON line, ready to append.
+
+    `sort_keys` SO TWO EMITS OF ONE EVENT ARE BYTE-IDENTICAL. Dedupe is on
+    identity rather than on bytes, so this is not what makes a retry safe — what
+    it makes possible is a human diffing two bags and seeing a difference that is
+    a difference. An unordered mapping would put field-ordering noise on every
+    line of a Phase 4 rebuild diff.
+
+    `ensure_ascii=False` BECAUSE THE CONTENT IS VERBATIM. Escaping non-ASCII
+    would store a different string from the one the run authored, and requirement
+    1's word is *verbatim*. The file is declared UTF-8 by the bag's own
+    `Tag-File-Character-Encoding`, so there is nothing to escape for.
+    """
+    payload: dict[str, Any] = asdict(event)
+    for key in ("kind", "provenance", "outcome", "terminal_state", "gap_class"):
+        value = payload.get(key)
+        if isinstance(value, Enum):
+            payload[key] = value.value
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False,
+                      separators=(",", ":"))
+
+
+def decode_event(line: str) -> JournalEvent:
+    """One JSON line back into an event, upcasting nothing yet.
+
+    ⚠ THE UPCASTER IS OPEN AND THIS IS NOT IT. Roadmap § *Open inputs* item 2
+    carries the mechanism; requirement 8's rule — version every event, never
+    mutate a written one, upcast on read — ships now because an unversioned v1
+    event is unrecoverable, and the mechanism follows. What this function does
+    today is REFUSE a version it has no code for, rather than reading a v2 event
+    with v1 field meanings and returning something that looks right.
+    """
+    raw = json.loads(line)
+    version = raw.get("schema_version")
+    if version != JOURNAL_SCHEMA_VERSION:
+        raise EventError(
+            f"event schema version {version!r} is not {JOURNAL_SCHEMA_VERSION}, "
+            f"and no upcaster exists yet (roadmap § Open inputs, item 2). "
+            f"Refusing rather than reading it with this version's field "
+            f"meanings — a v2 event read as v1 is confidently wrong, which is "
+            f"worse than unreadable.")
+    return JournalEvent(
+        kind=EventKind(raw["kind"]),
+        event_id=raw["event_id"],
+        run_id=raw["run_id"],
+        edge_id=raw["edge_id"],
+        key_epoch=raw["key_epoch"],
+        provenance=Provenance(raw["provenance"]),
+        write_path=raw["write_path"],
+        sequence=raw["sequence"],
+        destination=Destination(**raw["destination"]),
+        content=raw.get("content", ""),
+        content_bytes=raw.get("content_bytes", 0),
+        lineage=Lineage(**raw.get("lineage", {})),
+        outcome=Outcome(raw["outcome"]) if raw.get("outcome") else None,
+        terminal_state=(TerminalState(raw["terminal_state"])
+                        if raw.get("terminal_state") else None),
+        recorded_at=raw["recorded_at"],
+        schema_version=raw["schema_version"],
+        gap_class=GapClass(raw["gap_class"]) if raw.get("gap_class") else None,
+    )
+
+
+def dedupe_on_identity(events: list[JournalEvent]) -> list[JournalEvent]:
+    """Replay's dedupe rule — requirement 7(a), and it is what makes a retry safe.
+
+    FIRST OCCURRENCE WINS, KEYED ON `(event_id, kind)`. Not on `event_id` alone:
+    an intent and its completion deliberately SHARE one identity — that is what
+    makes them one unit — so keying on the id alone would silently drop every
+    completion in the journal and turn `applied_intents` below into a function
+    that applies nothing.
+
+    FIRST RATHER THAN LAST because the journal is append-only and the first write
+    is the one that happened; a later duplicate is a retry re-running a side
+    effect, not a correction. Requirement 8 forbids corrections outright.
+    """
+    seen: set[tuple[str, str]] = set()
+    kept: list[JournalEvent] = []
+    for event in events:
+        key = (event.event_id, event.kind.value)
+        if key in seen:
+            continue
+        seen.add(key)
+        kept.append(event)
+    return kept
+
+
+def applied_intents(events: list[JournalEvent]) -> list[JournalEvent]:
+    """The intents a replay applies: exactly those that have a completion.
+
+    THIS ONE RULE IS WHAT MAKES TWO OF THE THREE PAIRED-WRITE FAILURES VISIBLE
+    RATHER THAN SILENTLY WRONG. Without it, an intent whose store write failed
+    replays into content the store never got — Phase 4 would MATERIALISE
+    unpublished content into the store, turning a failed write into a delayed
+    successful one that no run and no human approved. The rebuild is supposed to
+    restore what happened, not complete what did not.
+
+    A `STORE_WRITE_FAILURE` event does NOT satisfy an intent, and the asymmetry
+    is the point: it is a positive record that the write did not land, so the
+    intent stays unapplied AND a reader can tell "the store write failed" from
+    "the run died between the two events". Both are unapplied; only one is a
+    defect in this component.
+
+    DEDUPE FIRST, ALWAYS. A retried activity appends both events twice, and
+    counting completions without deduping would report two applications of one
+    write — the same red diff in the opposite direction from the row above.
+    """
+    deduped = dedupe_on_identity(events)
+    completed = {e.event_id for e in deduped if e.kind is EventKind.COMPLETION}
+    return [e for e in deduped
+            if e.kind is EventKind.INTENT and e.event_id in completed]
+
+
+def gap_event(*, run_id: str, edge_id: str, key_epoch: str, write_path: str,
+              sequence: int, gap_class: GapClass, lost_bytes: int,
+              destination: Destination,
+              provenance: Provenance = Provenance.FLEET_AUTHORED) -> JournalEvent:
+    """Requirement 4 case (c): the write did not land, and the record says so.
+
+    A CLOSED TYPED FIELD SET — write-path id, byte count, error class, timestamp
+    — and never free text derived from the content or from an exception message.
+    It costs a few hundred bytes and cannot become a side channel for the very
+    bytes it is reporting the loss of.
+
+    THE CALLER MARKS THE BAG `incomplete`; this only builds the record. The two
+    are separate because `Bag.mark_incomplete` is idempotent on the flag and
+    append-only on the gaps — a run that loses three writes carries three gap
+    records and one flag — and folding the flag in here would make the event
+    constructor do I/O.
+    """
+    return JournalEvent(
+        kind=EventKind.GAP,
+        event_id=event_identity(run_id=run_id, write_path=write_path,
+                                sequence=sequence),
+        run_id=run_id, edge_id=edge_id, key_epoch=key_epoch,
+        provenance=provenance, write_path=write_path, sequence=sequence,
+        destination=destination, content="", content_bytes=lost_bytes,
+        gap_class=gap_class, terminal_state=TerminalState.EMIT_FAILED)
+
+
+def redaction_placeholder_event(*, run_id: str, edge_id: str, key_epoch: str,
+                                write_path: str, sequence: int,
+                                destination: Destination, removed_bytes: int,
+                                rule: str,
+                                provenance: Provenance) -> JournalEvent:
+    """Requirement 10: capture-time filtering fired, and the record says so.
+
+    THE RECORD STAYS COMPLETE ABOUT THE *FACT* OF A REDACTION rather than
+    silently shorter. `rule` names WHICH filter matched — not what it matched,
+    which would be the secret — so an operator can tell a credential pattern from
+    an over-broad rule eating legitimate content without the event carrying
+    either.
+
+    DISTINCT FROM PHASE 1's REDACTION EVENT CLASS, which is the after-the-fact
+    complement for what gets through. This one fires BEFORE any byte reaches the
+    journal root; that one replaces a payload file already sealed into a
+    manifest. Conflating them would make a filter working normally look like an
+    incident.
+    """
+    return JournalEvent(
+        kind=EventKind.REDACTION_PLACEHOLDER,
+        event_id=event_identity(run_id=run_id, write_path=write_path,
+                                sequence=sequence),
+        run_id=run_id, edge_id=edge_id, key_epoch=key_epoch,
+        provenance=provenance, write_path=write_path, sequence=sequence,
+        destination=destination, content=f"[FILTERED AT CAPTURE: {rule}]",
+        content_bytes=removed_bytes)

--- a/scripts/workflows/temporal/modules/journal/journal_activities.py
+++ b/scripts/workflows/temporal/modules/journal/journal_activities.py
@@ -53,9 +53,11 @@ from .bag import Bag, open_bag
 from .config_digest import (LABEL_CONFIG_DIGEST, ConfigDigestError,
                             ConfigTreeError, config_digest,
                             unavailable_tag_value)
+from .emit import Emitter, register_emitter
 from .root import JournalRootError, resolve_journal_root
 
-__all__ = ["mint_run_id", "open_run_bag", "load_journal_config", "JournalRootError"]
+__all__ = ["mint_run_id", "open_run_bag", "load_journal_config",
+           "JournalRootError"]
 
 # `config.yaml` sits at the repo root of THIS repo — the fleet's own
 # configuration, not the target repo's. Resolved from this file's location for
@@ -512,6 +514,22 @@ def _open(root: Path, run_id: str, writer: str | None, repo_root: Path,
     # ever share a file, and making it adopt would hand a retry the directory a
     # concurrent sibling is writing into. The cost is a subfolder per attempt,
     # which is visible in the bag rather than silent.
-    if writer is not None:
-        bag.writer_dir(writer)
+    # PHASE 3 CHANGES WHAT THIS ALLOCATION IS FOR, so the comment above is now
+    # half the story: the subfolder is no longer only an observable, it is where
+    # this invocation's events land. `Emitter.for_run` allocates it, which is why
+    # this call is gone rather than kept beside it — allocating twice would give
+    # one member two subfolders and split its events across them.
+    #
+    # THE PARENT GETS ONE TOO, NAMED `parent`. Under Phase 1 a parent had no
+    # subfolder because nothing wrote into a bag; now it emits, and events with
+    # nowhere of their own to go would have to share a file with every member —
+    # the exact contention `writer_dir` exists to remove.
+    #
+    # REGISTERED, NOT RETURNED, and requirement 12 is why. The write paths that
+    # emit — `gh` invocations, `tracked/` filings — sit dozens of call sites away
+    # from here and hold no bag; threading one through every signature makes the
+    # emit an optional argument, and this package's whole thesis is that an
+    # optional control is a skipped control. `emit.register_emitter` states the
+    # trade and what it does not reach.
+    register_emitter(Emitter.for_run(bag, writer=writer, journal_root=root))
     return bag

--- a/scripts/workflows/temporal/modules/journal/root.py
+++ b/scripts/workflows/temporal/modules/journal/root.py
@@ -8,6 +8,14 @@ The distinction is the whole requirement — a silent fallback to a home directo
 is how the second edge (which may have no user account at all) would discover
 its journal in the wrong place months later, with the records already written.
 
+⚠ THE ROOT HOLDS ONE FILE THAT IS NOT A BAG, AND EVERY ENUMERATOR MUST SAY SO.
+Phase 3 r6 persists the machine's `edge_id` here (`edge_id.EDGE_ID_FILE`) — it is
+per-MACHINE state, so a file inside a bag would make it per-run, and an id that
+changed per run is not an id. **A consumer listing bags therefore filters to
+DIRECTORIES**; `validate.main` and `verify.main` already do. An enumerator that
+does not would hand a plain file to `validate_bag` and report the journal broken
+because the machine has a name.
+
 RESOLUTION FAILS THE RUN (Phase 1 r9). This is deliberately the earliest and
 cheapest of the three write-failure cases the component rules on: the root is
 resolved once, before a worktree is cut or a token is spent, so a missing path, a

--- a/scripts/workflows/temporal/modules/journal/validate.py
+++ b/scripts/workflows/temporal/modules/journal/validate.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from . import bag as bagmod
 from .bag import (BAGIT_FILE, BAG_INFO_FILE, MANIFEST_FILE, PAYLOAD_DIR,
                   BagError, contained_relpath, payload_files, payload_symlinks,
-                  sha256_of, read_tag_file)
+                  sha256_of, read_tag_file, unrecognised_journal_labels)
 
 __all__ = ["BagReport", "validate_bag", "render_report", "main"]
 
@@ -63,6 +63,14 @@ class BagReport:
     payload_bytes: int = 0
     redactions: tuple[str, ...] = ()
     gaps: tuple[str, ...] = ()
+    #: `Journal-` labels this fleet has no code for — Phase 3 r13(b). REPORTED
+    #: AND NOT REFUSED, and deliberately absent from `ok` below: RFC 8493 permits
+    #: arbitrary `bag-info.txt` labels, so a bag written by a newer fleet is a
+    #: VALID bag and failing it would make the namespace's stated extensibility
+    #: false the first time anyone used it. Silently dropping it is the other
+    #: wrong answer — that is how a contributed field stops existing without
+    #: anyone learning. So: it validates, and it is named.
+    unrecognised_tags: tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
@@ -300,7 +308,8 @@ def validate_bag(bag_path: Path) -> BagReport:
         structural=tuple(structural), missing=tuple(missing),
         mismatched=tuple(mismatched), unlisted=tuple(unlisted),
         payload_files=len(on_disk), payload_bytes=payload_bytes,
-        redactions=state.redactions, gaps=state.gaps)
+        redactions=state.redactions, gaps=state.gaps,
+        unrecognised_tags=unrecognised_journal_labels(entries))
 
 
 def render_report(report: BagReport) -> str:
@@ -323,7 +332,12 @@ def render_report(report: BagReport) -> str:
                          ("mismatched", report.mismatched),
                          ("unlisted", report.unlisted),
                          ("redactions", report.redactions),
-                         ("gaps", report.gaps)):
+                         ("gaps", report.gaps),
+                         # NAMED SEPARATELY FROM `structural`, because it is not
+                         # a defect: it is this fleet reporting the limit of its
+                         # own vocabulary. Rendering it under `structural` would
+                         # make a valid bag from a newer fleet read as broken.
+                         ("unrecognised tag", report.unrecognised_tags)):
         for item in items:
             lines.append(f"  {label}: {item}")
     return "\n".join(lines)

--- a/scripts/workflows/temporal/modules/vocabulary.py
+++ b/scripts/workflows/temporal/modules/vocabulary.py
@@ -1,0 +1,130 @@
+"""One declaration per concept the typed exit record and the journal event share.
+
+REQUIREMENT 3 OF PERSISTENT MEMORY PROTOCOL PHASE 3, AND IT IS A MODULE RATHER
+THAN A RULE BECAUSE A RULE IS WHAT DRIFTED. The two contracts are separate — the
+phase doc's § *One vocabulary, two contracts* gives the reason, and it is not a
+preference: `exit-protocol.md` §2 forbids a field added for a consumer that does
+not exist, and §2.5 bounds the record at 4096 bytes, while a journal event
+carries authored content verbatim and adds six fields no parent branches on. So
+an extension is not available and two contracts are what exist.
+
+Two contracts that name the same concept twice is the failure that follows, and
+it is a REAL risk rather than a tidiness worry: `outcome` spelled `merge`/`hold`
+in one and `MERGE`/`HOLD` in the other makes a rebuild's diff report a
+difference that is not one. This module is where each shared concept is spelled,
+once. Both sides import it; neither restates it.
+
+WHY IT SITS AT `modules/` AND NOT INSIDE EITHER PACKAGE. `modules/journal/`
+imports no workflow module — `test_the_journal_package_imports_no_workflow_module`
+holds that, and Phase 6's reader depends on it, because dragging in
+`modules.assistant` drags in `temporalio` behind it. So the vocabulary cannot
+live beside `exit_record.py`. Putting it inside `modules/journal/` instead would
+invert the problem: `exit_record.py` is dependency-free by design and importing
+the journal package would execute its whole `__init__`. A leaf at `modules/`
+belongs to neither and is importable by both, which is the only placement that
+leaves both properties intact.
+
+STDLIB ONLY, NO I/O, NO CLOCK — the same discipline `routing.py` and
+`exit_record.py` keep, and for the same reason: a vocabulary that could fail to
+import is a vocabulary that stops being the single declaration.
+
+WHAT IS DELIBERATELY *NOT* HERE. A concept named by only one of the two
+contracts stays where it is used. `RoutedOutcome` and `UndeterminedReason` are
+the parent's computed stratum (`exit-protocol.md` §2.3) and no journal event
+carries them, so hoisting them here would make this module a dumping ground for
+the exit record's enums rather than the shared surface it is. The test that
+holds this is `test_shared_vocabulary_is_declared_once.py`, which asserts the
+spelling agreement in both directions rather than the membership of this file.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+__all__ = ["Outcome", "HoldKind", "Disposition", "TerminalState",
+           "SHARED_CONCEPTS"]
+
+
+class Outcome(str, Enum):
+    """What a run asserts about the work it did.
+
+    Authored by the child on the exit record (`exit-protocol.md` §2.1) and
+    carried verbatim into the journal as the outcome of the run that emitted the
+    event. `str`-valued so `json.dumps` serialises it without an encoder, which
+    is what keeps the journal's on-disk spelling and the exit record's wire
+    spelling the same string rather than two conversions that agree today.
+    """
+
+    MERGE = "merge"
+    HOLD = "hold"
+
+
+class HoldKind(str, Enum):
+    """The sub-kind every parent branches on — `hold` alone does not route.
+
+    NEEDS_RULING is the ASSERTED abstention arm: the evaluation completed and
+    the answer is that a human must decide. It stays a model assertion by
+    construction — a predicate that could detect "this needs a human" would be
+    the ground truth it is asking for.
+    """
+
+    REDISPATCH = "redispatch"
+    NEEDS_RULING = "needs_ruling"
+
+
+class Disposition(str, Enum):
+    """What happened to one finding. The one vocabulary both contracts enumerate.
+
+    THIS IS THE CONCEPT THE DRIFT RISK IS REAL ON, because it is spelled in three
+    places today: the exit record's `findings[].disposition` schema enum, the
+    `pr_review:` block a reviewer writes, and `convergence.py`'s open/closed
+    partition. `memory-model.md` §4.1 records the partition — CLOSED is `fixed` /
+    `deferred` / `rejected` / `noted` / `dissolved` / `escalated`, OPEN is `hold`
+    plus anything unrecognised — and a journal event replaying a finding row has
+    to spell it the way the partition reads it or the rebuild diff is noise.
+    """
+
+    HOLD = "hold"
+    FIXED = "fixed"
+    DEFERRED = "deferred"
+    REJECTED = "rejected"
+    NOTED = "noted"
+    ESCALATED = "escalated"
+    DISSOLVED = "dissolved"
+
+
+class TerminalState(str, Enum):
+    """How a run — or one emit unit inside it — ENDED. Never how it was judged.
+
+    SEPARATE FROM `Outcome` AND THE SEPARATION IS THE POINT. `Outcome` is a
+    judgement about the work; this is a fact about the process. A run can end
+    `COMPLETED` while asserting `HOLD`, and it can end `JOURNAL_UNWRITABLE`
+    having asserted nothing at all. Collapsing them would make the phase doc's
+    case (d) — the journal is gone, so the run stops — indistinguishable from a
+    reviewer holding a PR, which is the one signal this component's failure path
+    depends on being separately visible.
+
+    `JOURNAL_UNWRITABLE` is requirement 4 case (d)'s named terminal state and
+    `EMIT_FAILED` is case (b)'s. They are two states because they need two
+    remedies: case (b) means the journal took no more writes at a known boundary
+    and the store write was withheld, which is recoverable by re-running; case
+    (d) means the journal root itself is gone, and re-running writes nothing.
+    """
+
+    COMPLETED = "completed"
+    EMIT_FAILED = "emit_failed"
+    JOURNAL_UNWRITABLE = "journal_unwritable"
+    STORE_WRITE_FAILED = "store_write_failed"
+
+
+#: The concepts this module declares, as `(name, member-values)`. Enumerated so a
+#: conformance test can walk it rather than restating the membership — the same
+#: "walk the declaration, never re-type it" discipline `exit_record._validate`
+#: applies to `CHILD_SCHEMA`. A concept added here is checked in both contracts
+#: without editing the test.
+SHARED_CONCEPTS: dict[str, tuple[str, ...]] = {
+    "Outcome": tuple(m.value for m in Outcome),
+    "HoldKind": tuple(m.value for m in HoldKind),
+    "Disposition": tuple(m.value for m in Disposition),
+    "TerminalState": tuple(m.value for m in TerminalState),
+}

--- a/scripts/workflows/temporal/modules/vocabulary.py
+++ b/scripts/workflows/temporal/modules/vocabulary.py
@@ -33,8 +33,20 @@ contracts stays where it is used. `RoutedOutcome` and `UndeterminedReason` are
 the parent's computed stratum (`exit-protocol.md` §2.3) and no journal event
 carries them, so hoisting them here would make this module a dumping ground for
 the exit record's enums rather than the shared surface it is. The test that
-holds this is `test_shared_vocabulary_is_declared_once.py`, which asserts the
-spelling agreement in both directions rather than the membership of this file.
+holds this is `test_shared_vocabulary_is_declared_once.py`, which asks the SYNTAX
+TREE whether either contract re-declares a concept — an import binds the same
+name as a declaration, so `hasattr` cannot tell the two apart — and asserts the
+shared objects by IDENTITY, because two enums spelled alike compare unequal
+member-to-member while every string comparison in the fleet keeps passing. It
+walks `SHARED_CONCEPTS` rather than re-typing any spelling, and checks that dict
+against `__all__` so a fifth concept cannot be silently exempt from the walk.
+
+⚠ THAT FILE WAS CITED HERE BEFORE IT EXISTED, and the citation is why it does
+now. This module's own argument — made three times across this package — is that
+a rule written only as prose has not once prevented the thing it forbids; the one
+invariant it was added to protect was itself protected by this paragraph, and
+`SHARED_CONCEPTS`, built so a conformance test could walk it, was imported by
+nothing.
 """
 
 from __future__ import annotations

--- a/scripts/workflows/temporal/tests/conftest.py
+++ b/scripts/workflows/temporal/tests/conftest.py
@@ -119,6 +119,40 @@ def _journal_root_is_never_the_operators(tmp_path_factory):
     finally:
         journal_activities.CONFIG_PATH = real
 
+# --- the emit boundary must never leak from one test into the next ---------------
+
+# PMP PHASE 3 REGISTERS A PROCESS-SCOPED EMITTER FROM `open_run_bag`, and every
+# test that drives an entrypoint's `main()` therefore leaves one registered.
+# WITHOUT THIS FIXTURE the leak is worse than an untidy global: the emitter holds
+# a `Bag` under a `tmp_path` pytest has already removed, so a LATER test's store
+# write would emit into a directory that no longer exists — a write-path failure
+# manufactured entirely by test ordering, arriving in whichever test happened to
+# run next.
+#
+# FOUND BY RUNNING THE SUITE, not by reading the code: two assertions that
+# `current_emitter()` is `None` passed alone and failed in the full run, which is
+# the signature of exactly this class. Same discipline as the journal-root
+# sandbox above — durable process state a test creates is state the next test
+# inherits.
+#
+# AUTOUSE AND UNCONDITIONAL, because the tests that leak are the ones that never
+# mention the journal: they call `main()` and inherit bag-open from the
+# entrypoint. A fixture only the journal tests requested would miss every one of
+# them.
+import pytest as _pytest
+
+
+@_pytest.fixture(autouse=True)
+def _no_emitter_leaks_between_tests():
+    from modules.journal import emit as _emit
+
+    _emit.register_emitter(None)
+    try:
+        yield
+    finally:
+        _emit.register_emitter(None)
+
+
 # `tests/` on the path so a unit test can `from planning_corpus import ...`.
 # The corpus moved to the sibling planning repo on 2026-08-31 and seventeen tests
 # assert against the live one; they share ONE resolver rather than each deriving

--- a/scripts/workflows/temporal/tests/unit/assembled_prompt.py
+++ b/scripts/workflows/temporal/tests/unit/assembled_prompt.py
@@ -46,8 +46,10 @@ WHAT THIS DOES NOT DO, so it is not over-read:
     oldest assertion. It went unnoticed because the parity check expands both
     sides and the error cancelled; the next assertion written over it would not
     have been so lucky. `local` mirrors what the workflow's values dict does,
-    and `test_a_CHILD_S_OWN_FILE_WINS_over_a_pool_fragment_of_the_same_stem`
-    holds it.
+    `local` is what holds it — the test that named this property was DELETED
+    with the collision it demonstrated (see `test_assembled_prompt.py`, which
+    says so at the site it stood on), so the behaviour is asserted by the
+    resolver's own precedence and by nothing else.
   * **It resolves to a FIXED POINT, bounded.** A pool fragment may itself carry a
     pool placeholder. Ten rounds, then it raises rather than spinning — the same
     bound and the same reason as `render()`.

--- a/scripts/workflows/temporal/tests/unit/prose_number_words.py
+++ b/scripts/workflows/temporal/tests/unit/prose_number_words.py
@@ -34,5 +34,6 @@ NUMBER_WORDS: dict[str, int] = {
     "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
     "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
     "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
-    "twenty": 20,
+    "twenty": 20, "twenty-one": 21, "twenty-two": 22, "twenty-three": 23,
+    "twenty-four": 24, "twenty-five": 25,
 }

--- a/scripts/workflows/temporal/tests/unit/test_a_bounded_reply_is_CHECKED_not_only_read.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_bounded_reply_is_CHECKED_not_only_read.py
@@ -60,11 +60,17 @@ as broader than it is does more harm than a narrow one:
     is that a new spelling escapes rather than that a good one is blocked.
 
 THE POPULATION FIGURE IS DERIVED, NOT ASSERTED. `test_the_census_matches_the_
-tree` fails when the number of launch bindings changes, so the sentence "eight
+tree` fails when the number of launch bindings changes, so the sentence "seven
 launch bindings live in the tree" cannot go stale the way the docstring this
 guard replaces did. It went from seven to eight when the content store's
 `verify.git_blob` landed, which is the census doing its job: the author of that
-function was told, by this assertion, that they had joined this population. That is the discipline this file exists to demonstrate: a
+function was told, by this assertion, that they had joined this population. It
+went BACK to seven under PMP Phase 3, and the direction matters — a member left
+the population by being routed through a choke point rather than by being
+deleted. `intake._gh` bound `run_bounded` directly and now calls
+`assistant_activities.gh_attempt`, which is where the fleet's `gh` mutations
+acquire both their retry discipline and their journal emit; the reply is still
+checked, one layer up. That is the discipline this file exists to demonstrate: a
 coverage claim is either an assertion that goes red, or it is a hedge.
 """
 
@@ -298,8 +304,8 @@ def test_the_census_matches_the_tree() -> None:
     next person to add one is told, here, that they are now in this population.
     """
     _, total = _scan_tree()
-    assert total == 8, (
-        f"the walk found {total} launch-reply binding(s), not the 8 recorded when "
+    assert total == 7, (
+        f"the walk found {total} launch-reply binding(s), not the 7 recorded when "
         f"this was written. That is not a failure — it is the census telling you "
         f"the population moved. Confirm the new site reads its outcome, then "
         f"update this number and the docstring's count together."

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -210,7 +210,15 @@ _HERE = Path(__file__).resolve().parent
 # because it ships its own literal control: the shipped arrangement, the
 # corrected one, a function that never cuts, and a call that legitimately
 # needs the worktree.
-_PINNED = (44, 34)
+# 44 -> 45 and 34 -> 35 when a `build-refine` pass added
+# `test_shared_vocabulary_is_declared_once.py` — the test `modules/vocabulary.py`
+# had CITED while it did not exist, which is why the module's one invariant was
+# held by a paragraph. BOTH numbers moved because it arrived WITH its control:
+# six literal snippets drive its re-declaration predicate, and the two that
+# matter are an `import` (which binds the same name a declaration does, so
+# `hasattr` cannot tell them apart) and a DOCSTRING naming the class (the
+# substring bug a text scan gets wrong in the other direction).
+_PINNED = (45, 35)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_census_guard_proves_its_own_predicate.py
@@ -49,13 +49,22 @@ That is the failure this whole PR is about, committed by the file that states
 the rule: a coverage claim must either be a derived assertion that goes red, or
 must not be written as a universal. This file takes the first arm for its
 population and the second arm for its recogniser's boundary, and says which is
-which below. The repository gates this class in four corpora now —
+which below. The repository gates this class in three corpora now —
 `test_journal_prose_figures_are_DERIVED.py` for the journal package,
 `testing/scripts/tests/unit/test_measurement_figures_are_cited.py` for the
-phase docs that opt in, `test_candidates_prose_matches_the_table.py` for
-`candidates.md`, and `test_a_prose_COUNT_of_a_collection_is_DERIVED.py`, added
-alongside this correction, for prose in this directory that counts a collection
-the same module defines. That last one is what holds the one figure below.
+phase docs that opt in, and `test_a_prose_COUNT_of_a_collection_is_DERIVED.py`,
+added alongside this correction, for prose in this directory that counts a
+collection the same module defines. That last one is what holds the one figure
+below.
+
+⚠ AND THIS SENTENCE SAID `four`, NAMING A GATE DELETED IN `91925af` ALONGSIDE
+THE `candidates.md` CORPUS IT HELD — inside the file whose whole thesis is that
+an unbacked prose count of a collection must not be written as a universal. The
+count was wrong AND was the exact shape its neighbour exists to forbid.
+`test_EVERY_TEST_MODULE_PROSE_CITES_EXISTS` in
+`testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py` is the
+class check added with this correction, because the deleted name was cited at
+seven sites and correcting them one at a time is what has never converged.
 
 WHAT THIS GUARD DOES NOT LOOK AT:
 
@@ -218,7 +227,15 @@ _HERE = Path(__file__).resolve().parent
 # matter are an `import` (which binds the same name a declaration does, so
 # `hasattr` cannot tell them apart) and a DOCSTRING naming the class (the
 # substring bug a text scan gets wrong in the other direction).
-_PINNED = (45, 35)
+# 45 -> 46 and 35 -> 36 when the SECOND `build-refine` pass gave
+# `test_journal_emit.py` a walk over the production tree — the case-(d) channel
+# table's deriver, which asks every non-test module whether it passes
+# `case_d_report=True`. BOTH numbers moved because it arrived with its control:
+# three literal snippets, and the two that matter are a DOCSTRING mentioning the
+# flag (the substring bug this package has already met twice, once in `gh_attempt`
+# itself where reading the flag off the content skipped the journal entirely) and
+# a call passing it `False`.
+_PINNED = (46, 36)
 
 
 # GRANDFATHERED — walks the tree, has no literal control, PREDATES this rule.

--- a/scripts/workflows/temporal/tests/unit/test_a_held_PR_is_refused_without_the_correction_flag.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_held_PR_is_refused_without_the_correction_flag.py
@@ -27,11 +27,10 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "modules"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from assistant.review_pr import review_pr_activities as act  # noqa: E402
-from assistant.review_pr import review_pr_helper as helper  # noqa: E402
+from modules.assistant.review_pr import review_pr_activities as act  # noqa: E402
+from modules.assistant.review_pr import review_pr_helper as helper  # noqa: E402
 
 RUNNERS = ("run_plan_refine.py", "run_plan_sprint.py")
 _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"

--- a/scripts/workflows/temporal/tests/unit/test_a_prose_COUNT_of_a_collection_is_DERIVED.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_prose_COUNT_of_a_collection_is_DERIVED.py
@@ -20,18 +20,20 @@ rather than remembered:
 
 Four instances, four different files, three different corpora, one shape.
 Enumerating them has not converged in five attempts. The repository already
-gates this class in three places and the pattern each uses is the same one:
+gates this class in two places and the pattern each uses is the same one:
 DERIVE THE NUMBER, DO NOT REMEMBER IT.
 
   * `test_journal_prose_figures_are_DERIVED.py` — entrypoint-population figures
     in the journal package, bound sentence-by-sentence to derivers.
   * `testing/scripts/tests/unit/test_measurement_figures_are_cited.py` — a
     cite-don't-restate rule for the phase docs that opt in.
-  * `testing/scripts/tests/unit/test_candidates_prose_matches_the_table.py` —
-    every declared total in `candidates.md` § Where things stand.
 
-The guards under `tests/unit/` were the fourth corpus and had no gate at all,
-which is why the defect kept landing there. This is that gate.
+A third was listed here — a gate over `candidates.md` § Where things stand — and
+it was deleted in `91925af` together with that corpus, when the candidates store
+became `tracked/candidates/`. The bullet outlived both.
+
+The guards under `tests/unit/` had no gate at all, which is why the defect kept
+landing there. This is that gate.
 
 WHAT IT KEYS ON, AND WHY THE SCOPE IS THIS NARROW. Prose that counts a
 collection the same module DEFINES — "the 12 names in `_WITHOUT_A_CONTROL_YET`",

--- a/scripts/workflows/temporal/tests/unit/test_a_refused_bag_mutation_CHANGES_NOTHING.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_refused_bag_mutation_CHANGES_NOTHING.py
@@ -90,7 +90,8 @@ SCOPE = "modules/journal/bag.py"
 # The four functions permitted to touch the filesystem directly. Everything else
 # in `bag.py` mutates THROUGH one of these, which is what lets half B find the
 # members by name instead of by tracing every call.
-_PRIMITIVES = {"_write_tag_file", "_append_tag_line", "Bag.writer_dir", "open_bag"}
+_PRIMITIVES = {"_write_tag_file", "_replace_tag_file", "_append_tag_line",
+               "Bag.writer_dir", "Bag.write_payload", "open_bag"}
 
 # Method names that are unambiguously a filesystem mutation. `rename`/`replace`
 # are deliberately absent from this set and handled below by receiver, because
@@ -265,9 +266,12 @@ TOTAL = "TOTAL"
 
 _MUTATORS: dict[str, str] = {
     "_write_tag_file": TOTAL,
+    "_replace_tag_file": TOTAL,
     "_append_tag_line": "refusable",
     "_set_tag_line": "refusable",
     "Bag.writer_dir": TOTAL,
+    "Bag.write_payload": "refusable",
+    "Bag.add_tag": "refusable",
     "Bag.seal": TOTAL,
     "Bag.redact": "refusable",
     "Bag.mark_incomplete": "refusable",
@@ -283,6 +287,12 @@ _TOTAL_REASONS = {
         "name into a slug. Its single `BagError` is ordinal exhaustion, reached "
         "only after 9999 `os.mkdir` calls have EVERY ONE raised `FileExistsError`, "
         "so the refusing path is the path on which nothing was created.",
+    "_replace_tag_file":
+        "`_write_tag_file`'s atomic twin, and TOTAL for the same reason: it "
+        "validates nothing and raises no `BagError`. Its only failure is an "
+        "`OSError` from the write or the rename, which is the filesystem "
+        "refusing rather than this module refusing a caller's value — and it "
+        "unlinks its own temp file on that path so the bag keeps no litter.",
     "Bag.seal":
         "takes no caller argument. Every value it composes is module-derived — a "
         "byte count, a file count and `utc_now()` — and none can fold a tag line "
@@ -387,6 +397,18 @@ _REFUSAL_DRIVERS: list[tuple[str, str, Callable, Callable]] = [
      _redact_setup, lambda b: b.mark_incomplete(FOLDS, "disk full")),
     ("Bag.mark_incomplete", "a second gap on a bag already flagged",
      lambda root: _flagged(root), lambda b: b.mark_incomplete("the reply", FOLDS)),
+    ("Bag.write_payload", "a path outside the payload directory",
+     _redact_setup, lambda b: b.write_payload("bag-info.txt", "x")),
+    ("Bag.write_payload", "a payload path that escapes the bag",
+     _redact_setup, lambda b: b.write_payload("data/../../escape", "x")),
+    ("Bag.write_payload", "a payload file that already exists — written once, never twice",
+     _redact_setup, lambda b: b.write_payload("data/child/payload", "x")),
+    ("Bag.add_tag", "a reserved lifecycle label, which the package writes alone",
+     _redact_setup, lambda b: b.add_tag("Journal-Incomplete", "true")),
+    ("Bag.add_tag", "a descriptive VALUE that does not survive a round trip",
+     _redact_setup, lambda b: b.add_tag("Journal-Region", FOLDS)),
+    ("Bag.add_tag", "a LABEL that forges a second record",
+     _redact_setup, lambda b: b.add_tag(FOLDS, "x")),
     ("open_bag", "an `info` VALUE that does not survive a round trip",
      lambda root: root, lambda root: open_bag(root, "fresh", info={"Journal-Worktree": FOLDS})),
     ("open_bag", "an `info` LABEL that forges a second record",

--- a/scripts/workflows/temporal/tests/unit/test_a_refused_bag_mutation_CHANGES_NOTHING.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_refused_bag_mutation_CHANGES_NOTHING.py
@@ -267,6 +267,7 @@ TOTAL = "TOTAL"
 _MUTATORS: dict[str, str] = {
     "_write_tag_file": TOTAL,
     "_replace_tag_file": TOTAL,
+    "_set_tag_line_locked": TOTAL,
     "_append_tag_line": "refusable",
     "_set_tag_line": "refusable",
     "Bag.writer_dir": TOTAL,
@@ -293,6 +294,13 @@ _TOTAL_REASONS = {
         "`OSError` from the write or the rename, which is the filesystem "
         "refusing rather than this module refusing a caller's value — and it "
         "unlinks its own temp file on that path so the bag keeps no litter.",
+    "_set_tag_line_locked":
+        "`_set_tag_line`'s body, for a caller already holding the lock. TOTAL "
+        "because the refusal it used to contain stayed in the wrapper: "
+        "`_refuse_folded_value` runs BEFORE the lock is taken, so by the time "
+        "this runs the value has already been accepted and nothing here can "
+        "abort. Split out for `seal`, which writes four files that have to move "
+        "under one lock and cannot take a non-reentrant one twice.",
     "Bag.seal":
         "takes no caller argument. Every value it composes is module-derived — a "
         "byte count, a file count and `utc_now()` — and none can fold a tag line "

--- a/scripts/workflows/temporal/tests/unit/test_a_run_given_a_PR_is_never_told_to_CREATE_one.py
+++ b/scripts/workflows/temporal/tests/unit/test_a_run_given_a_PR_is_never_told_to_CREATE_one.py
@@ -31,7 +31,8 @@ tier had carried the latent form since it was written — it has always passed
 `plan_path` — and one predicate fixed both, which is why nothing here is
 parametrised on the tier that happened to be reported.
 
-`test_axis_CENSUS` IS WHAT MAKES THIS A CLASS CHECK RATHER THAN A CASE LIST. The
+`test_axis_CENSUS_no_selector_argument_is_unknown_to_the_cross_product` IS WHAT
+MAKES THIS A CLASS CHECK RATHER THAN A CASE LIST. The
 cross-product below can only cover the axes it knows about, so a new selector
 parameter appearing on any member of the population reds the census with an
 instruction to extend the product. Without it this file would silently degrade

--- a/scripts/workflows/temporal/tests/unit/test_dispatch_identity.py
+++ b/scripts/workflows/temporal/tests/unit/test_dispatch_identity.py
@@ -236,8 +236,8 @@ def test_a_SEQUENTIAL_RETRY_under_one_run_id_yields_ONE_BAG(
                           workflow_key="build", worktree_name="wt-1")
 
     assert second.path == first.path
-    assert [p.name for p in root.iterdir()] == ["retried-run"], (
-        f"one run produced more than one bag: {sorted(p.name for p in root.iterdir())}. "
+    assert [p.name for p in root.iterdir() if p.is_dir()] == ["retried-run"], (
+        f"one run produced more than one bag: {sorted(p.name for p in root.iterdir() if p.is_dir())}. "
         f"This is the failure that is SILENT — two bags read as two runs forever.")
     assert (second.path / BAG_INFO_FILE).read_text() == before, (
         "the retry rewrote bag-info.txt. A rewrite drops tombstones and gap "
@@ -288,9 +288,9 @@ def test_a_PARENT_AND_ITS_CHILDREN_produce_ONE_bag_with_ONE_SUBFOLDER_EACH(
                               workflow_key=child, worktree_name="build-1")
         assert joined.path == parent.path, f"{child} filed its own bag"
 
-    assert [p.name for p in root.iterdir()] == ["one-run"], (
-        f"one run produced {len(list(root.iterdir()))} bags: "
-        f"{sorted(p.name for p in root.iterdir())}")
+    assert [p.name for p in root.iterdir() if p.is_dir()] == ["one-run"], (
+        f"one run produced {len([p for p in root.iterdir() if p.is_dir()])} bags: "
+        f"{sorted(p.name for p in root.iterdir() if p.is_dir())}")
     assert sorted(p.name for p in (parent.path / PAYLOAD_DIR).iterdir()) == [
         "build_draft", "build_refine", "review_pr"], (
         "one subfolder per writer, named for the writer — a shared directory is "
@@ -316,7 +316,7 @@ def test_a_STANDALONE_CHILD_produces_exactly_one_bag_and_NO_ORPHAN(
                        repo_root=TEMPORAL, workflow_key="research_refine",
                        worktree_name=None)
 
-    assert [p.name for p in root.iterdir()] == [identity.run_id]
+    assert [p.name for p in root.iterdir() if p.is_dir()] == [identity.run_id]
     assert list((bag.path / PAYLOAD_DIR).iterdir()) == [], (
         "an invocation that IS the run takes no writer subfolder — its records "
         "are the run's, not one member's")
@@ -366,7 +366,7 @@ def test_a_MEMBER_of_a_run_whose_bag_does_not_exist_yet_CREATES_it(
                           workflow_key="child_b", worktree_name="wt")
 
     assert first.path == second.path
-    assert [p.name for p in root.iterdir()] == ["parentless"]
+    assert [p.name for p in root.iterdir() if p.is_dir()] == ["parentless"]
     assert sorted(p.name for p in (first.path / PAYLOAD_DIR).iterdir()) == [
         "child_a", "child_b"]
     # The bag records the FIRST arrival's workflow, not the last — adoption does
@@ -388,4 +388,4 @@ def test_two_DIFFERENT_run_ids_DO_produce_two_bags(root: pathlib.Path) -> None:
     """
     open_bag(root, "run-one")
     open_bag(root, "run-two")
-    assert sorted(p.name for p in root.iterdir()) == ["run-one", "run-two"]
+    assert sorted(p.name for p in root.iterdir() if p.is_dir()) == ["run-one", "run-two"]

--- a/scripts/workflows/temporal/tests/unit/test_every_fleet_write_path_EMITS.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_fleet_write_path_EMITS.py
@@ -288,6 +288,13 @@ def test_the_case_d_REPORT_is_the_one_write_that_does_not_emit(tmp_path: Path,
     component is broken. A build that implements case (b) as an unconditional
     wrapper without this exception ships the failure path silently broken, which
     is exactly what this test exists to catch.
+
+    ⚠ THE EXCEPTION IS ASSERTED BY THE CALLER, NEVER READ OFF THE CONTENT. The
+    first version of this pair drove the bypass by putting the marker in the
+    comment body, and the code gated on exactly that — so every `gh` mutation
+    whose text merely QUOTED the marker skipped the journal with no error and no
+    record. `test_a_comment_that_QUOTES_the_marker_still_emits` below is the
+    control that fails if the content ever gates it again.
     """
     from modules.assistant import assistant_activities as act
     from modules.journal.emit import (UNWRITABLE_JOURNAL_MARKER,
@@ -303,12 +310,46 @@ def test_the_case_d_REPORT_is_the_one_write_that_does_not_emit(tmp_path: Path,
     line = f"{report['marker']}: {report['detail']}"
 
     with emitting_into(emitter):
-        act.gh_attempt(["pr", "comment", "1", "--body", line], tmp_path)
+        act.gh_attempt(["pr", "comment", "1", "--body", line], tmp_path,
+                       case_d_report=True)
 
     assert _events(emitter) == [], (
         "the case-(d) report emitted, which means a run whose journal is "
         "unwritable would fail to publish the report saying so")
     assert UNWRITABLE_JOURNAL_MARKER in line
+
+
+def test_a_comment_that_QUOTES_the_marker_still_emits(tmp_path: Path,
+                                                     monkeypatch) -> None:
+    """THE FALSE-POSITIVE DIRECTION, which nothing asserted until it was found.
+
+    A bypass inferred from the bytes being published is a bypass any author can
+    trigger by accident: a run quoting a previous failure, a bug report about
+    this component, a review comment naming the marker. Each of those silently
+    left the journal with no intent, no completion and no gap — requirement 1's
+    invariant defeated by ordinary prose. The exception is a FLAG the caller
+    sets, so this write emits like every other one.
+    """
+    from modules.assistant import assistant_activities as act
+    from modules.journal.emit import UNWRITABLE_JOURNAL_MARKER
+
+    class _Done:
+        returncode, stdout, stderr = 0, "https://github.com/o/r/pull/1#c9\n", ""
+
+    monkeypatch.setattr(act, "run_bounded", lambda *a, **k: _Done())
+    emitter = _emitter(tmp_path)
+    body = (f"the previous run reported `{UNWRITABLE_JOURNAL_MARKER}` and this "
+            f"comment is quoting it, not being it")
+    with emitting_into(emitter):
+        act.gh_attempt(["pr", "comment", "1", "--body", body], tmp_path)
+
+    events = _events(emitter)
+    assert [e.kind for e in events] == [EventKind.INTENT, EventKind.COMPLETION], (
+        f"a comment that merely quotes {UNWRITABLE_JOURNAL_MARKER} did not "
+        f"emit, so the case-(d) exception is being inferred from the content "
+        f"again — every write whose prose names the marker is then absent from "
+        f"the record, with no error and nothing to count it")
+    assert events[0].content == body
 
 
 def test_an_ORDINARY_comment_still_emits_so_the_exception_is_NARROW(

--- a/scripts/workflows/temporal/tests/unit/test_every_fleet_write_path_EMITS.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_fleet_write_path_EMITS.py
@@ -1,0 +1,373 @@
+"""Requirement 1, wired: every inventoried fleet-code write path emits.
+
+⚠ THE BAR IS REQUIREMENT 1'S OWN, AND IT IS NARROWER THAN THE HEADLINE. *"Every
+write path to every store"* carries two readings an order of magnitude apart —
+the envelope proven on one path, versus every path in the fleet — and the phase
+doc states the bar precisely because the sibling component already paid for that
+ambiguity at a measured factor of ten. **The bar is: the inventory is complete,
+and every inventoried path emits.** So this file has two halves:
+
+  * a CENSUS that fails when a store write appears with no emit beside it, which
+    is what keeps the inventory complete; and
+  * a BEHAVIOURAL test per inventoried path, which is what proves each emits.
+
+THE CENSUS IS THE HALF THAT MATTERS AFTER THIS PHASE CLOSES. A snapshot goes
+stale the first time a write path is added, and Phase 4's rebuild test is the
+guard the phase doc names for that — this is the cheaper one that fires at
+authoring time rather than at rebuild time. **It is not a substitute for Phase 4
+and does not claim to be**: it can only see the shapes it enumerates, and a write
+through a shape nobody listed is invisible to it exactly as it is to a grep.
+
+⚠ AND IT REACHES FLEET-CODE WRITES ONLY. When the child itself runs
+`gh pr comment`, there is no call site in this process at all — that half is
+Phase 10's post-exit harvest, and nothing here can or should assert about it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import open_bag
+from modules.journal.emit import Emitter, emitting_into
+from modules.journal.events import EVENTS_FILE, EventKind, decode_event
+
+MODULES = Path(__file__).resolve().parents[2] / "modules"
+
+#: Requirement 9's fleet-code half, as `(module path, the write it performs)`.
+#: ENUMERATED HERE AND NOWHERE ELSE in the test tree, so the phase doc's table
+#: and this list are two renderings of one census rather than two lists.
+FLEET_CODE_WRITE_PATHS: dict[str, str] = {
+    "assistant/assistant_activities.py":
+        "every `gh` mutation — pr create/comment/edit, issue create/comment/close",
+    "assistant/tracked/tracked_items.py":
+        "the four `tracked/` stores — file_item, expand, increment",
+    "assistant/merge/merge_pr.py":
+        "`gh pr merge`, which cannot go through the retrying choke point",
+    "assistant/plan/plan_project/plan_project_activities.py":
+        "the planning corpus — one research-pool synthesis seed",
+}
+
+
+def _emitter(tmp_path: Path) -> Emitter:
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700)
+    return Emitter.for_run(open_bag(root, "run-1"), writer=None,
+                           journal_root=root)
+
+
+def _events(emitter: Emitter) -> list:
+    path = emitter.writer_dir / EVENTS_FILE
+    if not path.is_file():
+        return []
+    return [decode_event(line) for line
+            in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# --- the census -------------------------------------------------------------
+
+@pytest.mark.parametrize("relpath", sorted(FLEET_CODE_WRITE_PATHS))
+def test_every_inventoried_module_BINDS_the_emit_boundary(relpath: str) -> None:
+    """Each inventoried module imports the emit, asked of its IMPORTS.
+
+    Not of its text: three of these four explain in prose why they emit, so a
+    substring check would pass on a file that only talked about emitting.
+    """
+    source = (MODULES / relpath).read_text(encoding="utf-8")
+    modules_named = [f"{'.' * n.level}{n.module or ''}"
+                     for n in ast.walk(ast.parse(source))
+                     if isinstance(n, ast.ImportFrom)]
+    assert any(m.endswith("journal") or m.endswith("journal.events")
+               for m in modules_named), (
+        f"{relpath} is inventoried as a fleet-code write path and binds no "
+        f"journal module. Either it emits, or it is no longer a write path and "
+        f"belongs out of `FLEET_CODE_WRITE_PATHS` — a row for a module that "
+        f"does not write is what makes the next reader trust the list without "
+        f"checking it.")
+
+
+def test_no_UNINVENTORIED_module_reaches_a_store_write_shape() -> None:
+    """THE CENSUS. A store write with no emit beside it fails here.
+
+    ⚠ THE SHAPE IS NAMED AND IT IS THE LIMIT OF THE CLAIM. This walks for ONE
+    thing: a subprocess launched with `gh` as its first argv element, from a
+    module not on the inventory. **It deliberately does NOT walk for a bare
+    `write_text`** — the fleet writes prompts, temp files and worktree scratch
+    that way, so that walk would be almost entirely false positives and would
+    teach a reader to add exemptions rather than to stop reaching. It also does
+    not see a write through `shutil`, through a shell string, or through any
+    shape nobody listed.
+
+    **So this is the cheap guard, not the complete one.** Phase 4's rebuild test
+    is the guard for the class this cannot see — a write path nobody wrapped —
+    and saying so here is what stops this file reading as a completeness proof.
+
+    A NON-ZERO EXAMINED COUNT IS ASSERTED, because a walk that scoped itself
+    wrongly reports a clean sweep over nothing.
+    """
+    examined = 0
+    offenders: list[str] = []
+    for path in sorted(MODULES.rglob("*.py")):
+        if "journal" in path.parts:
+            continue                    # the journal writes ITSELF; see below
+        examined += 1
+        relpath = str(path.relative_to(MODULES))
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            launches_gh = (
+                node.args
+                and isinstance(node.args[0], (ast.List, ast.Tuple))
+                and node.args[0].elts
+                and isinstance(node.args[0].elts[0], ast.Constant)
+                and node.args[0].elts[0].value == "gh")
+            if launches_gh and relpath not in FLEET_CODE_WRITE_PATHS:
+                offenders.append(f"{relpath}:{node.lineno} launches `gh` directly")
+    assert examined > 20, (
+        f"the walk examined {examined} modules; a census over nothing proves "
+        f"nothing about coverage")
+    assert not offenders, (
+        f"these launch `gh` outside an inventoried write path, so a mutation "
+        f"through one would reach a store with nothing recording it: "
+        f"{offenders}. Route it through `assistant_activities.gh_attempt`, or "
+        f"add the module to `FLEET_CODE_WRITE_PATHS` with the emit it performs.")
+
+
+def test_the_journal_package_is_EXCLUDED_from_the_census_deliberately() -> None:
+    """It is the record, not a store, so its writes are not writes-to-a-store.
+
+    Stated as a test rather than as a comment because the exclusion is the one
+    line of this file a reader would suspect of hiding something: if the journal
+    package could reach `gh`, the exclusion WOULD be hiding something.
+    """
+    offenders = [str(p) for p in (MODULES / "journal").rglob("*.py")
+                 if '"gh"' in p.read_text(encoding="utf-8")]
+    assert not offenders, (
+        f"the journal package launches `gh`, so excluding it from the census "
+        f"above hides a real write path: {offenders}")
+
+
+# --- one behavioural test per inventoried path ------------------------------
+
+def test_a_gh_MUTATION_emits_and_a_gh_READ_does_not(tmp_path: Path,
+                                                    monkeypatch) -> None:
+    """The discriminator that makes this assertion worth anything.
+
+    Emitting on reads would put every `gh pr view` in the journal — thousands of
+    events per run, and the completeness claim would drown in them. Emitting on
+    neither would look identical to emitting on both in a test that only checked
+    "some events exist".
+    """
+    from modules.assistant import assistant_activities as act
+
+    class _Done:
+        returncode, stdout, stderr = 0, "https://github.com/o/r/pull/1#c1\n", ""
+
+    monkeypatch.setattr(act, "run_bounded", lambda *a, **k: _Done())
+    emitter = _emitter(tmp_path)
+    body = tmp_path / "comment.md"
+    body.write_text("## Decision Log\n\nkept it whole.\n", encoding="utf-8")
+
+    with emitting_into(emitter):
+        act.gh_attempt(["pr", "view", "1", "--json", "state"], tmp_path)
+        assert _events(emitter) == [], "a READ must not emit"
+
+        act.gh_attempt(["pr", "comment", "1", "--body-file", str(body)], tmp_path)
+
+    intent, done = _events(emitter)
+    assert intent.kind is EventKind.INTENT and done.kind is EventKind.COMPLETION
+    assert intent.write_path == "gh:pr:comment"
+    assert intent.content == "## Decision Log\n\nkept it whole.\n", (
+        "the `--body-file` was recorded as a PATH rather than read — a pointer "
+        "to bytes outside the journal is not the verbatim content")
+    assert done.destination.address == "https://github.com/o/r/pull/1#c1"
+
+
+def test_a_gh_write_that_FAILS_records_a_store_write_failure(tmp_path: Path,
+                                                             monkeypatch) -> None:
+    """And `gh_attempt` still RETURNS the failure rather than raising it.
+
+    Two callers depend on that contract — `gh issue list` degrading to a note,
+    and `ci_verdict` classifying by parsing a non-zero `gh pr checks`. The raise
+    exists only inside the closure, so `paired_write` can see the store write
+    fail.
+    """
+    from modules.assistant import assistant_activities as act
+
+    class _Failed:
+        returncode, stdout, stderr = 1, "", "HTTP 422"
+
+    monkeypatch.setattr(act, "run_bounded", lambda *a, **k: _Failed())
+    emitter = _emitter(tmp_path)
+    with emitting_into(emitter):
+        result = act.gh_attempt(["pr", "comment", "1", "--body", "hi"], tmp_path)
+
+    assert result.returncode == 1, "gh_attempt must not raise on a non-zero exit"
+    assert [e.kind for e in _events(emitter)] == [
+        EventKind.INTENT, EventKind.STORE_WRITE_FAILURE]
+
+
+def test_a_tracked_item_FILING_emits(tmp_path: Path) -> None:
+    from modules.assistant.tracked import tracked_items as ti
+
+    emitter = _emitter(tmp_path)
+    stores = tmp_path / "tracked"
+    with emitting_into(emitter):
+        ti.file_item(stores, ti.STORES["candidates"], title="a proposal",
+                     filed_by="build-draft", status="open",
+                     body="the reasoning")
+
+    intent = _events(emitter)[0]
+    assert intent.write_path == "tracked:candidates:file"
+    assert intent.destination.store == "tracked_candidates"
+    assert "the reasoning" in intent.content
+    assert _events(emitter)[-1].destination.address.endswith(".md")
+
+
+def test_a_tracked_item_INCREMENT_emits(tmp_path: Path) -> None:
+    """`count` is the recurrence signal triage sorts on, so its write is a write."""
+    from modules.assistant.tracked import tracked_items as ti
+
+    stores = tmp_path / "tracked"
+    path = ti.file_item(stores, ti.STORES["issues"], title="a defect",
+                        filed_by="review-pr", status="open", body="what broke")
+    emitter = _emitter(tmp_path)
+    with emitting_into(emitter):
+        assert ti.increment(path, "seen again on PR #300") == 2
+
+    assert _events(emitter)[0].write_path == "tracked:issues:increment"
+
+
+def test_a_research_pool_SEED_emits(tmp_path: Path) -> None:
+    """The write that does not look like one — no `gh`, no `tracked/` item.
+
+    That is the class requirement 9's enumeration exists to find.
+    """
+    from modules.assistant.plan.plan_project import plan_project_activities as ppa
+
+    emitter = _emitter(tmp_path)
+    seeded = tmp_path / "pool" / "synthesis.md"
+    seeded.parent.mkdir(parents=True)
+    with emitting_into(emitter):
+        ppa._write_seed(seeded, "# synthesis\n\nnot yet researched\n")
+
+    intent = _events(emitter)[0]
+    assert intent.write_path == "planning:research-pool:seed"
+    assert intent.destination.store == "planning_corpus"
+    assert seeded.read_text(encoding="utf-8") == "# synthesis\n\nnot yet researched\n"
+
+
+def test_a_write_path_OUTSIDE_a_run_still_performs_its_write(tmp_path: Path) -> None:
+    """`current_emitter()` answers `None` for a helper script or a unit test.
+
+    That is a real state and not an error — manufacturing an emitter would write
+    a bag for a process that is not a run, under a `run_id` nobody minted. The
+    STORE WRITE must still happen, or the emit rule would have broken every
+    non-run caller in the fleet.
+    """
+    from modules.assistant.tracked import tracked_items as ti
+
+    path = ti.file_item(tmp_path / "tracked", ti.STORES["issues"],
+                        title="filed outside a run", filed_by="a test",
+                        status="open", body="body")
+    assert path.is_file() and "filed outside a run" in path.read_text()
+
+
+def test_the_case_d_REPORT_is_the_one_write_that_does_not_emit(tmp_path: Path,
+                                                               monkeypatch) -> None:
+    """⚠ THE STATED EXCEPTION TO REQUIREMENT 1'S INVARIANT AND TO CASE (b).
+
+    The durable report IS a store write, and case (b) says a store write does not
+    happen unless its intent landed first — but in case (d) the journal is
+    unwritable by definition, so the intent can never land. Read literally, this
+    component's own ordering rule suppresses the only durable signal that the
+    component is broken. A build that implements case (b) as an unconditional
+    wrapper without this exception ships the failure path silently broken, which
+    is exactly what this test exists to catch.
+    """
+    from modules.assistant import assistant_activities as act
+    from modules.journal.emit import (UNWRITABLE_JOURNAL_MARKER,
+                                      JournalUnwritable,
+                                      unwritable_journal_report)
+
+    class _Done:
+        returncode, stdout, stderr = 0, "https://github.com/o/r/pull/1#c9\n", ""
+
+    monkeypatch.setattr(act, "run_bounded", lambda *a, **k: _Done())
+    emitter = _emitter(tmp_path)
+    report = unwritable_journal_report(JournalUnwritable("root is gone"))
+    line = f"{report['marker']}: {report['detail']}"
+
+    with emitting_into(emitter):
+        act.gh_attempt(["pr", "comment", "1", "--body", line], tmp_path)
+
+    assert _events(emitter) == [], (
+        "the case-(d) report emitted, which means a run whose journal is "
+        "unwritable would fail to publish the report saying so")
+    assert UNWRITABLE_JOURNAL_MARKER in line
+
+
+def test_an_ORDINARY_comment_still_emits_so_the_exception_is_NARROW(
+        tmp_path: Path, monkeypatch) -> None:
+    """The discriminator for the exception above.
+
+    Without it, a bug that skipped the emit for EVERY comment would pass that
+    test — and the completeness claim would be false for the single most
+    important surface this component records.
+    """
+    from modules.assistant import assistant_activities as act
+
+    class _Done:
+        returncode, stdout, stderr = 0, "https://github.com/o/r/pull/1#c9\n", ""
+
+    monkeypatch.setattr(act, "run_bounded", lambda *a, **k: _Done())
+    emitter = _emitter(tmp_path)
+    with emitting_into(emitter):
+        act.gh_attempt(["pr", "comment", "1", "--body", "an ordinary comment"],
+                       tmp_path)
+    assert len(_events(emitter)) == 2
+
+
+def test_a_TRANSIENT_failure_on_a_WRITE_is_not_retried_and_emits_ONE_pair(
+        tmp_path: Path, monkeypatch) -> None:
+    """⚠ THIS TEST'S FIRST VERSION ASSERTED A RETRY AND THE FLEET DOES NOT RETRY
+    WRITES — the correction is the finding, and it is a property worth pinning.
+
+    `gh_attempt` refuses to repeat a mutation past a transient server-side
+    failure: a 502 on a write may mean the write LANDED and only the reply was
+    lost, and nothing in the reply distinguishes that from a write that never
+    ran. So the risk the original test was written against — an emit inside the
+    retry loop producing one intent per attempt, and three duplicate rows in a
+    Phase 4 rebuild — is unreachable for writes by construction, and reachable
+    only for reads, which do not emit at all.
+
+    What IS assertable, and what this now asserts: one call produces exactly one
+    intent and one `store_write_failure`, and the transient reply drove exactly
+    one attempt.
+    """
+    from modules.assistant import assistant_activities as act
+
+    attempts: list[int] = []
+
+    def _transient(*_a, **_k):
+        attempts.append(1)
+
+        class _Reply:
+            returncode, stdout, stderr = 1, "", "HTTP 503"
+        return _Reply()
+
+    monkeypatch.setattr(act, "run_bounded", _transient)
+    emitter = _emitter(tmp_path)
+    with emitting_into(emitter):
+        act.gh_attempt(["issue", "create", "--title", "t", "--body", "b"],
+                       tmp_path)
+
+    assert attempts == [1], (
+        "a mutation was repeated past a transient failure, which may apply the "
+        "write twice")
+    assert [e.kind for e in _events(emitter)] == [
+        EventKind.INTENT, EventKind.STORE_WRITE_FAILURE]

--- a/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
@@ -760,8 +760,8 @@ def test_the_journal_package_imports_no_workflow_module(module: str) -> None:
     clean sweep over nothing.
 
     ⚠ ASKED OF THE IMPORTS, NOT OF THE TEXT — the same substring bug
-    `test_a_module_named_only_in_PROSE_is_not_reachable` above exists to rule
-    out, met here from the other side. `__init__.py` explains in prose why the
+    `test_the_reachability_check_FAILS_on_a_module_only_MENTIONED` above exists
+    to rule out, met here from the other side. `__init__.py` explains in prose why the
     package imports no workflow module, and a text scan reported that sentence
     as the violation it describes. The widened walk found it immediately; the
     fixed list never reached the file.

--- a/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_parent_opens_a_run_bag.py
@@ -728,7 +728,23 @@ def test_the_reachability_check_FAILS_on_a_module_only_MENTIONED(tmp_path: Path)
         "substring bug this check was rewritten to rule out")
 
 
-@pytest.mark.parametrize("module", ["root", "bag", "validate", "journal_activities"])
+#: The journal package's own directory, walked rather than listed. A FIXED LIST
+#: IS WHAT WENT STALE: this guard named the four Phase 1 modules, and Phase 2
+#: then Phase 3 added nine more — so the isolation property Phase 6's reader
+#: depends on was unasserted for nine files, including the four least-reviewed
+#: ones, while the guard still read as covering the package.
+_JOURNAL_PACKAGE = (REPO_ROOT / "scripts" / "workflows" / "temporal" /
+                    "modules" / "journal")
+
+#: ONE expression, read by the parametrize AND by its denominator below. Written
+#: twice, the denominator re-derived the population instead of measuring the one
+#: the cases come from — so a walk narrowed to nothing collapsed the parametrize
+#: to zero cases while the denominator kept passing on its own second glob.
+#: Found by mutating the parametrize and watching NOTHING go red.
+_JOURNAL_MODULES = sorted(p.stem for p in _JOURNAL_PACKAGE.glob("*.py"))
+
+
+@pytest.mark.parametrize("module", _JOURNAL_MODULES)
 def test_the_journal_package_imports_no_workflow_module(module: str) -> None:
     """The journal must be loadable by a measurement helper or a CPI sweep.
 
@@ -736,8 +752,40 @@ def test_the_journal_package_imports_no_workflow_module(module: str) -> None:
     `run_log.py`. Phase 6's reader is the consumer this protects: a validator
     that dragged in `modules.assistant` would drag in its `temporalio` import
     with it.
+
+    PARAMETRISED OVER A DIRECTORY WALK, so a module added to the package is
+    covered on the commit that adds it rather than on the commit somebody
+    remembers to widen a list. `test_the_journal_package_walk_SEES_something`
+    below is the denominator: a walk that scoped itself wrongly would report a
+    clean sweep over nothing.
+
+    ⚠ ASKED OF THE IMPORTS, NOT OF THE TEXT — the same substring bug
+    `test_a_module_named_only_in_PROSE_is_not_reachable` above exists to rule
+    out, met here from the other side. `__init__.py` explains in prose why the
+    package imports no workflow module, and a text scan reported that sentence
+    as the violation it describes. The widened walk found it immediately; the
+    fixed list never reached the file.
     """
-    source = (REPO_ROOT / "scripts" / "workflows" / "temporal" / "modules" /
-              "journal" / f"{module}.py").read_text()
-    assert "modules.assistant" not in source
-    assert "from ..assistant" not in source
+    tree = ast.parse((_JOURNAL_PACKAGE / f"{module}.py").read_text())
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            imported.append(f"{'.' * node.level}{node.module or ''}")
+        elif isinstance(node, ast.Import):
+            imported += [alias.name for alias in node.names]
+    offenders = [name for name in imported
+                 if name.startswith("modules.assistant")
+                 or name.startswith("..assistant")]
+    assert not offenders, (
+        f"`journal/{module}.py` imports {offenders}, which drags "
+        f"`temporalio` into every measurement helper and CPI sweep that loads "
+        f"the journal — Phase 6's reader is the consumer this protects")
+
+
+def test_the_journal_package_walk_SEES_something() -> None:
+    """A parametrised walk that matched no file passes by collecting no cases."""
+    assert len(_JOURNAL_MODULES) >= 10 and "emit" in _JOURNAL_MODULES, (
+        f"the isolation walk found {_JOURNAL_MODULES}; if it is empty or has "
+        f"lost the package's own modules, every case above is vacuous — and a "
+        f"parametrize over an empty list collects NO cases, which reads as "
+        f"green rather than as absent")

--- a/scripts/workflows/temporal/tests/unit/test_every_reach_into_the_content_store_CROSSES_THE_BOUNDARY.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_reach_into_the_content_store_CROSSES_THE_BOUNDARY.py
@@ -102,15 +102,16 @@ excusing it.
 
 ⚠ FAMILIES 1 AND 2 EACH CONTAIN THE FLEET'S OWN IDIOM, WHICH IS WHY NEITHER IS
 EXOTIC.
-Nineteen swept modules import a journal submodule as a name: the sixteen
+Twenty-two swept modules import a journal submodule as a name: the sixteen
 entrypoints take `journal_activities as journal`, `verify_citations.py` and
-`validate_bag.py` take `verify` and `validate`, and `assistant_activities.py`
-takes `emit as journal_emit` — the first two of those three are operator tools
-that READ a finished bag rather than entrypoints, per
-`journal_entrypoint_facts.py`'s own classification, so this file says *call
-sites* wherever the nineteen are meant. The nineteenth is Phase 3's, and it is
-the first fleet module to bind a journal submodule for a reason other than
-opening a bag: it wraps every `gh` mutation in the emit. `from .. import journal` is the
+`validate_bag.py` take `verify` and `validate`, and FOUR fleet modules take
+`emit as journal_emit` — `assistant_activities.py`, `tracked_items.py`,
+`merge_pr.py` and `plan_project_activities.py`. The two operator tools READ a
+finished bag rather than being entrypoints, per `journal_entrypoint_facts.py`'s
+own classification, so this file says *call sites* wherever the twenty-two are
+meant. The four emit binders are PMP Phase 3's, and they are the first fleet
+modules to bind a journal submodule for a reason other than opening a bag: each
+is a WRITE PATH, wrapping its store write in the intent-then-completion pair. `from .. import journal` is the
 dominant relative-import spelling across the workflow tree (`from .. import
 routing`, `from .. import plan_activities as act`, `from . import
 tracked_items as ti`). So both are what a real bypass looks like: a line copied
@@ -128,13 +129,13 @@ attributed the whole job to one of them and MEASUREMENT SAID OTHERWISE:
     `from modules.assistant import journal`, a sibling exporting a colliding
     name.
 
-The nineteen call sites are excluded REDUNDANTLY, by both at once, which is
+The twenty-two call sites are excluded REDUNDANTLY, by both at once, which is
 why neither mechanism can be controlled through them: each shape above isolates
 exactly one, and the control below uses those rather than the idiom.
 
 ⚠ AND NEITHER COSTS THE EIGHTEEN FALSE POSITIVES THEY WERE PREDICTED TO COST.
 Deleting the parent check outright leaves every test in this file green and
-flags no fleet module: those nineteen reach only `journal.open_run_bag` and
+flags no fleet module: those twenty-two reach only `journal.open_run_bag` and
 Phase 3's `journal_emit.current_emitter` / `paired_write`,
 which is in neither `STORE_MODULES` nor `STORE_IO_NAMES`, so a reach-based
 matcher never looks at them. The trap is structurally unreachable rather than
@@ -909,8 +910,8 @@ def test_the_FLEET_IDIOM_binding_journal_to_the_activities_module_is_NOT_flagged
     IS WHERE IT WAS FIRST WRITTEN. Deleting the parent check was expected to fail
     this file loudly and to flag nineteen fleet modules. MEASURED, IT DOES
     NEITHER: every test stayed green and the real-tree sweep named nothing,
-    because those nineteen call sites reach only `journal.open_run_bag` and the
-    emit boundary, neither of which is
+    because those twenty-two call sites reach only `journal.open_run_bag` and
+    the emit boundary, neither of which is
     in neither name set. So a control routed through the sweep over THE REAL TREE
     is vacuous — it would begin discriminating only once some module writes
     `journal.load_object` off the activities alias, which is the moment the guard

--- a/scripts/workflows/temporal/tests/unit/test_every_reach_into_the_content_store_CROSSES_THE_BOUNDARY.py
+++ b/scripts/workflows/temporal/tests/unit/test_every_reach_into_the_content_store_CROSSES_THE_BOUNDARY.py
@@ -102,12 +102,15 @@ excusing it.
 
 ⚠ FAMILIES 1 AND 2 EACH CONTAIN THE FLEET'S OWN IDIOM, WHICH IS WHY NEITHER IS
 EXOTIC.
-Eighteen swept modules import a journal submodule as a name: the sixteen
-entrypoints take `journal_activities as journal`, and `verify_citations.py` and
-`validate_bag.py` take `verify` and `validate` — those two are operator tools
+Nineteen swept modules import a journal submodule as a name: the sixteen
+entrypoints take `journal_activities as journal`, `verify_citations.py` and
+`validate_bag.py` take `verify` and `validate`, and `assistant_activities.py`
+takes `emit as journal_emit` — the first two of those three are operator tools
 that READ a finished bag rather than entrypoints, per
 `journal_entrypoint_facts.py`'s own classification, so this file says *call
-sites* wherever the eighteen are meant. `from .. import journal` is the
+sites* wherever the nineteen are meant. The nineteenth is Phase 3's, and it is
+the first fleet module to bind a journal submodule for a reason other than
+opening a bag: it wraps every `gh` mutation in the emit. `from .. import journal` is the
 dominant relative-import spelling across the workflow tree (`from .. import
 routing`, `from .. import plan_activities as act`, `from . import
 tracked_items as ti`). So both are what a real bypass looks like: a line copied
@@ -125,13 +128,14 @@ attributed the whole job to one of them and MEASUREMENT SAID OTHERWISE:
     `from modules.assistant import journal`, a sibling exporting a colliding
     name.
 
-The eighteen call sites are excluded REDUNDANTLY, by both at once, which is
+The nineteen call sites are excluded REDUNDANTLY, by both at once, which is
 why neither mechanism can be controlled through them: each shape above isolates
 exactly one, and the control below uses those rather than the idiom.
 
 ⚠ AND NEITHER COSTS THE EIGHTEEN FALSE POSITIVES THEY WERE PREDICTED TO COST.
 Deleting the parent check outright leaves every test in this file green and
-flags no fleet module: those eighteen only ever reach `journal.open_run_bag`,
+flags no fleet module: those nineteen reach only `journal.open_run_bag` and
+Phase 3's `journal_emit.current_emitter` / `paired_write`,
 which is in neither `STORE_MODULES` nor `STORE_IO_NAMES`, so a reach-based
 matcher never looks at them. The trap is structurally unreachable rather than
 narrowly avoided — and the guard against it is therefore untestable through the
@@ -280,7 +284,7 @@ def _package_bindings(tree: ast.AST) -> dict[str, int]:
     the whole difficulty. Eighteen fleet modules write
     `from modules.journal import journal_activities as journal`, which binds the
     ACTIVITIES module to the name `journal` and reaches nothing — so a matcher
-    reading the identifier text fails the unmodified tree eighteen times over.
+    reading the identifier text fails the unmodified tree nineteen times over.
     What is collected here is the prefix through which the package's attributes
     become reachable:
 
@@ -301,7 +305,7 @@ def _package_bindings(tree: ast.AST) -> dict[str, int]:
     modules.assistant as ma` reaches nothing and must stay out. Both halves are
     controlled below, in each direction.
 
-    Two independent checks keep a non-package binding out, and the eighteen
+    Two independent checks keep a non-package binding out, and the nineteen
     `journal_activities as journal` entrypoints happen to trip both — so neither
     can be observed through them. `alias.name` (never the asname) rejects
     `from modules import journal_activities as journal`; `node.module` rejects
@@ -492,7 +496,7 @@ def test_the_sweep_is_not_vacuous() -> None:
     """A sweep that examined nothing satisfies the assertion above exactly.
 
     THE FLOOR IS PER DIRECTORY, AND A SINGLE AGGREGATE FLOOR IS WHAT THIS FILE
-    SHIPPED FIRST. `modules/` alone holds 60 of the 82, so a total-only floor of
+    SHIPPED FIRST. `modules/` alone holds 61 of the 83, so a total-only floor of
     fifty stayed green with `scripts/` — all 22 of its modules — dropped from
     the population entirely. That is the failure this control exists to catch,
     passing the control: a guard whose SCOPE has halved reports the same green
@@ -507,7 +511,7 @@ def test_the_sweep_is_not_vacuous() -> None:
                  if (FLEET_ROOT / name) in p.parents]
         assert len(found) >= floor, (
             f"only {len(found)} modules discovered under {FLEET_ROOT / name}; "
-            f"this fleet has 60 under modules/ (outside the journal package) "
+            f"this fleet has 61 under modules/ (outside the journal package) "
             f"and 22 under scripts/. The predicate has drifted from the tree "
             f"and the absence above proves nothing about this half of it.")
 
@@ -606,7 +610,7 @@ def test_the_SUBMODULE_AS_A_NAME_bypass_is_caught(tmp_path) -> None:
 
     `from modules.journal import content_store` names the package, not the
     module, and binds the module anyway — so neither a dotted-path check nor a
-    re-exported-function-name check sees it. It is also how eighteen fleet
+    re-exported-function-name check sees it. It is also how nineteen fleet
     modules already import a journal submodule, which is what makes it the
     likeliest bypass rather than an exotic one.
     """
@@ -903,9 +907,10 @@ def test_the_FLEET_IDIOM_binding_journal_to_the_activities_module_is_NOT_flagged
 
     ⚠ WHY THE PRIMARY ASSERTION IS ON THE FUNCTION AND NOT ON THE SWEEP, WHICH
     IS WHERE IT WAS FIRST WRITTEN. Deleting the parent check was expected to fail
-    this file loudly and to flag eighteen fleet modules. MEASURED, IT DOES
+    this file loudly and to flag nineteen fleet modules. MEASURED, IT DOES
     NEITHER: every test stayed green and the real-tree sweep named nothing,
-    because those eighteen call sites only reach `journal.open_run_bag`, which is
+    because those nineteen call sites reach only `journal.open_run_bag` and the
+    emit boundary, neither of which is
     in neither name set. So a control routed through the sweep over THE REAL TREE
     is vacuous — it would begin discriminating only once some module writes
     `journal.load_object` off the activities alias, which is the moment the guard
@@ -951,7 +956,7 @@ def test_the_FLEET_IDIOM_binding_journal_to_the_activities_module_is_NOT_flagged
     # AND THE ONE `alias.name` ALONE HOLDS. This clears the parent check —
     # `modules` IS the package's parent — so only matching the original name
     # rather than the asname keeps it out. It is the isolated form of the
-    # eighteen entrypoints, which trip both checks at once and therefore
+    # nineteen entrypoints, which trip both checks at once and therefore
     # demonstrate neither.
     aliased_sibling = ast.parse(
         "from modules import journal_activities as journal\n")
@@ -1118,7 +1123,7 @@ def _journal_submodule_call_sites() -> dict[str, set[str]]:
 
     `from modules.journal import journal_activities as journal` and its two
     cousins. Derived rather than remembered: this file's prose rests on "the
-    eighteen call sites" and "the sixteen entrypoints", and a count with nothing
+    nineteen call sites" and "the sixteen entrypoints", and a count with nothing
     on the other end of it is what shipped wrong four times in this package.
     """
     submodules = {path.stem for path in BOUNDARY_DIR.glob("*.py")} - {"__init__"}
@@ -1186,12 +1191,12 @@ def test_the_FIGURES_this_files_prose_rests_on_are_DERIVED() -> None:
 
     # AND THE MAP'S COPY OF THE SAME FIGURES, because that is the surface where
     # one of them shipped FALSE — `docs/file_structure.txt` said `content_store`
-    # was the entrypoints' spelling in eighteen places, and no fleet module
+    # was the entrypoints' spelling in nineteen places, and no fleet module
     # imports `content_store` as a name at all. `test_journal_prose_figures_are_
     # DERIVED` sweeps that file but recognises only entrypoint-population forms,
     # so these figures sit in the one gap between the two guards.
     # ⚠ EVERY OCCURRENCE, NOT THE FIGURE'S PRESENCE SOMEWHERE. This assertion
-    # first asked whether `"eighteen call"` appeared in the annotation, and a
+    # first asked whether `"nineteen call"` appeared in the annotation, and a
     # mutation falsifying ONE of its three copies stayed green because the other
     # two still matched — predicted one red, observed zero. A presence check over
     # a repeated figure is exactly the vacuity this file is about, so each

--- a/scripts/workflows/temporal/tests/unit/test_journal_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_bag.py
@@ -555,3 +555,72 @@ def test_write_payload_REFUSES_a_symlinked_segment(tmp_path: Path) -> None:
         bag.write_payload("data/linked/x.txt", "x")
     assert not (outside / "x.txt").exists(), (
         "the write followed the link and landed outside the bag")
+
+
+def test_the_MANIFEST_is_written_INSIDE_the_lock_that_covers_the_tag_lines(
+        tmp_path: Path) -> None:
+    """⚠ `_tag_file_lock` CLAIMED TO COVER THE MANIFEST AND DID NOT.
+
+    Its docstring says *"one lock covers `bag-info.txt` and
+    `manifest-sha256.txt` together, which is what a reseal actually needs:
+    `seal` writes both, and a reader between them would see a manifest that does
+    not match the Oxum"* — while `seal` wrote the manifest OUTSIDE the lock,
+    through the truncating writer, and then took and released the lock three
+    times for its three tag lines. `mark_incomplete` reseals, and Phase 3 makes
+    that reachable from every emitter on a full disk, so two concurrent reseals
+    could interleave two truncating writes of one manifest.
+
+    THE PROBE IS "DOES SEAL TOUCH THE MANIFEST WHILE ANOTHER HOLDER HAS THE
+    LOCK", which is decidable without racing anything: a second process holds
+    the bag directory's `flock`, and this thread calls `seal()`. Under the
+    defect the manifest is rewritten immediately and only the tag lines block;
+    with the fix nothing moves until the lock is released. A final assertion
+    that the reseal DID land is what stops this passing on a `seal()` that
+    simply never wrote.
+    """
+    import subprocess
+    import sys
+    import textwrap
+    import threading
+    import time
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700)
+    bag = open_bag(root, "lock")
+    bag.write_payload("data/a.txt", "first")
+    bag.seal()
+    before = bag.manifest_path.read_text(encoding="utf-8")
+
+    # A SECOND PAYLOAD FILE, so a reseal MUST change the manifest. Without it
+    # "unchanged while the lock is held" would be true of a seal that ran.
+    bag.write_payload("data/b.txt", "second")
+
+    holder = textwrap.dedent(f"""
+        import fcntl, os, time
+        fd = os.open({str(bag.path)!r}, os.O_RDONLY | os.O_DIRECTORY)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        print("held", flush=True)
+        time.sleep(2.0)
+        os.close(fd)
+    """)
+    script = tmp_path / "holder.py"
+    script.write_text(holder, encoding="utf-8")
+    worker = subprocess.Popen([sys.executable, str(script)],
+                              stdout=subprocess.PIPE, text=True)
+    try:
+        assert worker.stdout.readline().strip() == "held"
+        sealer = threading.Thread(target=bag.seal)
+        sealer.start()
+        time.sleep(0.5)
+        during = bag.manifest_path.read_text(encoding="utf-8")
+        assert during == before, (
+            "the manifest was rewritten while another writer held the bag's "
+            "lock, so `seal` is not the single critical section its own lock "
+            "docstring describes — two concurrent reseals can interleave two "
+            "whole-file writes of it")
+    finally:
+        worker.wait(timeout=10)
+        sealer.join(timeout=10)
+
+    assert "data/b.txt" in bag.manifest_path.read_text(encoding="utf-8"), (
+        "the reseal never landed, so the assertion above held vacuously")

--- a/scripts/workflows/temporal/tests/unit/test_journal_bag.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_bag.py
@@ -496,3 +496,62 @@ def test_open_bag_ADOPTS_rather_than_crashing_when_the_directory_appears_first(r
     second = open_bag(root, "raced")
     assert second.path == first.path
     assert (second.payload_dir / "a.txt").read_text() == "written by the winner"
+
+
+# --- the payload writer PMP Phase 3 adds --------------------------------------
+
+def test_a_payload_file_written_through_the_bag_is_FILE_MODE(tmp_path: Path) -> None:
+    """PMP Phase 3: `config.yaml` states payload files are `0600`.
+
+    Phase 1 applied `FILE_MODE` only to the tag files it wrote itself, because
+    nothing wrote payload yet — so this phase is what makes that statement true
+    or a lie. It stops being harmless the moment Phase 7 tars a bag and lands
+    world-readable transcripts somewhere the `0700` root is not protecting them,
+    at which point the fix is a bucket-wide operation rather than a mode
+    argument.
+    """
+    if os.geteuid() == 0:
+        pytest.skip("mode assertions do not bind uid 0")
+    bag = open_bag(tmp_path, "run")
+    written = bag.write_payload("data/child/transcript.jsonl", "a line\n")
+    assert written.stat().st_mode & 0o777 == FILE_MODE
+    assert written.read_text(encoding="utf-8") == "a line\n"
+
+
+def test_a_payload_file_is_written_ONCE_and_never_overwritten(tmp_path: Path) -> None:
+    """The journal is append-only, so overwriting is the immutability rule being
+    broken from inside the writer that enforces it. A redaction is the one
+    sanctioned replacement."""
+    bag = open_bag(tmp_path, "run")
+    bag.write_payload("data/child/a.txt", "first")
+    with pytest.raises(BagError, match="written once"):
+        bag.write_payload("data/child/a.txt", "second")
+    assert (bag.path / "data/child/a.txt").read_text() == "first"
+
+
+@pytest.mark.parametrize("relpath", ["bag-info.txt", "data/../../escape",
+                                     "../outside"])
+def test_write_payload_REFUSES_a_path_outside_the_payload_directory(
+        tmp_path: Path, relpath: str) -> None:
+    """The same containment `redact` proves its own path with, reused rather than
+    re-derived — the input is the same class, a caller-supplied string composed
+    onto a trusted base path."""
+    bag = open_bag(tmp_path, "run")
+    with pytest.raises(BagError):
+        bag.write_payload(relpath, "x")
+
+
+def test_write_payload_REFUSES_a_symlinked_segment(tmp_path: Path) -> None:
+    """A bag holds bytes, not pointers to bytes that live outside it.
+
+    A symlinked intermediate directory relocates everything beneath it just as
+    effectively as a symlinked file does, which is why every segment is checked.
+    """
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    bag = open_bag(tmp_path, "run")
+    (bag.payload_dir / "linked").symlink_to(outside)
+    with pytest.raises(BagError, match="symlink"):
+        bag.write_payload("data/linked/x.txt", "x")
+    assert not (outside / "x.txt").exists(), (
+        "the write followed the link and landed outside the bag")

--- a/scripts/workflows/temporal/tests/unit/test_journal_edge_id_and_capture_filter.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_edge_id_and_capture_filter.py
@@ -1,0 +1,279 @@
+"""The machine's name and the append-time filter — PMP Phase 3 requirements 6, 10.
+
+TWO SMALL MODULES IN ONE FILE, BECAUSE THEY SHARE ONE ARGUMENT. Both exist to
+keep a secret out of a durable record: `edge_id` by refusing an identity derived
+from a credential, `capture_filter` by removing named credential shapes before
+any byte reaches the root. Splitting them would put that argument in two places
+and let one copy go stale.
+
+⚠ THE FILTER'S BOUNDARY IS ASSERTED AS A BOUNDARY, NOT AS A CAPABILITY. A
+pattern filter sees the shapes it was given; it does not see a bare password, a
+credential wrapped across two lines, or one base64-ed. The tests below say so
+out loud rather than leaving a reader to infer a guarantee this module cannot
+support — a suite that only demonstrated catches would read as a completeness
+claim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.journal.capture_filter import (RULES, filter_capture,
+                                            placeholder_for)
+from modules.journal.edge_id import (EDGE_ID_FILE, NO_CREDENTIAL_EPOCH,
+                                     EdgeIdError, adopt_edge_id, read_edge_id,
+                                     resolve_edge_id)
+
+
+@pytest.fixture()
+def root(tmp_path: Path) -> Path:
+    directory = tmp_path / "journal"
+    directory.mkdir(mode=0o700)
+    return directory
+
+
+# --- requirement 6: the identity -------------------------------------------
+
+def test_the_id_is_minted_once_and_is_STABLE_across_runs(root: Path) -> None:
+    """Stability is the whole requirement: a journal keyed by a rotating value
+    orphans an edge's entire history the day that value changes."""
+    first = resolve_edge_id(root)
+    assert resolve_edge_id(root) == first
+    assert (root / EDGE_ID_FILE).read_text(encoding="utf-8").strip() == first
+
+
+def test_an_unminted_machine_READS_as_None_rather_than_as_a_fresh_id(
+        root: Path) -> None:
+    """`None` means NOT YET MINTED, which is the true state of a first run.
+
+    Returning a fresh id from a READ would give a validator, a Phase 6 sweep and
+    the run itself three different answers for one machine.
+    """
+    assert read_edge_id(root) is None
+
+
+def test_the_id_is_persisted_at_the_MACHINE_and_not_inside_a_bag(
+        root: Path) -> None:
+    """A file inside a bag would be per-RUN, and an id that changes per run is
+    not an id."""
+    resolve_edge_id(root)
+    assert (root / EDGE_ID_FILE).is_file()
+    assert not any(p.is_dir() for p in root.iterdir()), (
+        "the id must not have created a bag-shaped directory at the root")
+
+
+def test_the_id_is_0600_like_everything_else_under_a_0700_root(root: Path) -> None:
+    resolve_edge_id(root)
+    assert (root / EDGE_ID_FILE).stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.parametrize("digest_length", [32, 40, 64])
+def test_a_DIGEST_SHAPED_id_is_REFUSED_on_adoption(root: Path,
+                                                   digest_length: int) -> None:
+    """`hash(api_key)` is ruled out twice over and this is the rule as code.
+
+    It changes on rotation — the orphaning bug the whole requirement exists to
+    prevent — and a stored hash of a live credential is an offline confirmation
+    oracle. A future implementer who reads *"the key maps to a stable id"* and
+    reaches for `sha256(key).hexdigest()` is stopped by an error naming the rule;
+    they are not stopped by a paragraph in a docstring.
+    """
+    with pytest.raises(EdgeIdError, match="shape of a bare digest"):
+        adopt_edge_id(root, "a" * digest_length, source="the upstream pair")
+
+
+def test_a_PREFIXED_random_token_is_ACCEPTED(root: Path) -> None:
+    """The check is on SHAPE, and it must not refuse a legitimate assigned name.
+
+    This is the control for the parametrised refusal above: without it, a rule
+    that refused everything would pass all three of those cases.
+    """
+    assert adopt_edge_id(root, "edge-" + "a" * 32) == "edge-" + "a" * 32
+
+
+def test_adopting_a_DIFFERENT_id_on_a_machine_that_has_one_is_REFUSED(
+        root: Path) -> None:
+    """Every event already written carries the old value.
+
+    Adopting a second would split one machine's history into two edges that look
+    like two machines — the same orphaned-history failure a credential-derived id
+    causes, reached deliberately instead of by rotation.
+    """
+    resolve_edge_id(root)
+    with pytest.raises(EdgeIdError, match="cannot become"):
+        adopt_edge_id(root, "edge-operator-assigned")
+
+
+def test_adopting_the_SAME_id_is_idempotent(root: Path) -> None:
+    """A caller passing the configured id on every run is correct, not an error."""
+    adopt_edge_id(root, "edge-mdc-01")
+    assert adopt_edge_id(root, "edge-mdc-01") == "edge-mdc-01"
+
+
+@pytest.mark.parametrize("bad,why", [
+    ("", "empty"),
+    (" edge-1", "surrounding whitespace"),
+    ("edge-1 ", "surrounding whitespace"),
+    ("edge/1", "permitted set"),
+    ("edge\n1", "permitted set"),
+    ("e" * 129, "permitted set"),
+])
+def test_an_id_that_would_not_survive_a_tag_line_is_REFUSED(root: Path, bad: str,
+                                                            why: str) -> None:
+    """It goes into `bag-info.txt` as a tag value AND into every event.
+
+    Anything `str.splitlines()` breaks on folds the line into what reads as a
+    second label — the forging class `bag.folds_a_tag_line` exists to close — and
+    surrounding whitespace reads back stripped, a different string from the one
+    written.
+    """
+    with pytest.raises(EdgeIdError, match=why):
+        adopt_edge_id(root, bad)
+
+
+def test_a_NON_UTF8_id_file_is_REFUSED_rather_than_guessed(root: Path) -> None:
+    """`UnicodeDecodeError` is a `ValueError`, so `except OSError` would miss it.
+
+    It cannot be guessed either: every event under this root carries the value
+    that belongs in this file.
+    """
+    (root / EDGE_ID_FILE).write_bytes(b"\xff\xfe not utf-8")
+    with pytest.raises(EdgeIdError, match="not valid UTF-8"):
+        read_edge_id(root)
+
+
+def test_an_EMPTY_id_file_names_its_own_remedy(root: Path) -> None:
+    """A run killed between `O_EXCL` create and the write leaves this state.
+
+    A retry loop here would spin on it forever; the refusal names the file and
+    what to do, which is what a human needs because no run can fix it.
+
+    ⚠ IT IS REFUSED AT THE READ, WHICH IS WHERE IT IS REACHABLE. `resolve_edge_id`
+    reads before it mints, so an empty file never reaches the `O_EXCL` race arm
+    — an `if raced is None` branch there would be dead code carrying a second
+    copy of this message. Both callers hit one refusal.
+    """
+    (root / EDGE_ID_FILE).write_text("")
+    with pytest.raises(EdgeIdError, match="an EMPTY FILE here means"):
+        resolve_edge_id(root)
+    with pytest.raises(EdgeIdError, match="an EMPTY FILE here means"):
+        read_edge_id(root)
+
+
+def test_no_credential_epoch_is_a_VALUE_and_not_an_absence() -> None:
+    """`JournalEvent` refuses an empty `key_epoch`, so this cannot be skipped.
+
+    "None" is a real answer for this fleet today — it authenticates to no
+    upstream pair — and an empty string would be indistinguishable from a field
+    somebody forgot to fill, which is a state a replay scoped past a leaked
+    credential cannot act on.
+    """
+    assert NO_CREDENTIAL_EPOCH and NO_CREDENTIAL_EPOCH.strip() == NO_CREDENTIAL_EPOCH
+
+
+# --- requirement 10: the capture filter -------------------------------------
+
+@pytest.mark.parametrize("rule_name,sample", [
+    ("github-token", "ghp_" + "A" * 36),
+    ("github-pat", "github_pat_" + "A" * 40),
+    ("aws-access-key", "AKIA" + "B" * 16),
+    ("openai-key", "sk-" + "c" * 40),
+    ("slack-token", "xoxb-123456789012-abcdefghijkl"),
+    ("google-api-key", "AIza" + "D" * 35),
+    ("bearer-header", "Authorization: Bearer abcdef0123456789"),
+    ("url-embedded-credential", "https://user:pa55word@example.com/x"),
+])
+def test_each_named_shape_is_REMOVED_and_the_rule_is_NAMED(rule_name: str,
+                                                           sample: str) -> None:
+    """Every rule fires on its own sample, and the placeholder names it.
+
+    A suite that exercised one rule and trusted the rest would leave a broken
+    pattern shipping — and a broken pattern in this table is a secret in a
+    durable record, not a missing feature.
+    """
+    result = filter_capture(f"prefix {sample} suffix")
+    assert sample not in result.text
+    assert result.fired
+    assert result.removed_bytes > 0
+    assert "prefix" in result.text and "suffix" in result.text, (
+        "the rule ate surrounding content, which is the over-broad failure the "
+        "placeholder's rule name exists to make diagnosable")
+
+
+def test_the_private_key_BLOCK_is_removed_whole() -> None:
+    """A multi-line shape, which the per-line intuition would miss."""
+    block = ("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+             "b3BlbnNzaC1rZXktdjEAAAAA\nAAAA\n"
+             "-----END OPENSSH PRIVATE KEY-----")
+    result = filter_capture(f"here it is:\n{block}\ndone")
+    assert "b3BlbnNzaC1rZXktdjEAAAAA" not in result.text
+    assert "done" in result.text
+
+
+def test_ordinary_prose_is_UNTOUCHED() -> None:
+    """The control. Without it every assertion above passes for a filter that
+    removes everything, which would empty the journal rather than protect it."""
+    prose = ("## Decision Log\n\n- **[High]** kept the phase whole. The commit "
+             "is 4d0fb8dfd74b9e645c46c3cb and the PR is #284.\n")
+    result = filter_capture(prose)
+    assert result.text == prose
+    assert not result.fired
+    assert result.removed_bytes == 0
+
+
+def test_a_git_SHA_does_NOT_fire_the_filter() -> None:
+    """The specific false positive an entropy heuristic would have produced.
+
+    Every `event_id` in the journal's own events is a 32-character hex string, so
+    an entropy rule would filter the record's own identity fields and report a
+    leak on every bag. That is why the rules are prefixed shapes.
+    """
+    assert not filter_capture("commit 4d0fb8dfd74b9e645c46c3cb0123456789abcdef").fired
+
+
+def test_removed_bytes_counts_the_INPUT_span_and_is_never_negative() -> None:
+    """A length difference would report a NEGATIVE removal for a short token —
+    a number that reads as "the filter added content"."""
+    secret = "ghp_" + "A" * 36
+    assert filter_capture(secret).removed_bytes == len(secret)
+
+
+def test_the_filter_is_TOTAL_over_its_input_and_never_raises() -> None:
+    """It runs on the append path of a component whose thesis is that a failed
+    write must not be silent; a filter that raised would convert a leak into a
+    crash on the path that is supposed to keep running."""
+    for weird in ("", "\x00\x01", "𝔘𝔫𝔦𝔠𝔬𝔡𝔢", "a" * 100_000):
+        assert isinstance(filter_capture(weird).text, str)
+
+
+def test_the_placeholder_names_the_rule_and_carries_no_match() -> None:
+    assert placeholder_for("github-token") == "[FILTERED:github-token]"
+
+
+def test_every_declared_rule_has_a_UNIQUE_name() -> None:
+    """A duplicate name makes the placeholder ambiguous about which rule fired,
+    which is the one diagnostic the record carries."""
+    names = [rule.name for rule in RULES]
+    assert len(names) == len(set(names))
+
+
+@pytest.mark.parametrize("missed", [
+    "password: hunter2",
+    "Z2hwX0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ==",
+])
+def test_the_STATED_BLIND_SPOTS_are_real_and_are_asserted_as_such(
+        missed: str) -> None:
+    """⚠ THESE PASS THE FILTER, AND THAT IS THE POINT OF WRITING THEM DOWN.
+
+    A credential with no distinguishing shape and one that is base64 of something
+    the filter would otherwise catch both go through. The module says so; this
+    is the assertion that keeps the claim honest, and it goes RED the day someone
+    widens the rules — at which point the docstring is what needs updating, not
+    this test's expectation.
+
+    Phase 1's redaction is the component's control for what gets past here. This
+    is the cheap gate; that is the incident response.
+    """
+    assert not filter_capture(missed).fired

--- a/scripts/workflows/temporal/tests/unit/test_journal_emit.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_emit.py
@@ -1,0 +1,492 @@
+"""The emit boundary — PMP Phase 3 requirements 1, 4, 10, 11, 12.
+
+DRIVEN AGAINST REAL BAGS ON A REAL FILESYSTEM, never against a mocked writer.
+The phase's whole argument for answering *what happens when the write fails* is
+that the answer decides whether Phase 4's guarantee means anything — and a mocked
+`open()` proves the code branches, not that the bag ends up in the state the
+branch claims. Every failure below is induced by making the filesystem refuse:
+a read-only directory, a path that is not there, a file where a directory should
+be. The assertion is always on the BAG AFTERWARDS.
+
+⚠ AND THE FAILURES ARE INDUCED BY MODE, WHICH DOES NOT BIND ROOT. `test_journal_
+bag.py` already skips its mode assertions under root for this reason; the two
+here that need a refusing filesystem carry the same skip rather than passing
+vacuously on a CI image that runs as uid 0.
+
+WHAT THIS FILE DOES NOT ASSERT: the contract itself. `test_journal_events.py`
+owns admission, identity and the two replay rules, and keeping them apart is what
+stops a contract written wrongly and exercised wrongly from agreeing with itself.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from modules.journal import emit as emitmod
+from modules.journal.bag import LABEL_GAP, open_bag, read_tag_file
+from modules.journal.edge_id import NO_CREDENTIAL_EPOCH
+from modules.journal.emit import (EmitFailed, Emitter, JournalUnwritable,
+                                  StoreWriteFailed, current_emitter,
+                                  emitting_into, gap_class_for,
+                                  unwritable_journal_in_text,
+                                  unwritable_journal_report)
+from modules.journal.events import (EVENTS_FILE, Destination, EventKind,
+                                    GapClass, Provenance, decode_event)
+from modules.vocabulary import TerminalState
+
+ROOT_SKIP = pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason="a mode-induced write refusal does not bind uid 0, so this would "
+           "assert nothing rather than assert something weaker")
+
+
+@pytest.fixture()
+def bag(tmp_path: Path):
+    root = tmp_path / "journal"
+    # `open_bag` stages the bag in a hidden sibling directory and renames it into
+    # place (Phase 9 r7), so the ROOT has to exist first. In the fleet
+    # `resolve_journal_root` creates it; here nothing has, and the failure it
+    # produces — a `FileNotFoundError` out of `tempfile` — points at the staging
+    # code rather than at the missing root.
+    root.mkdir(mode=0o700, parents=True)
+    return open_bag(root, "run-1")
+
+
+@pytest.fixture()
+def emitter(bag) -> Emitter:
+    return Emitter.for_run(bag, writer=None, journal_root=bag.path.parent)
+
+
+def _events(emitter: Emitter) -> list:
+    if not emitter.events_path.is_file():
+        return []
+    return [decode_event(line) for line
+            in emitter.events_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()]
+
+
+def _make_unwritable(emitter: Emitter) -> None:
+    """Make every append fail, the way a full disk or a lost mount does.
+
+    THE DIRECTORY IS SEALED, NOT THE FILE. Removing the file would be caught by
+    `O_CREAT` and the append would succeed; a `0500` directory refuses the
+    creation itself, which is the shape `ENOSPC`/`EROFS` present at this call.
+    """
+    emitter.writer_dir.chmod(0o500)
+
+
+# --- the boundary itself ----------------------------------------------------
+
+def test_a_parent_emits_at_the_payload_ROOT_and_a_member_in_its_own_subfolder(
+        bag) -> None:
+    """Phase 9 ruled that an invocation which IS the run takes no writer subfolder.
+
+    Its records are the run's, not one member's. There is no contention either
+    way: a parent writes `data/events.jsonl` and each member writes
+    `data/<writer>/events.jsonl`, so no two writers share a file — the property
+    `writer_dir` exists for.
+    """
+    parent = Emitter.for_run(bag, writer=None, journal_root=bag.path.parent)
+    member = Emitter.for_run(bag, writer="critic", journal_root=bag.path.parent)
+    assert parent.events_path == bag.payload_dir / EVENTS_FILE
+    assert member.events_path == bag.payload_dir / "critic" / EVENTS_FILE
+
+
+def test_an_edge_id_is_minted_once_and_reused(bag) -> None:
+    first = Emitter.for_run(bag, writer=None, journal_root=bag.path.parent)
+    second = Emitter.for_run(bag, writer="w", journal_root=bag.path.parent)
+    assert first.edge_id == second.edge_id
+    assert first.edge_id.startswith("edge-")
+    assert first.key_epoch == NO_CREDENTIAL_EPOCH
+
+
+# --- requirement 4 case (b): the paired write -------------------------------
+
+def test_a_paired_write_emits_the_INTENT_BEFORE_the_store_write(
+        emitter: Emitter) -> None:
+    """Write-ahead ordering, asserted by observing the journal FROM the store write.
+
+    ⚠ THIS IS THE ASSERTION THAT ACTUALLY CHECKS ORDER. Reading the file
+    afterwards and finding two events in order proves the WRITE order, not the
+    ordering relative to the side effect — the intent could have been written
+    after `perform` returned and still land first in the file. Asking the
+    question from INSIDE `perform` is the only place the distinction is visible.
+    """
+    seen: list[str] = []
+
+    def _perform() -> str:
+        seen.extend(e.kind.value for e in _events(emitter))
+        return "https://example/1"
+
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content="the body", perform=_perform,
+                         address_of=lambda url: url)
+    assert seen == ["intent"], (
+        "the store write ran before its intent was on disk, so a journal failure "
+        "would leave the store holding content the record does not")
+
+
+def test_a_completed_pair_shares_ONE_identity_and_carries_the_address(
+        emitter: Emitter) -> None:
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content="the body", perform=lambda: "https://example/1",
+                         address_of=lambda url: url)
+    intent, done = _events(emitter)
+    assert intent.event_id == done.event_id, "a pair is ONE unit with two events"
+    assert intent.destination.address == ""
+    assert done.destination.address == "https://example/1"
+    assert done.terminal_state is TerminalState.COMPLETED
+
+
+def test_the_content_is_carried_VERBATIM(emitter: Emitter) -> None:
+    """Requirement 1's word. A summary here is the whole component failing quietly."""
+    body = "## Decision Log\n\n- **[High]** kept the phase whole — em dash —\n"
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content=body, perform=lambda: "u")
+    assert _events(emitter)[0].content == body
+
+
+@ROOT_SKIP
+def test_a_FAILED_INTENT_means_the_store_write_does_NOT_happen(
+        emitter: Emitter) -> None:
+    """Case (b), and the invariant holds because BOTH sides are absent.
+
+    This is the ordering's whole payoff: *if any store gets it, the journal gets
+    it*. A journal failure means neither happened, so the record is SHORT rather
+    than WRONG — and short is recoverable while wrong is not.
+    """
+    performed: list[int] = []
+    _make_unwritable(emitter)
+    with pytest.raises(EmitFailed, match="store write was NOT performed"):
+        emitter.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content="body",
+                             perform=lambda: performed.append(1))
+    assert performed == [], "the store write ran after its intent failed"
+
+
+def test_a_FAILED_STORE_WRITE_records_a_failure_event_and_re_raises(
+        emitter: Emitter) -> None:
+    """The intent landed and the store write did not — a POSITIVE record exists.
+
+    Without it Phase 4's replay materialises unpublished content into the store,
+    turning a failed write into a delayed successful one that no run and no human
+    approved.
+    """
+    def _boom() -> None:
+        raise RuntimeError("gh exited 1")
+
+    with pytest.raises(StoreWriteFailed, match="replay will not apply"):
+        emitter.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content="body", perform=_boom)
+    kinds = [e.kind for e in _events(emitter)]
+    assert kinds == [EventKind.INTENT, EventKind.STORE_WRITE_FAILURE]
+
+
+def test_a_RETRIED_paired_write_appends_a_deduplicable_pair_per_attempt(
+        emitter: Emitter) -> None:
+    """An activity executes AT LEAST ONCE, so the journal must survive a retry.
+
+    ⚠ THE APPEND IS NOT SUPPRESSED — the journal is append-only, so a retry
+    genuinely writes again. What makes it safe is that both attempts derive the
+    SAME identity, so `dedupe_on_identity` collapses them on read. Suppressing
+    the append would require the emitter to remember what it wrote, which is
+    state a retried process does not have.
+    """
+    from modules.journal.events import applied_intents
+
+    for _ in range(2):
+        retried = Emitter(bag=emitter.bag, writer_dir=emitter.writer_dir,
+                          run_id=emitter.run_id, edge_id=emitter.edge_id)
+        retried.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content="body", perform=lambda: "u",
+                             address_of=lambda u: u)
+
+    assert len(_events(emitter)) == 4, "an append-only journal appends"
+    assert len(applied_intents(_events(emitter))) == 1, (
+        "replay applied the retried write twice — the duplicate-row failure "
+        "dedupe-on-identity exists to prevent")
+
+
+# --- requirement 4 case (c): the unpairable write ---------------------------
+
+def test_an_unpairable_write_emits_a_COMPLETION_with_no_prior_intent(
+        emitter: Emitter) -> None:
+    """The content already exists, so there is nothing to withhold.
+
+    This is also the shape Phase 10's post-exit harvest emits for a model-issued
+    write — a completion with no intent is a legitimate typed shape rather than
+    a hole, and the docs must not imply otherwise.
+    """
+    emitter.unpairable_write(write_path="transcript",
+                             destination=Destination(store="filesystem"),
+                             content="tool calls")
+    assert [e.kind for e in _events(emitter)] == [EventKind.COMPLETION]
+
+
+@ROOT_SKIP
+def test_a_FAILED_unpairable_write_marks_the_bag_incomplete_and_continues(
+        emitter: Emitter, bag) -> None:
+    """Case (c): the failure is RECORDED rather than prevented, and the run goes on.
+
+    Everything downstream then treats the bag as a known-gap input rather than a
+    clean one — Phase 4 reports it with a count and its denominator, Phase 6 says
+    so in its report, and Phase 7 ships the marking with the bag.
+    """
+    _make_unwritable(emitter)
+    emitter.unpairable_write(write_path="run-facts",
+                             destination=Destination(store="filesystem"),
+                             content="x" * 100)
+    assert bag.incomplete, "a gap that leaves the bag reading clean is a SILENT gap"
+    gaps = [v for label, v in read_tag_file(bag.info_path) if label == LABEL_GAP]
+    assert len(gaps) == 1 and "run-facts" in gaps[0]
+
+
+@ROOT_SKIP
+def test_the_TRANSCRIPT_arm_STOPS_the_run_where_an_ordinary_gap_does_not(
+        emitter: Emitter, bag) -> None:
+    """The one member of case (c) that is not merely a completeness problem.
+
+    The transcript is the fleet's only record of what commands ran, this fleet
+    runs with permissions bypassed, and a run can itself create the disk-full
+    condition that drops it. Losing it while the run proceeds to completion is
+    evidence loss wearing a routine defect's clothes.
+    """
+    _make_unwritable(emitter)
+    with pytest.raises(EmitFailed, match="stops the run"):
+        emitter.unpairable_write(write_path="transcript",
+                                 destination=Destination(store="filesystem"),
+                                 content="tool calls", stop_on_failure=True)
+    assert bag.incomplete, "stopping must not cost the gap record"
+
+
+@pytest.mark.parametrize("errno_name,expected", [
+    ("ENOSPC", GapClass.DISK_FULL),
+    ("EROFS", GapClass.READ_ONLY),
+    ("ENOENT", GapClass.PATH_GONE),
+    ("EIO", GapClass.WRITE_FAILED),
+])
+def test_an_OSError_becomes_a_CLOSED_class_and_never_its_message(
+        errno_name: str, expected: GapClass) -> None:
+    """The message is discarded on purpose.
+
+    A `why` carrying `strerror` or `filename` would put the failing path — and on
+    some filesystems a fragment of what was being written — into the record that
+    exists to say those bytes were dropped. The operator still gets the message,
+    on stderr and in the raised exception; what is bounded is what reaches the
+    DURABLE record Phase 7 syncs and Phase 4 replays.
+    """
+    import errno as errno_mod
+    assert gap_class_for(OSError(getattr(errno_mod, errno_name), "x")) is expected
+
+
+# --- requirement 4 case (d): the bootstrap case -----------------------------
+
+@ROOT_SKIP
+def test_case_d_raises_when_even_the_GAP_RECORD_cannot_be_written(
+        emitter: Emitter, bag) -> None:
+    """The case that makes (c) circular if it is not answered.
+
+    Both the gap event and the `incomplete` flag fail, so the journal cannot
+    record that the journal failed — and the report has to leave on channels that
+    are not the journal.
+    """
+    # ⚠ THE TAG FILE IS SEALED AT THE FILE, NOT THE DIRECTORY, AND THAT
+    # CORRECTION IS THE FINDING. A `0500` directory refuses CREATION and nothing
+    # else: `bag-info.txt` already exists, so `_append_tag_line`'s
+    # `O_WRONLY|O_APPEND` on it still succeeds and the `incomplete` flag lands —
+    # which is why the first version of this test asserted case (d) and observed
+    # case (c). A read-only mount refuses the write itself, which is `0400` here.
+    _make_unwritable(emitter)
+    bag.info_path.chmod(0o400)
+    try:
+        with pytest.raises(JournalUnwritable, match="cannot be written and neither"):
+            emitter.unpairable_write(write_path="run-facts",
+                                     destination=Destination(store="filesystem"),
+                                     content="x")
+    finally:
+        bag.info_path.chmod(0o600)
+
+
+def test_case_d_reports_on_the_exit_record_AND_a_durable_surface() -> None:
+    """Requirement 11: two channels, and the second is why the first is not enough.
+
+    The typed exit record plus a non-zero exit carry it out of the process — and
+    both are invocation state, read within seconds and then gone, so a failure
+    reported only there is invisible to every consumer this component builds.
+    """
+    report = unwritable_journal_report(JournalUnwritable("root is gone"),
+                                       bag_path=Path("/j/run-1"))
+    assert report["terminal_state"] == TerminalState.JOURNAL_UNWRITABLE.value
+    assert report["bag"] == "/j/run-1"
+    assert report["marker"] == emitmod.UNWRITABLE_JOURNAL_MARKER
+
+
+def test_the_durable_signal_HAS_a_committed_reader() -> None:
+    """Requirement 11, and it is the one thing this phase must not get wrong.
+
+    Adding a field to a channel and leaving the reading to somebody later is how
+    this fleet has already lost three observables, and the one channel this
+    component's failure path depends on is the last place to repeat it.
+    """
+    report = unwritable_journal_report(JournalUnwritable("root is gone"))
+    comment = f"### Run failed\n\n{report['marker']}: {report['detail']}\n"
+    assert unwritable_journal_in_text(comment)
+    assert not unwritable_journal_in_text(
+        "### Run failed\n\nthe worktree was dirty\n"), (
+        "the reader answers true for ordinary prose, so it reports every run as "
+        "having an unwritable journal")
+
+
+@ROOT_SKIP
+def test_the_RAISED_case_d_exception_is_readable_by_the_same_reader(
+        emitter: Emitter, bag) -> None:
+    """The THIRD channel — the process's own exit — carries the same marker.
+
+    `JournalUnwritable` subclasses `RuntimeError`, so every entrypoint's existing
+    `except RuntimeError: return refuse(exc)` prints this message and exits
+    non-zero. Leading with the declared marker means the reader that greps a PR
+    comment reads the process output too, with no entrypoint edited and no second
+    literal. Without it the exit channel would carry a failure nothing could
+    recognise — a signal with no reader, on the one path this component's failure
+    reporting depends on.
+    """
+    _make_unwritable(emitter)
+    bag.info_path.chmod(0o400)
+    try:
+        with pytest.raises(JournalUnwritable) as raised:
+            emitter.unpairable_write(write_path="run-facts",
+                                     destination=Destination(store="filesystem"),
+                                     content="x")
+    finally:
+        bag.info_path.chmod(0o600)
+    assert unwritable_journal_in_text(str(raised.value))
+
+
+def test_the_marker_is_ONE_declaration_shared_by_producer_and_reader() -> None:
+    """A producer and a consumer that each spell the marker are two declarations.
+
+    That is the defect `exit-protocol.md` §6 exists to forbid, and the one this
+    fleet already committed at `as_prose_verdict`. Mutating the constant must
+    break neither side — which is only true if neither side re-types it.
+    """
+    import ast
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parents[2] / "modules" /
+              "journal" / "emit.py").read_text(encoding="utf-8")
+    literals = [n.value for n in ast.walk(ast.parse(source))
+                if isinstance(n, ast.Constant) and isinstance(n.value, str)
+                and n.value == emitmod.UNWRITABLE_JOURNAL_MARKER]
+    assert len(literals) == 1, (
+        f"the marker literal appears {len(literals)} times in emit.py; the "
+        f"reader must reference the constant rather than respell it")
+
+
+# --- requirement 10: capture-time filtering ---------------------------------
+
+def test_a_secret_is_FILTERED_before_any_byte_reaches_the_root(
+        emitter: Emitter) -> None:
+    """AT APPEND, not at seal. Capture is the only cheap point in the lifecycle.
+
+    After Phase 4 wires the rebuild test to a gate, removing a payload file is a
+    gate change; after Phase 7 it is a bucket-wide purge. And filtering at SEAL
+    would change written events, which requirement 8 forbids outright.
+    """
+    secret = "ghp_" + "A" * 36
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content=f"token is {secret}", perform=lambda: "u")
+    on_disk = emitter.events_path.read_text(encoding="utf-8")
+    assert secret not in on_disk, "the secret reached the journal root"
+    assert "[FILTERED:github-token]" in on_disk
+
+
+def test_the_filter_emits_a_PLACEHOLDER_so_the_record_is_not_silently_shorter(
+        emitter: Emitter) -> None:
+    """The record stays complete about the FACT of the removal."""
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content="token " + "ghp_" + "A" * 36,
+                         perform=lambda: "u")
+    placeholders = [e for e in _events(emitter)
+                    if e.kind is EventKind.REDACTION_PLACEHOLDER]
+    assert len(placeholders) == 1
+    assert placeholders[0].content_bytes == 40, "the byte count is what was removed"
+    assert "github-token" in placeholders[0].content
+    assert "ghp_" not in placeholders[0].content, (
+        "the placeholder names the RULE and never the match")
+
+
+# --- requirement 12: the boundary is registered, not remembered -------------
+
+def test_no_registered_emitter_is_a_REAL_state_and_not_an_error() -> None:
+    """A unit test, a helper script and `validate_bag` all run outside a run.
+
+    Manufacturing an emitter for them would write a bag for a process that is not
+    a run, under a `run_id` nobody minted.
+    """
+    assert current_emitter() is None
+
+
+def test_emitting_into_RESTORES_the_previous_boundary(emitter: Emitter) -> None:
+    """A nested block must not detach every later write path in the process."""
+    assert current_emitter() is None
+    with emitting_into(emitter):
+        assert current_emitter() is emitter
+        with emitting_into(None):
+            assert current_emitter() is None
+        assert current_emitter() is emitter, (
+            "the inner block cleared the outer run's boundary, so every write "
+            "after it would silently stop emitting")
+    assert current_emitter() is None
+
+
+def test_the_provenance_class_survives_onto_the_event(emitter: Emitter) -> None:
+    """Requirement 7(d). Phase 8's poller reads a row and STARTS WORK.
+
+    So the field it filters on has to exist on the event and survive Phase 4's
+    rebuild — and a field absent from version-1 events is absent forever.
+    """
+    emitter.unpairable_write(write_path="fetched-page",
+                             destination=Destination(store="content_store"),
+                             content="<html>", provenance=Provenance.FETCHED)
+    assert _events(emitter)[0].provenance is Provenance.FETCHED
+
+
+def test_every_event_a_run_emits_carries_the_run_and_the_edge(
+        emitter: Emitter) -> None:
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content="body", perform=lambda: "u")
+    for event in _events(emitter):
+        assert event.run_id == "run-1"
+        assert event.edge_id == emitter.edge_id
+        assert event.key_epoch == NO_CREDENTIAL_EPOCH
+
+
+def test_no_event_carries_a_key_or_a_key_derived_value(emitter: Emitter) -> None:
+    """Requirement 6's constraint, which rides on the buildable half deliberately.
+
+    The `edge_id` is an identifier and appears in every event; the key is a
+    secret and appears in none. `hash(api_key)` is ruled out twice over — it
+    changes on rotation, and a stored hash of a live credential is an offline
+    confirmation oracle.
+    """
+    import re
+    emitter.paired_write(write_path="gh:pr:comment",
+                         destination=Destination(store="github"),
+                         content="body", perform=lambda: "u")
+    for event in _events(emitter):
+        assert not re.fullmatch(r"[0-9a-f]{32}|[0-9a-f]{40}|[0-9a-f]{64}",
+                                event.edge_id), (
+            "the edge id has the shape of a bare digest, which is what a "
+            "key-derived id looks like")
+        assert event.key_epoch == NO_CREDENTIAL_EPOCH

--- a/scripts/workflows/temporal/tests/unit/test_journal_emit.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_emit.py
@@ -316,6 +316,156 @@ def test_case_d_raises_when_even_the_GAP_RECORD_cannot_be_written(
         bag.info_path.chmod(0o600)
 
 
+# --- what escaped the taxonomy entirely, until it was probed for -------------
+
+#: A credential shape `capture_filter` matches, so `_build` appends a redaction
+#: placeholder BEFORE the event it was called to construct. That second append is
+#: the one the failure taxonomy did not cover.
+_FILTERED_SHAPE = "ghp_" + "A" * 24
+
+
+@ROOT_SKIP
+def test_a_FILTERED_paired_write_on_a_dead_journal_still_raises_EmitFailed(
+        emitter: Emitter, bag) -> None:
+    """⚠ THE PLACEHOLDER APPEND USED TO ESCAPE EVERY ONE OF THE FOUR CASES.
+
+    `_build` appends a redaction placeholder of its own whenever the filter
+    fires, and it was called ABOVE the `try` that catches a failed append. On a
+    read-only mount a filtered write therefore raised a bare `PermissionError`
+    straight out of `paired_write`: no `EmitFailed`, no gap, no `incomplete`
+    flag — and past every entrypoint's `except RuntimeError`, because `OSError`
+    is not one.
+
+    ⚠ THE CONTROL IS THE PAIR, NOT THIS ASSERTION ALONE.
+    `test_a_FAILED_INTENT_means_the_store_write_does_NOT_happen` above drives the
+    identical call with content the filter ignores and gets `EmitFailed`. The
+    only difference between the two is whether the placeholder was appended, so
+    the pair is what localises the escape to it.
+    """
+    performed = []
+    _make_unwritable(emitter)
+    with pytest.raises(EmitFailed):
+        emitter.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content=f"token {_FILTERED_SHAPE} leaked",
+                             perform=lambda: performed.append(1))
+    assert performed == [], (
+        "the store write ran even though the journal refused the intent — the "
+        "invariant is that a journal failure means NEITHER side happened")
+
+
+@ROOT_SKIP
+def test_a_FILTERED_unpairable_write_on_a_dead_journal_still_MARKS_THE_BAG(
+        emitter: Emitter, bag) -> None:
+    """The same escape on the case with no store write to withhold, where it costs more.
+
+    Here the placeholder's `OSError` did not merely skip a typed exception: it
+    skipped `_record_gap`, so the content was lost AND nothing recorded the loss.
+    A bag that lost data and reads as complete is the outcome the four-state
+    design exists to prevent, reached through the function that exists to
+    prevent it.
+    """
+    _make_unwritable(emitter)
+    emitter.unpairable_write(write_path="transcript",
+                             destination=Destination(store="filesystem"),
+                             content=f"a transcript holding {_FILTERED_SHAPE}")
+    assert bag.incomplete, (
+        "a filtered write that could not land left the bag reading as complete")
+    gaps = [v for label, v in read_tag_file(bag.info_path) if label == LABEL_GAP]
+    assert len(gaps) == 1 and "transcript" in gaps[0]
+
+
+def test_CONTENT_that_cannot_be_ENCODED_fails_as_EmitFailed_not_as_a_crash(
+        emitter: Emitter) -> None:
+    """`UnicodeEncodeError` is a `ValueError`, so it joined no `except OSError`.
+
+    A lone surrogate — which reaches this fleet from `surrogateescape`-decoded
+    filenames and from tool output — raised out of `paired_write` untyped,
+    exactly as the placeholder append did, and for the same reason: the failure
+    set was written as "the disk" when it is "the disk OR the bytes".
+    `edge_id.read_edge_id` already names the same trap from the decode side.
+
+    THE STORE WRITE IS WITHHELD, which is the correct answer rather than an
+    incidental one: the journal cannot record this write, so it does not happen.
+    """
+    performed = []
+    with pytest.raises(EmitFailed):
+        emitter.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content="a lone surrogate \ud800 in the body",
+                             perform=lambda: performed.append(1))
+    assert performed == []
+
+
+@ROOT_SKIP
+def test_a_failed_FLAG_is_case_d_even_when_the_gap_event_LANDED(
+        emitter: Emitter, bag) -> None:
+    """⚠ THE ONE HOLE IN *a gap may exist; a silent gap may not*.
+
+    `_record_gap` raised `JournalUnwritable` only when BOTH writes failed. With
+    the gap event landing and the flag failing, it returned normally and told
+    nobody — and nothing downstream reads a writer's `events.jsonl` to decide
+    whether a bag is clean. Phase 4, Phase 6 and Phase 7 all branch on the flag,
+    so that bag lost data and read as complete.
+
+    ⚠ THE FIXTURE HAS TO FAIL ONE WRITE AND NOT THE OTHER, which a mode cannot
+    do — both events go to one file. So the CONTENT is what fails: a lone
+    surrogate cannot be encoded, while the gap event that reports it carries no
+    content at all and lands normally. `bag-info.txt` is read-only at the FILE,
+    because a `0500` directory refuses creation and `events.jsonl` already
+    exists — the correction this file's case-(d) test already records.
+    """
+    bag.info_path.chmod(0o400)
+    try:
+        with pytest.raises(JournalUnwritable, match="the gap event landed"):
+            emitter.unpairable_write(write_path="run-facts",
+                                     destination=Destination(store="filesystem"),
+                                     content="run facts with \ud800 in them")
+    finally:
+        bag.info_path.chmod(0o600)
+    kinds = [e.kind for e in _events(emitter)]
+    assert EventKind.GAP in kinds, (
+        "the fixture did not reach the case it names — the gap event has to "
+        "LAND for this to be the event-landed/flag-failed arm")
+
+
+@ROOT_SKIP
+def test_a_store_failure_whose_record_ALSO_dies_names_the_unwritable_journal(
+        emitter: Emitter, bag) -> None:
+    """The third place a failed `incomplete` flag was swallowed with no signal.
+
+    The store write fails, its `store_write_failure` event cannot be written,
+    and the flag cannot either — so nothing in the journal says this write is
+    missing. `StoreWriteFailed` is still what the caller needs, because its
+    handlers are written against the store failure; what changed is that the
+    journal's death now leaves on that message, LEADING with the one declared
+    marker so `unwritable_journal_in_text` reads it on the process channel.
+
+    The message also used to assert *"a store-write-failure event was
+    recorded"* unconditionally — on the path where recording it had just failed.
+    """
+    def _die() -> None:
+        # AT THE FILE, NOT THE DIRECTORY: the intent has already created
+        # `events.jsonl`, so a `0500` directory would refuse nothing and the
+        # failure event would land. Same correction the case-(d) test above
+        # carries, and the same trap.
+        emitter.events_path.chmod(0o400)
+        bag.info_path.chmod(0o400)
+        raise RuntimeError("the store refused it")
+
+    try:
+        with pytest.raises(StoreWriteFailed) as caught:
+            emitter.paired_write(write_path="gh:pr:comment",
+                                 destination=Destination(store="github"),
+                                 content="a comment", perform=_die)
+    finally:
+        emitter.events_path.chmod(0o600)
+        bag.info_path.chmod(0o600)
+    assert unwritable_journal_in_text(str(caught.value)), (
+        "the journal died while recording a store-write failure and no channel "
+        "said so — this is the exception's only surface")
+
+
 def test_case_d_reports_on_the_exit_record_AND_a_durable_surface() -> None:
     """Requirement 11: two channels, and the second is why the first is not enough.
 

--- a/scripts/workflows/temporal/tests/unit/test_journal_emit.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_emit.py
@@ -20,7 +20,10 @@ stops a contract written wrongly and exercised wrongly from agreeing with itself
 
 from __future__ import annotations
 
+import ast
+import json
 import os
+import pathlib
 from pathlib import Path
 
 import pytest
@@ -35,6 +38,7 @@ from modules.journal.emit import (EmitFailed, Emitter, JournalUnwritable,
                                   unwritable_journal_report)
 from modules.journal.events import (EVENTS_FILE, Destination, EventKind,
                                     GapClass, Provenance, decode_event)
+from modules.assistant.review_pr import exit_record
 from modules.vocabulary import TerminalState
 
 ROOT_SKIP = pytest.mark.skipif(
@@ -188,6 +192,41 @@ def test_a_FAILED_STORE_WRITE_records_a_failure_event_and_re_raises(
                              content="body", perform=_boom)
     kinds = [e.kind for e in _events(emitter)]
     assert kinds == [EventKind.INTENT, EventKind.STORE_WRITE_FAILURE]
+
+
+def test_a_RAISING_address_of_is_a_GAP_and_not_an_untyped_CRASH(
+        emitter: Emitter, bag) -> None:
+    """`address_of` is CALLER-SUPPLIED, so it is inside the guard like the intent.
+
+    IT PARSES A STORE REPLY, which is the one input at this boundary the fleet
+    does not author — `gh_attempt` reads `stdout.splitlines()[-1]`, and the
+    obvious next write path parses JSON. Evaluated above the `try` (as it was),
+    an `IndexError` or a `JSONDecodeError` escaped `paired_write` bare: no
+    `EmitFailed`, no gap event, no `incomplete` flag, and — since neither is a
+    `RuntimeError` — past every entrypoint's handler as well. AFTER the store
+    write had landed and was therefore unrecoverable.
+
+    THE EXCEPTION CHOSEN HERE IS DELIBERATELY NOT A `RuntimeError`. A
+    `RuntimeError` would be caught by the entrypoints even on the broken code, so
+    it would not discriminate; `IndexError` is what an empty `gh` stdout actually
+    raises, and it is the shape that escaped everything.
+    """
+    def _address(_result: None) -> str:
+        raise IndexError("gh printed nothing, so stdout.splitlines()[-1] blew up")
+
+    with pytest.raises(EmitFailed, match="store write DID land"):
+        emitter.paired_write(write_path="gh:pr:comment",
+                             destination=Destination(store="github"),
+                             content="body", perform=lambda: None,
+                             address_of=_address)
+    kinds = [e.kind for e in _events(emitter)]
+    assert kinds == [EventKind.INTENT, EventKind.GAP], (
+        f"a raising `address_of` produced {kinds}; the record must carry the "
+        f"intent and a typed gap, so replay sees an intent with no completion "
+        f"and declines to apply a write it cannot prove")
+    assert bag.incomplete, (
+        "the bag reads as complete after a write whose completion was lost — "
+        "the outcome Phase 1's four-state design exists to prevent")
 
 
 def test_a_RETRIED_paired_write_appends_a_deduplicable_pair_per_attempt(
@@ -466,12 +505,16 @@ def test_a_store_failure_whose_record_ALSO_dies_names_the_unwritable_journal(
         "said so — this is the exception's only surface")
 
 
-def test_case_d_reports_on_the_exit_record_AND_a_durable_surface() -> None:
-    """Requirement 11: two channels, and the second is why the first is not enough.
+def test_the_case_d_PAYLOAD_is_ONE_shape_for_every_channel() -> None:
+    """One payload builder, so no two channels can disagree about what happened.
 
-    The typed exit record plus a non-zero exit carry it out of the process — and
-    both are invocation state, read within seconds and then gone, so a failure
-    reported only there is invisible to every consumer this component builds.
+    ⚠ THIS TEST USED TO BE NAMED `test_case_d_reports_on_the_exit_record_AND_a_
+    durable_surface`, AND THE NAME WAS FALSE — neither of those channels has a
+    producer. A green test asserting a channel is wired is the strongest possible
+    form of the drift `CASE_D_CHANNELS` was declared to stop, because a test name
+    reads as proof rather than as prose. What this actually holds is the payload's
+    SHAPE; which channels carry it is
+    `test_the_case_d_CHANNEL_TABLE_matches_the_tree` below.
     """
     report = unwritable_journal_report(JournalUnwritable("root is gone"),
                                        bag_path=Path("/j/run-1"))
@@ -480,12 +523,19 @@ def test_case_d_reports_on_the_exit_record_AND_a_durable_surface() -> None:
     assert report["marker"] == emitmod.UNWRITABLE_JOURNAL_MARKER
 
 
-def test_the_durable_signal_HAS_a_committed_reader() -> None:
+def test_the_case_d_signal_HAS_a_committed_reader() -> None:
     """Requirement 11, and it is the one thing this phase must not get wrong.
 
     Adding a field to a channel and leaving the reading to somebody later is how
     this fleet has already lost three observables, and the one channel this
     component's failure path depends on is the last place to repeat it.
+
+    THE READER IS CHANNEL-BLIND, WHICH IS WHY IT SHIPS AHEAD OF TWO OF THE THREE.
+    It is a substring test against the one declared marker, so it reads the
+    process output that IS wired today and a pull-request comment on the day that
+    channel acquires a producer. A comment body is used here as the input BECAUSE
+    the durable channel is the unbuilt one — the reader is ready and the writer is
+    not, which is the correct half of that pair to ship first.
     """
     report = unwritable_journal_report(JournalUnwritable("root is gone"))
     comment = f"### Run failed\n\n{report['marker']}: {report['detail']}\n"
@@ -519,6 +569,102 @@ def test_the_RAISED_case_d_exception_is_readable_by_the_same_reader(
     finally:
         bag.info_path.chmod(0o600)
     assert unwritable_journal_in_text(str(raised.value))
+
+
+def _passes_case_d_report_true(tree: ast.AST) -> bool:
+    """Does this module CALL something with `case_d_report=True`?
+
+    Asked of the AST and not of the text, for the reason every guard in this
+    package learned the hard way: a docstring explaining the flag mentions its
+    name, and a substring scan reads the explanation as the wiring.
+    """
+    return any(
+        isinstance(node, ast.Call)
+        and any(kw.arg == "case_d_report"
+                and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                for kw in node.keywords)
+        for node in ast.walk(tree))
+
+
+def _derive_case_d_wiring() -> tuple[bool, ...]:
+    """Which of `CASE_D_CHANNELS` has a live producer — READ FROM THE TREE.
+
+    One derivation per row, in the table's order. Each answers *is there a
+    producer*, never *is there a plan*, because the whole defect this replaces was
+    prose describing the plan in the present tense.
+    """
+    fleet = pathlib.Path(__file__).resolve().parents[2]
+
+    # (0) THE PROCESS EXIT — wired by INHERITANCE and by nothing else. Every
+    # entrypoint already carries `except RuntimeError`, so a `JournalUnwritable`
+    # that subclasses it reaches the operator with no entrypoint edited. Break
+    # that inheritance and the channel is gone, silently, which is why the
+    # derivation is the inheritance rather than a count of handlers.
+    process_exit = issubclass(JournalUnwritable, RuntimeError)
+
+    # (1) THE DURABLE WORKING-RECORD COMMENT — its producer is the `case_d_report`
+    # bypass, so the channel is live exactly when some PRODUCTION file calls it.
+    # Tests are excluded deliberately: a test exercising the bypass proves the
+    # mechanism works, not that anything reports through it.
+    durable = any(
+        _passes_case_d_report_true(ast.parse(path.read_text(encoding="utf-8",
+                                                            errors="replace")))
+        for path in sorted(fleet.rglob("*.py"))
+        if "tests" not in path.parts)
+
+    # (2) THE TYPED EXIT RECORD — live when its schema declares somewhere for the
+    # terminal state to go. Asked of `CHILD_SCHEMA` itself, which
+    # `exit-protocol.md` §2 makes the single declaration of that record's shape.
+    exit_record_field = TerminalState.JOURNAL_UNWRITABLE.value in json.dumps(
+        exit_record.CHILD_SCHEMA)
+
+    return (process_exit, durable, exit_record_field)
+
+
+def test_the_case_d_CHANNEL_TABLE_matches_the_tree() -> None:
+    """`CASE_D_CHANNELS` says which channels carry case (d). THE TREE DECIDES.
+
+    THIS TEST EXISTS BECAUSE THE PROSE VERSION DRIFTED AT SEVEN SITES ON ONE
+    BRANCH — `emit.py`'s module docstring twice, `_record_gap`'s docstring, its
+    raised message, `unwritable_journal_report`'s docstring, `journal/__init__.py`
+    and a TEST NAME — every one of them asserting that case (d) reports on the
+    typed exit record and on a durable working-record surface. Neither had a
+    producer. The channel that did — the process exit — was named by none of them,
+    so on the single failure path where this component cannot speak for itself the
+    operator was sent to two empty surfaces and away from the full one.
+
+    Correcting seven paragraphs does not converge; the eighth gets written next
+    pass. So the claim became DATA with a derivation behind it, and this is that
+    derivation. The day somebody gives `case_d_report=True` a production caller or
+    adds the field to `CHILD_SCHEMA`, this goes red against the table — and the
+    message `case_d_channel_sentence` composes changes with it, because that
+    sentence reads the same table.
+    """
+    declared = tuple(wired for _, wired in emitmod.CASE_D_CHANNELS)
+    derived = _derive_case_d_wiring()
+    assert declared == derived, (
+        f"`CASE_D_CHANNELS` declares {declared} and the tree says {derived}. A "
+        f"channel that gained a producer must be flipped to True here — and the "
+        f"prose citing this table re-read — because the case-(d) message names "
+        f"exactly the rows this table calls wired."
+    )
+
+
+def test_the_channel_DERIVATION_discriminates() -> None:
+    """A deriver that answered True to everything would agree with any table.
+
+    Both directions on the one row that is decided by a code shape rather than by
+    a class relationship: a call carrying the flag is seen, and a docstring
+    MENTIONING it is not — which is the substring bug this package has already met
+    twice, once in the journal-isolation guard and once in `gh_attempt` itself,
+    where reading the flag off the content skipped the journal entirely.
+    """
+    assert _passes_case_d_report_true(ast.parse(
+        "gh_attempt(['gh', 'pr', 'comment'], root, case_d_report=True)"))
+    assert not _passes_case_d_report_true(ast.parse(
+        '''def f():\n    """Pass `case_d_report=True` to bypass the emit."""\n'''))
+    assert not _passes_case_d_report_true(ast.parse(
+        "gh_attempt(['gh', 'pr', 'view'], root, case_d_report=False)"))
 
 
 def test_the_marker_is_ONE_declaration_shared_by_producer_and_reader() -> None:

--- a/scripts/workflows/temporal/tests/unit/test_journal_emit.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_emit.py
@@ -25,6 +25,7 @@ import json
 import os
 import pathlib
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -648,6 +649,48 @@ def test_the_case_d_CHANNEL_TABLE_matches_the_tree() -> None:
         f"prose citing this table re-read — because the case-(d) message names "
         f"exactly the rows this table calls wired."
     )
+
+
+def test_the_case_d_SENTENCE_agrees_with_the_table_it_reads() -> None:
+    """The table test above never reads the SENTENCE, and that was the gap.
+
+    `case_d_channel_sentence` composed the channel NAMES from `CASE_D_CHANNELS`
+    and then spelled the COUNT by hand — *"both are declared … NEITHER has a
+    producer … appear on them"*. Driven with a one-dead-channel table that is
+    three false plurals about a single channel, and
+    `test_the_case_d_CHANNEL_TABLE_matches_the_tree` stays green throughout,
+    because it compares the table against the tree.
+
+    THAT IS NOT A FUTURE PROBLEM. The table flips the day somebody wires the
+    durable line or adds the `CHILD_SCHEMA` field — which is what the deriver
+    above exists to force — and the operator-facing message on the one path where
+    this component cannot speak for itself would start asserting an unbuilt fact
+    in the present tense.
+
+    Driven at every cardinality the table can hold, because the defect was
+    invisible at the ONE cardinality the tree happens to have today.
+    """
+    def sentence_for(table):
+        with mock.patch.object(emitmod, "CASE_D_CHANNELS", table):
+            return emitmod.case_d_channel_sentence()
+
+    one_dead = sentence_for((('A', True), ('B', False)))
+    assert "both are" not in one_dead and "NEITHER" not in one_dead, (
+        f"a one-dead-channel table produced a plural: {one_dead!r}")
+    assert "appear on them" not in one_dead, (
+        f"a one-dead-channel table produced a plural pronoun: {one_dead!r}")
+    assert "has NO producer yet" in one_dead, (
+        f"the negation did not survive the singular: {one_dead!r}")
+
+    two_dead = sentence_for((('A', True), ('B', False), ('C', False)))
+    assert "both are declared" in two_dead and "NEITHER has a producer" in two_dead
+
+    three_dead = sentence_for((('A', False), ('B', False), ('C', False)))
+    assert "all 3 are declared" in three_dead and "NONE has a producer" in three_dead
+
+    none_dead = sentence_for((('A', True), ('B', True)))
+    assert "NOT on" not in none_dead, (
+        f"a fully-wired table still names dead channels: {none_dead!r}")
 
 
 def test_the_channel_DERIVATION_discriminates() -> None:

--- a/scripts/workflows/temporal/tests/unit/test_journal_events.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_events.py
@@ -1,0 +1,405 @@
+"""The journal event contract — PMP Phase 3 requirements 2, 3, 5, 7, 8.
+
+WHAT THIS FILE ASSERTS AND WHAT IT DELIBERATELY DOES NOT. It owns the CONTRACT:
+what an event is, what makes it admissible, and the two replay rules. It owns no
+I/O — `test_journal_emit.py` drives the write-failure cases against real bags,
+and keeping them apart is what stops a contract written wrongly and exercised
+wrongly from agreeing with itself.
+
+THE ADMISSION CHECKS ARE ASSERTED AS REFUSALS, NEVER AS DOCUMENTATION. Every one
+of them is a rule the phase doc states in prose, and this component's own thesis
+— stated three times in that doc — is that a rule written only as prose has not
+once prevented the thing it forbids. A test that constructed an admissible event
+and checked its fields would leave every refusal untested while looking thorough.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from modules.journal.bag import JOURNAL_SCHEMA_VERSION
+from modules.journal.events import (Destination, EventError, EventKind,
+                                    GapClass, JournalEvent, Lineage,
+                                    Provenance, applied_intents, decode_event,
+                                    dedupe_on_identity, encode_event,
+                                    event_identity, gap_event,
+                                    redaction_placeholder_event)
+from modules.vocabulary import Disposition, HoldKind, Outcome, TerminalState
+
+EDGE = "edge-test"
+EPOCH = "none"
+
+
+def _admissible(**overrides) -> JournalEvent:
+    """A minimal admissible event. Every test varies ONE thing from this.
+
+    NOT NAMED `_event`, DELIBERATELY. `test_prose_NAMES_a_symbol_that_RESOLVES.py`
+    carries a `_DECLARED` row saying `_event` is a DICT KEY in
+    `replay_run_resources.py` and never an identifier — and a helper by that name
+    makes the symbol real, so prose about the dict key would resolve to this
+    function and mean something else. Caught by that guard; renamed rather than
+    deleting the exemption, because the exemption is still true.
+    """
+    fields = dict(
+        kind=EventKind.INTENT,
+        event_id=event_identity(run_id="r", write_path="w", sequence=0),
+        run_id="r", edge_id=EDGE, key_epoch=EPOCH,
+        provenance=Provenance.FLEET_AUTHORED,
+        write_path="w", sequence=0,
+        destination=Destination(store="github"),
+        content="body", content_bytes=4)
+    fields.update(overrides)
+    return JournalEvent(**fields)
+
+
+# --- requirement 7: admission ----------------------------------------------
+
+@pytest.mark.parametrize("field,value,expected", [
+    ("run_id", "", "run_id"),
+    ("edge_id", "", "edge_id"),
+    ("key_epoch", "", "key_epoch"),
+    ("content_bytes", -1, "content_bytes"),
+])
+def test_an_event_missing_an_admission_field_is_REFUSED_at_construction(
+        field: str, value, expected: str) -> None:
+    """Requirement 7's four fields are checked where an event is BUILT.
+
+    NOT IN A VALIDATOR, and the difference is the whole point: a validator runs
+    over a bag that already contains the inadmissible event, and requirement 8
+    forbids changing a written one. By then the only remedy is a redaction.
+    """
+    with pytest.raises(EventError, match=expected):
+        _admissible(**{field: value})
+
+
+def test_an_INTENT_carrying_a_store_address_is_REFUSED() -> None:
+    """An address on an intent means the emit ran AFTER its store write.
+
+    That inverts write-ahead ordering, which is what makes requirement 1's
+    invariant self-enforcing — order the intent first and a journal failure
+    means NEITHER side happened. This refusal is what stops a caller building
+    the inverted shape by hand.
+    """
+    with pytest.raises(EventError, match="intent event carries no store address"):
+        _admissible(destination=Destination(store="github", address="https://x/1"))
+
+
+def test_a_COMPLETION_carries_the_store_assigned_address() -> None:
+    """The third thing one event per write cannot carry.
+
+    A GitHub comment has no id or URL until after it is created, and requirement
+    8 forbids changing the written intent — so the address lands here or nowhere.
+    """
+    done = _admissible(kind=EventKind.COMPLETION,
+                  destination=Destination(store="github", address="https://x/1"))
+    assert done.destination.address == "https://x/1"
+
+
+def test_a_gap_event_with_no_gap_class_is_REFUSED() -> None:
+    """A gap names why it happened, from a CLOSED set.
+
+    Free text is refused rather than sanitised because a gap event reports that
+    content was LOST — a `why` derived from that content or from an exception
+    message would be a side channel for the very bytes it says were dropped, on
+    the least-reviewed path there is.
+    """
+    with pytest.raises(EventError, match="gap event names why"):
+        _admissible(kind=EventKind.GAP)
+
+
+def test_a_NON_gap_event_carrying_a_gap_class_is_REFUSED() -> None:
+    """The other direction, and it is not symmetry for its own sake.
+
+    Phase 6 r6 counts gaps by reading gap events. A completion carrying a
+    `gap_class` would be counted as a loss that did not happen, which is worse
+    than an uncounted one: the measurement would report the component failing
+    where it worked.
+    """
+    with pytest.raises(EventError, match="only a gap event carries a gap_class"):
+        _admissible(kind=EventKind.COMPLETION, gap_class=GapClass.DISK_FULL)
+
+
+# --- requirement 7(a): identity --------------------------------------------
+
+def test_identity_is_DETERMINISTIC_over_run_write_path_and_sequence() -> None:
+    """A retried activity re-derives the SAME identity, which is what dedupe needs.
+
+    Temporal executes an activity at least once (Temporal Standard §7.1), so the
+    retry re-runs the same write of the same run — and therefore re-derives this.
+    """
+    first = event_identity(run_id="r", write_path="gh:pr:comment", sequence=3)
+    again = event_identity(run_id="r", write_path="gh:pr:comment", sequence=3)
+    assert first == again
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"run_id": "other", "write_path": "gh:pr:comment", "sequence": 3},
+    {"run_id": "r", "write_path": "gh:pr:create", "sequence": 3},
+    {"run_id": "r", "write_path": "gh:pr:comment", "sequence": 4},
+])
+def test_identity_DISCRIMINATES_on_each_of_its_three_inputs(kwargs) -> None:
+    """Each input alone changes the identity.
+
+    Without this the deterministic test above passes for a constant, which is
+    the vacuity that would make dedupe collapse every event in a bag to one.
+    """
+    base = event_identity(run_id="r", write_path="gh:pr:comment", sequence=3)
+    assert event_identity(**kwargs) != base
+
+
+def test_identity_is_NOT_derived_from_the_content() -> None:
+    """The question is *which write of which run*, not *what did it say*.
+
+    A content hash would give two identical comments posted to two different PRs
+    one identity, and would give one comment re-authored with a typo fix a
+    different one. Neither is the question dedupe asks.
+    """
+    one = _admissible(content="a")
+    two = _admissible(content="b")
+    assert one.event_id == two.event_id
+
+
+def test_a_negative_sequence_is_REFUSED() -> None:
+    with pytest.raises(EventError, match="non-negative"):
+        event_identity(run_id="r", write_path="w", sequence=-1)
+
+
+# --- the two replay rules ---------------------------------------------------
+
+def test_dedupe_keeps_the_FIRST_of_two_identical_appends() -> None:
+    """A retried activity appends twice; replay applies it once.
+
+    FIRST rather than last because the journal is append-only and the first
+    write is the one that happened — a later duplicate is a retry re-running a
+    side effect, not a correction. Requirement 8 forbids corrections outright.
+    """
+    first = _admissible(content="original")
+    duplicate = _admissible(content="original")
+    assert [e.content for e in dedupe_on_identity([first, duplicate])] == ["original"]
+
+
+def test_dedupe_keys_on_KIND_TOO_so_a_pair_survives_it() -> None:
+    """An intent and its completion SHARE one identity — that is what makes them one unit.
+
+    ⚠ THIS IS THE ONE THAT WOULD SILENTLY DESTROY THE CONTRACT. Keyed on
+    `event_id` alone, dedupe drops every completion in the journal and
+    `applied_intents` then applies nothing — a replay that rebuilds an empty
+    store while every assertion about dedupe still passes.
+    """
+    intent = _admissible(kind=EventKind.INTENT)
+    done = _admissible(kind=EventKind.COMPLETION,
+                  destination=Destination(store="github", address="u"))
+    assert len(dedupe_on_identity([intent, done])) == 2
+
+
+def test_replay_applies_an_intent_ONLY_when_a_completion_exists() -> None:
+    """The rule that makes a failed store write visible rather than silently wrong.
+
+    Without it, an intent whose store write failed replays into content the store
+    never got — Phase 4 would MATERIALISE unpublished content that no run and no
+    human approved. The rebuild restores what happened; it does not complete what
+    did not.
+    """
+    applied = _admissible(write_path="a")
+    applied_done = _admissible(write_path="a", kind=EventKind.COMPLETION,
+                          destination=Destination(store="github", address="u"))
+    orphan = _admissible(write_path="b",
+                    event_id=event_identity(run_id="r", write_path="b", sequence=0))
+    kept = applied_intents([applied, applied_done, orphan])
+    assert [e.write_path for e in kept] == ["a"]
+
+
+def test_a_store_write_FAILURE_does_not_satisfy_its_intent() -> None:
+    """The asymmetry is the diagnosis, not an oversight.
+
+    A `store_write_failure` is a POSITIVE record that the write did not land, so
+    the intent stays unapplied AND a reader can tell it apart from a run that
+    died between the two events. Both are unapplied; only one is a defect in this
+    component.
+    """
+    intent = _admissible()
+    failure = _admissible(kind=EventKind.STORE_WRITE_FAILURE,
+                     terminal_state=TerminalState.STORE_WRITE_FAILED)
+    assert applied_intents([intent, failure]) == []
+
+
+def test_a_retried_PAIR_is_applied_ONCE_not_twice() -> None:
+    """Dedupe and the completion rule composed, which is the real replay path.
+
+    Counting completions without deduping first reports two applications of one
+    write — the same red diff as the row above, in the opposite direction.
+    """
+    intent, done = _admissible(), _admissible(kind=EventKind.COMPLETION,
+                                    destination=Destination(store="github",
+                                                            address="u"))
+    assert len(applied_intents([intent, done, intent, done])) == 1
+
+
+# --- requirement 8: versioning ---------------------------------------------
+
+def test_every_event_carries_the_schema_version() -> None:
+    assert _admissible().schema_version == JOURNAL_SCHEMA_VERSION
+    assert json.loads(encode_event(_admissible()))["schema_version"] == \
+        JOURNAL_SCHEMA_VERSION
+
+
+def test_an_event_of_an_UNKNOWN_version_is_REFUSED_rather_than_read() -> None:
+    """No upcaster exists yet, so a v2 event is refused, not read as v1.
+
+    A v2 event read with v1 field meanings is CONFIDENTLY WRONG, which is worse
+    than unreadable — and the roadmap carries the upcaster mechanism as an open
+    input rather than as something this phase closes.
+    """
+    raw = json.loads(encode_event(_admissible()))
+    raw["schema_version"] = JOURNAL_SCHEMA_VERSION + 1
+    with pytest.raises(EventError, match="no upcaster exists"):
+        decode_event(json.dumps(raw))
+
+
+def test_an_event_round_trips_through_json_unchanged() -> None:
+    """Requirement 1's word is VERBATIM, so the round trip is the assertion."""
+    original = _admissible(kind=EventKind.COMPLETION,
+                      destination=Destination(store="sqlite", address="row/7"),
+                      content="…em dash, ünïcode, and a \"quote\"",
+                      lineage=Lineage(input_ref="src-1", input_index=2),
+                      outcome=Outcome.HOLD,
+                      terminal_state=TerminalState.COMPLETED)
+    assert decode_event(encode_event(original)) == original
+
+
+def test_the_encoding_does_NOT_escape_non_ascii() -> None:
+    """Escaping would store a different string from the one the run authored."""
+    assert "ünïcode" in encode_event(_admissible(content="ünïcode"))
+
+
+# --- requirement 2: the destination is a field, not a format ----------------
+
+@pytest.mark.parametrize("store", ["github", "git", "sqlite", "mqtt",
+                                   "tracked_issues", "planning_corpus"])
+def test_the_event_SHAPE_is_identical_whatever_the_destination(store: str) -> None:
+    """Requirement 2, asserted as the key set rather than as a sentence.
+
+    That property is not stylistic: it is what makes the record portable across
+    edges, and it is what Phase 7 depends on — a second edge of any type sources
+    the same data from the protocol rather than from a repo.
+    """
+    baseline = set(json.loads(encode_event(_admissible())))
+    other = set(json.loads(encode_event(
+        _admissible(destination=Destination(store=store)))))
+    assert other == baseline
+
+
+# --- requirement 5: lineage -------------------------------------------------
+
+def test_lineage_records_WHICH_INPUT_produced_this_output() -> None:
+    """n8n's `pairedItem`. Fan-out is real today — two critics 21 seconds apart."""
+    fanned = _admissible(lineage=Lineage(input_ref="finding-3", input_index=2))
+    assert json.loads(encode_event(fanned))["lineage"] == {
+        "input_ref": "finding-3", "input_index": 2}
+
+
+def test_lineage_is_OPTIONAL_because_a_runs_FIRST_emit_has_no_input() -> None:
+    """A required field nobody can fill is a self-inflicted absence.
+
+    `exit_record.CHILD_SCHEMA` documents that class from measurement: an
+    over-constrained required field produces SILENCE rather than an error.
+    """
+    assert _admissible().lineage == Lineage(None, None)
+
+
+# --- the two typed constructors --------------------------------------------
+
+def test_a_gap_event_carries_a_CLOSED_class_and_a_byte_count_and_no_content() -> None:
+    """What was lost, when, why and how much — and never what."""
+    gap = gap_event(run_id="r", edge_id=EDGE, key_epoch=EPOCH,
+                    write_path="transcript", sequence=1,
+                    gap_class=GapClass.DISK_FULL, lost_bytes=4096,
+                    destination=Destination(store="filesystem"))
+    assert gap.gap_class is GapClass.DISK_FULL
+    assert gap.content_bytes == 4096
+    assert gap.content == "", (
+        "a gap event carrying content would be the side channel for the very "
+        "bytes it reports as lost")
+
+
+def test_a_redaction_placeholder_names_the_RULE_and_never_the_match() -> None:
+    """An operator can tell a credential pattern from an over-broad rule.
+
+    Neither the placeholder nor its event ever carries the matched text, which
+    is the secret. `removed_bytes` is what makes the record complete about the
+    FACT of the removal rather than silently shorter.
+    """
+    placeholder = redaction_placeholder_event(
+        run_id="r", edge_id=EDGE, key_epoch=EPOCH, write_path="w", sequence=1,
+        destination=Destination(store="github"), removed_bytes=40,
+        rule="github-token", provenance=Provenance.FLEET_AUTHORED)
+    assert placeholder.content == "[FILTERED AT CAPTURE: github-token]"
+    assert placeholder.content_bytes == 40
+
+
+# --- requirement 3: one vocabulary, two contracts ---------------------------
+
+def test_the_shared_vocabulary_is_ONE_declaration_not_two() -> None:
+    """The exit record's `Outcome` and the journal's are the SAME OBJECT.
+
+    ⚠ IDENTITY, NOT EQUALITY OF VALUES. Two enums spelled identically compare
+    unequal member-to-member in Python, so a rebuild diffing a journal event's
+    outcome against an exit record's would report a difference that is not one —
+    which is exactly the drift requirement 3 exists to prevent, and it would be
+    invisible to a test that only compared `.value`.
+    """
+    from modules.assistant.review_pr import exit_record as er
+    assert er.Outcome is Outcome
+    assert er.HoldKind is HoldKind
+
+
+def test_the_exit_records_disposition_enum_is_DERIVED_from_the_declaration() -> None:
+    """The schema's enum is read off `vocabulary.Disposition`, never re-typed.
+
+    Three consumers spell this vocabulary — the schema, the `pr_review:` block,
+    and `convergence.py`'s open/closed partition — and a journal event replaying
+    a finding row is a fourth. `memory-model.md` §4.1 records the partition, and
+    a row spelled differently from it is a row the partition silently drops.
+    """
+    from modules.assistant.review_pr import exit_record as er
+    declared = sorted(m.value for m in Disposition)
+    in_schema = er.CHILD_SCHEMA["properties"]["findings"]["items"][
+        "properties"]["disposition"]["enum"]
+    assert sorted(in_schema) == declared
+
+
+def test_the_journal_package_does_not_import_the_exit_record() -> None:
+    """The vocabulary is a LEAF both sides import; the edge runs neither way.
+
+    `modules/journal/` importing `modules.assistant` would drag `temporalio` in
+    behind it and break Phase 6's reader; `exit_record.py` importing the journal
+    package would execute its whole `__init__` from a module that is
+    dependency-free by design. A leaf at `modules/` is the only placement that
+    leaves both properties intact, and this is what holds it.
+    """
+    import ast
+    import pathlib
+    source = (pathlib.Path(__file__).resolve().parents[2] / "modules" /
+              "journal" / "events.py").read_text(encoding="utf-8")
+
+    # ⚠ ASKED OF THE IMPORT STATEMENTS, NEVER OF THE FILE'S TEXT. A substring
+    # check flags the DOCSTRING — this module explains, in prose, why the exit
+    # record's contract cannot be extended, and naming the thing it is separate
+    # from is the explanation. Measured: the substring form of this assertion
+    # went red on a correct file, which is the assertion's population including
+    # the text that makes the claim about it.
+    imported: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(f"{'.' * node.level}{node.module or ''}")
+    assert imported, "no imports parsed — this check would pass vacuously"
+    assert not [m for m in imported if "assistant" in m or "exit_record" in m], (
+        f"`modules/journal/` must import no workflow module; found {imported}")
+    assert "..vocabulary" in imported, (
+        "the shared vocabulary must be IMPORTED rather than respelled — this "
+        "assertion is what stops the test above passing because both sides "
+        f"happen to agree today. Imports: {imported}")

--- a/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
+++ b/scripts/workflows/temporal/tests/unit/test_journal_regex_anchors.py
@@ -200,8 +200,8 @@ def _literal_parts(node: ast.expr) -> list[str] | None:
     rather than by reading it, which is the only way it could have been found:
     a blind sweep and a clean package are the same colour.
 
-    So an expression this cannot read fails `test_no_pattern_is_unreadable`
-    below. A pattern nobody can check must not look like a pattern that checked
+    So an expression this cannot read fails
+    `test_no_pattern_is_unreadable_to_the_sweep` below. A pattern nobody can check must not look like a pattern that checked
     out.
     """
     if isinstance(node, ast.Constant):

--- a/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
+++ b/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
@@ -17,10 +17,9 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "modules"))
 
-from assistant import routing
-from assistant.merge import merge_pr  # noqa: E402
+from modules.assistant import routing
+from modules.assistant.merge import merge_pr  # noqa: E402
 
 REPO = Path("/nonexistent-by-design")
 

--- a/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
+++ b/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
@@ -20,6 +20,9 @@ import pytest
 
 from modules.assistant import routing
 from modules.assistant.merge import merge_pr  # noqa: E402
+from modules.journal.bag import open_bag
+from modules.journal.emit import Emitter, emitting_into
+from modules.journal.events import EVENTS_FILE, EventKind, decode_event
 
 REPO = Path("/nonexistent-by-design")
 
@@ -153,6 +156,69 @@ def test_a_failed_BRANCH_DELETE_does_not_report_a_failed_MERGE(monkeypatch) -> N
     monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
     monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {"state": "MERGED"})
     assert merge_pr.merge_one("1", REPO) is None
+
+
+def test_a_failed_BRANCH_DELETE_is_journaled_as_a_COMPLETED_write(
+        monkeypatch, tmp_path: Path) -> None:
+    """The merge LANDED, so the journal must say so — permanently and only once.
+
+    ⚠ THE TWO TESTS ABOVE RUN WITH NO EMITTER REGISTERED, which is why this
+    defect shipped past them. With the emit wired, `gh` exiting non-zero on a
+    merge that succeeded made `paired_write` append a `store_write_failure` —
+    and the journal is append-only, so the record said *this write did not
+    happen* about a merge that had, uncorrectably. `applied_intents` then
+    declines that intent forever and a Phase 4 rebuild concludes the merge never
+    occurred, while `run_merge` reports it under `merged` in the same run. The
+    record exists to be trusted over the report; a record that contradicts a
+    correct report is worse than no record.
+
+    The scenario is PR #166's, measured: `--delete-branch` cannot remove a branch
+    checked out in a worktree, and this fleet always dispatches from one.
+    """
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "gh",
+                                            stderr="failed to delete local branch")
+
+    monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {"state": "MERGED"})
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700, parents=True)
+    bag = open_bag(root, "run-merge")
+    emitter = Emitter.for_run(bag, writer=None, journal_root=root)
+    with emitting_into(emitter):
+        assert merge_pr.merge_one("1", REPO) is None
+
+    lines = (emitter.writer_dir / EVENTS_FILE).read_text().splitlines()
+    kinds = [decode_event(line).kind for line in lines]
+    assert kinds == [EventKind.INTENT, EventKind.COMPLETION], (
+        f"a merge that LANDED was journaled as {[k.value for k in kinds]}. The "
+        f"exit code covers `--delete-branch` too, so the outcome has to be "
+        f"resolved INSIDE `perform` — resolving it in a handler is one frame "
+        f"too late, and the journal never forgets.")
+
+
+def test_a_GENUINELY_failed_merge_is_still_journaled_as_a_FAILURE(
+        monkeypatch, tmp_path: Path) -> None:
+    """THE CONTROL FOR THE TEST ABOVE. Asking the outcome must not launder a real
+    failure into a completion — that would be the same defect pointing the other
+    way, and Phase 4 would then MATERIALISE a merge nobody performed."""
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "gh", stderr="not mergeable")
+
+    monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {"state": "OPEN"})
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700, parents=True)
+    bag = open_bag(root, "run-merge-failed")
+    emitter = Emitter.for_run(bag, writer=None, journal_root=root)
+    with emitting_into(emitter):
+        assert merge_pr.merge_one("1", REPO) == "not mergeable"
+
+    lines = (emitter.writer_dir / EVENTS_FILE).read_text().splitlines()
+    kinds = [decode_event(line).kind for line in lines]
+    assert kinds == [EventKind.INTENT, EventKind.STORE_WRITE_FAILURE]
 
 
 def test_a_GENUINELY_failed_merge_is_still_reported(monkeypatch) -> None:

--- a/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
+++ b/scripts/workflows/temporal/tests/unit/test_merge_pr_refuses_before_it_merges.py
@@ -229,3 +229,119 @@ def test_a_GENUINELY_failed_merge_is_still_reported(monkeypatch) -> None:
     monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
     monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {"state": "OPEN"})
     assert merge_pr.merge_one("1", REPO) == "not mergeable"
+
+
+# ---------------------------------------------------------------------------
+# THE READ THAT RESOLVES THE OUTCOME. Moving "did it actually merge?" inside
+# `perform` made the journal and the report derive from ONE answer — and left
+# that answer resting on a single unretried call whose failure was silently
+# spelled "not merged". `gh pr merge` exiting non-zero is the NORMAL case here,
+# so the read sits on the ordinary path: one transient `gh` failure on it was
+# enough to journal a merge that LANDED as a write that did not happen.
+
+
+def test_a_TRANSIENTLY_unreadable_outcome_is_RE_ASKED_and_the_merge_COMPLETES(
+        monkeypatch, tmp_path: Path) -> None:
+    """A blip on the state read must not become a permanent wrong record.
+
+    THE FIX IS THE RE-ASK, AND THIS IS THE TEST THAT MEASURES IT. With one
+    attempt, the first `None` is read as "not merged" and `paired_write` appends
+    a `store_write_failure` for a merge that landed — into an append-only
+    journal, so `applied_intents` declines that intent forever.
+    """
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "gh",
+                                            stderr="failed to delete local branch")
+
+    answers = [None, None, {"state": "MERGED"}]
+    monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: answers.pop(0))
+    monkeypatch.setattr(merge_pr.time, "sleep", lambda s: None)
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700, parents=True)
+    bag = open_bag(root, "run-merge-transient")
+    emitter = Emitter.for_run(bag, writer=None, journal_root=root)
+    with emitting_into(emitter):
+        assert merge_pr.merge_one("1", REPO) is None
+
+    assert answers == [], "the re-ask stopped before the answer arrived"
+    lines = (emitter.writer_dir / EVENTS_FILE).read_text().splitlines()
+    kinds = [decode_event(line).kind for line in lines]
+    assert kinds == [EventKind.INTENT, EventKind.COMPLETION], (
+        f"a landed merge was journaled as {[k.value for k in kinds]} because the "
+        f"outcome read was not re-asked. The journal is append-only; this record "
+        f"cannot be corrected later.")
+
+
+def test_an_UNREAD_outcome_does_not_present_GH_S_STDERR_as_the_verdict(
+        monkeypatch) -> None:
+    """The verdict was never read, and the detail must say that rather than
+    quoting `gh pr merge`'s cleanup error as though it were the answer.
+
+    `failed to delete local branch` is a sentence about the BRANCH DELETE. Handed
+    back as the merge outcome it reads as "the PR did not merge", which is the
+    one thing this read exists to establish and the one thing nobody established.
+    """
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "gh",
+                                            stderr="failed to delete local branch")
+
+    monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: None)
+    monkeypatch.setattr(merge_pr.time, "sleep", lambda s: None)
+
+    detail = merge_pr.merge_one("1", REPO)
+    assert detail is not None
+    assert detail.startswith(merge_pr.UNRESOLVED_MERGE_PREFIX), (
+        f"an unread verdict was reported as {detail!r} — indistinguishable from "
+        f"a merge that was read and found not to have happened.")
+    # The stderr is still CARRIED, because an operator needs it. What changed is
+    # that it is attributed rather than presented as the verdict.
+    assert "failed to delete local branch" in detail
+
+
+def test_a_verdict_that_WAS_read_is_NOT_reported_as_unread(monkeypatch) -> None:
+    """THE DISCRIMINATION CONTROL. A prefix that appears on every failed merge
+    tells an operator nothing: the whole value of `UNRESOLVED_MERGE_PREFIX` is
+    that a genuinely-refused merge does NOT carry it."""
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(1, "gh", stderr="not mergeable")
+
+    monkeypatch.setattr(merge_pr.subprocess, "run", _boom)
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {"state": "OPEN"})
+    monkeypatch.setattr(merge_pr.time, "sleep", lambda s: None)
+
+    detail = merge_pr.merge_one("1", REPO)
+    assert detail == "not mergeable"
+    assert merge_pr.UNRESOLVED_MERGE_PREFIX not in detail
+
+
+def test_a_reply_that_PARSES_but_carries_no_state_is_UNREAD_not_an_answer(
+        monkeypatch) -> None:
+    """`{}` decodes cleanly and `.get("state")` on it returns the same `None` an
+    unreadable call does. Reading a missing field as an answer is the same
+    conflation one level in."""
+    monkeypatch.setattr(merge_pr, "_gh_json", lambda a, r: {})
+    monkeypatch.setattr(merge_pr.time, "sleep", lambda s: None)
+    assert merge_pr._merge_state("1", REPO) is None
+
+
+def test_a_gh_READ_rides_out_a_TRANSIENT_failure(monkeypatch) -> None:
+    """`_gh_json` was the one `gh` read in `modules/` that bypassed the fleet's
+    bounded wrapper, so a 503 on any of its three callers was one attempt and a
+    `None`. Driven through `gh_attempt`'s own retry loop rather than asserting
+    which function is called."""
+    replies = [
+        subprocess.CompletedProcess(["gh"], 1, stdout="",
+                                    stderr="HTTP 503: No server is currently "
+                                           "available to service your request."),
+        subprocess.CompletedProcess(["gh"], 0, stdout='{"state": "MERGED"}',
+                                    stderr=""),
+    ]
+    monkeypatch.setattr(merge_pr.act, "run_bounded", lambda *a, **k: replies.pop(0))
+    monkeypatch.setattr(merge_pr.act.time, "sleep", lambda s: None)
+
+    assert merge_pr._gh_json(["pr", "view", "1", "--json", "state"],
+                             REPO) == {"state": "MERGED"}
+    assert replies == [], "the transient reply was not retried past"

--- a/scripts/workflows/temporal/tests/unit/test_phase_sizing_reads_the_pre_rule_8_checkbox_form.py
+++ b/scripts/workflows/temporal/tests/unit/test_phase_sizing_reads_the_pre_rule_8_checkbox_form.py
@@ -36,10 +36,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "modules"))
 
 from planning_corpus import PLANNING_ROOT  # noqa: E402
-from assistant.plan import plan_activities as A  # noqa: E402
+from modules.assistant.plan import plan_activities as A  # noqa: E402
 
 import sys as _cg_sys  # noqa: E402
 from pathlib import Path as _cg_Path  # noqa: E402

--- a/scripts/workflows/temporal/tests/unit/test_promoted_fragments_render_for_every_consumer.py
+++ b/scripts/workflows/temporal/tests/unit/test_promoted_fragments_render_for_every_consumer.py
@@ -12,8 +12,8 @@ satisfies the static check completely and ships a literal `${ALTITUDE_COMPONENT}
 to the model, or trips `render()`'s leftover guard mid-dispatch, at real spend.
 
 So this module DRIVES THE REAL ENTRY POINTS and reads the prompt they built —
-the same shape `test_research_minor` uses, and for the same stated reason: the
-prompt file is not the prompt.
+the same shape `test_research_minor.py` used before it was deleted, and for
+the same stated reason it stated: the prompt file is not the prompt.
 
 WHAT THIS DOES NOT LOOK AT:
 

--- a/scripts/workflows/temporal/tests/unit/test_research_draft.py
+++ b/scripts/workflows/temporal/tests/unit/test_research_draft.py
@@ -34,7 +34,6 @@ import re
 import textwrap
 from pathlib import Path
 
-_MODULES = Path(__file__).resolve().parents[2] / "modules"
 
 import pytest
 import yaml
@@ -408,10 +407,6 @@ def test_the_pool_pointer_runs_BOTH_directions_and_neither_arm_is_silent() -> No
     shopping in its own pool and a product run into a write boundary it does not
     own, and both arms would still "pass" a mere non-empty check.
     """
-    import sys
-    sys.path.insert(0, str(_MODULES))
-    from assistant.research import research_activities as act
-
     # THE CORPUS LIVES IN THE PLANNING REPO SINCE THE 2026-08-31 CONSOLIDATION.
     #
     # THIS SAID "derived rather than hardcoded" AND IT WAS HARDCODED — a fixed

--- a/scripts/workflows/temporal/tests/unit/test_shared_vocabulary_is_declared_once.py
+++ b/scripts/workflows/temporal/tests/unit/test_shared_vocabulary_is_declared_once.py
@@ -1,0 +1,177 @@
+"""One declaration per shared concept — PMP Phase 3 requirement 3, as a test.
+
+⚠ THIS FILE EXISTS BECAUSE `modules/vocabulary.py` CITED IT AND IT DID NOT EXIST.
+Its docstring said *"The test that holds this is
+`test_shared_vocabulary_is_declared_once.py`, which asserts the spelling
+agreement in both directions"* — and the module's whole argument, stated three
+times across this package, is that *a rule written only as prose has not once
+prevented the thing it forbids.* The one invariant the module was added to
+protect was itself protected by prose, and `SHARED_CONCEPTS` — the dict built so
+a conformance test could walk it — was imported by nothing.
+
+WHAT IS ASSERTED, AND WHY IT IS IDENTITY RATHER THAN VALUE. Two enums spelled
+alike compare UNEQUAL member-to-member, so `exit_record.Outcome.MERGE ==
+vocabulary.Outcome.MERGE` is `False` the moment the class is re-declared — while
+every string comparison in the fleet keeps passing, because both serialise to
+`"merge"`. A value test would therefore go green on exactly the drift this file
+exists to catch. The identity test is what fails.
+
+THE SPELLINGS ARE WALKED FROM `SHARED_CONCEPTS`, never re-typed here. A concept
+added to the module is checked in both contracts without editing this file,
+which is the discipline `exit_record._validate` already applies to
+`CHILD_SCHEMA`.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules import vocabulary
+from modules.assistant import convergence
+from modules.assistant.review_pr import exit_record
+from modules.journal import events
+
+MODULES = Path(__file__).resolve().parents[2] / "modules"
+
+
+def test_SHARED_CONCEPTS_enumerates_every_enum_the_module_declares() -> None:
+    """The walk's own denominator: a concept absent from the dict is unchecked.
+
+    Every test below iterates `SHARED_CONCEPTS`, so a fifth enum added to
+    `vocabulary.py` and left out of the dict would be silently exempt from all
+    of them — a guard whose population is maintained by hand beside the thing it
+    guards. This asserts the two are the same set.
+    """
+    declared = {name for name in vocabulary.__all__ if name != "SHARED_CONCEPTS"}
+    assert set(vocabulary.SHARED_CONCEPTS) == declared, (
+        f"`SHARED_CONCEPTS` and `__all__` disagree: "
+        f"{declared ^ set(vocabulary.SHARED_CONCEPTS)}. Every conformance test "
+        f"in this file walks the dict, so a concept missing from it is a "
+        f"concept nothing checks.")
+
+
+def redeclares(tree: ast.Module, concept: str) -> bool:
+    """Does this tree DECLARE a class named `concept`, rather than import one?
+
+    THE PREDICATE, EXTRACTED SO A LITERAL CAN DRIVE IT. The controls below feed
+    it parsed snippets rather than files, because a walker that only ever runs
+    over the production tree passes every assertion it makes the day its
+    recogniser stops recognising anything — `test_a_census_guard_proves_its_own_
+    predicate` is the guard that refuses exactly that, and this file arrived
+    under it.
+
+    IT TAKES A TREE RATHER THAN SOURCE TEXT so the parse stays at the call site:
+    the production test parses a FILE and the controls parse a STRING, and the
+    census reads those two shapes to tell a tree-walker from its control. A
+    helper that swallowed the parse would hide both.
+    """
+    return any(isinstance(node, ast.ClassDef) and node.name == concept
+               for node in ast.walk(tree))
+
+
+@pytest.mark.parametrize("source,expected", [
+    ("from ..vocabulary import Outcome\n", False),
+    ("from modules.vocabulary import Outcome as Outcome\n", False),
+    ("Outcome = 1\n", False),
+    ('"""A docstring mentioning class Outcome(str, Enum)."""\n', False),
+    ("class Outcome(str, Enum):\n    MERGE = 'merge'\n", True),
+    ("if True:\n    class Outcome(str, Enum):\n        MERGE = 'merge'\n", True),
+])
+def test_the_redeclaration_predicate_answers_a_LITERAL_both_ways(
+        source: str, expected: bool) -> None:
+    """The positive control, and its discriminator.
+
+    An import binds the same name a declaration does, so a `hasattr` check
+    cannot separate them — the first two rows are what that check would get
+    wrong. The fourth is the substring bug: a docstring naming the class is
+    prose, and a text scan would call it a declaration. The last proves the walk
+    reaches a nested body rather than only the module's top level.
+    """
+    assert redeclares(ast.parse(source), "Outcome") is expected
+
+
+@pytest.mark.parametrize("concept", sorted(vocabulary.SHARED_CONCEPTS))
+def test_no_shared_concept_is_RE_DECLARED_in_either_contract(concept: str) -> None:
+    """Neither contract may declare a class of a shared concept's name.
+
+    ASKED OF THE SYNTAX TREE, not of the imported object: an import binds the
+    same name as a declaration, so `hasattr` cannot tell "imported from the one
+    declaration" from "declared again here". A `ClassDef` can only be the second.
+    """
+    for relpath in ("assistant/review_pr/exit_record.py", "journal/events.py"):
+        tree = ast.parse((MODULES / relpath).read_text(encoding="utf-8"))
+        assert not redeclares(tree, concept), (
+            f"modules/{relpath} declares `{concept}` again. Two enums spelled alike "
+            f"compare unequal member-to-member while both still serialise to "
+            f"the same string, so a rebuild diffing them reports a difference "
+            f"that is not one — and every string test keeps passing.")
+
+
+def test_the_exit_record_and_the_journal_share_the_SAME_OBJECTS() -> None:
+    """Identity, not equality — the only test that fails on a re-declaration."""
+    assert exit_record.Outcome is vocabulary.Outcome
+    assert exit_record.HoldKind is vocabulary.HoldKind
+    assert events.Outcome is vocabulary.Outcome
+    assert events.TerminalState is vocabulary.TerminalState
+
+
+def test_the_CHILD_SCHEMA_disposition_enum_is_the_shared_spelling() -> None:
+    """The exit record's schema string is derived from the declaration.
+
+    It was a hand-written list until this phase, and a hand-written list beside
+    an enum is the drift the module exists to prevent — the schema is what a
+    child is validated against, so a disposition present in one and absent from
+    the other is a finding row the fleet refuses or replays wrongly.
+    """
+    schema_enum = (exit_record.CHILD_SCHEMA["properties"]["findings"]["items"]
+                   ["properties"]["disposition"]["enum"])
+    assert schema_enum == sorted(vocabulary.SHARED_CONCEPTS["Disposition"])
+
+
+def test_the_convergence_partition_covers_EVERY_declared_disposition() -> None:
+    """The third consumer of one spelling, and the one that silently miscounts.
+
+    `convergence.py` partitions dispositions into CLOSED and OPEN and counts
+    anything unrecognised as OPEN. A disposition added to `vocabulary.py` and
+    not to that partition therefore does not fail anything — it makes a
+    converged loop report as unconverged, forever, with no error. That is the
+    asymmetry `convergence.py` documents as deliberate for a value nobody
+    declared; it is not what should happen to one this fleet declares itself.
+    """
+    partitioned = convergence.CLOSED_DISPOSITIONS | convergence.OPEN_DISPOSITIONS
+    declared = set(vocabulary.SHARED_CONCEPTS["Disposition"])
+    assert declared == partitioned, (
+        f"`convergence.py` partitions {sorted(partitioned)} and "
+        f"`vocabulary.Disposition` declares {sorted(declared)}. A declared "
+        f"disposition missing from the partition counts as OPEN by the "
+        f"unknown-is-open rule, so the loop never converges and nothing raises.")
+
+
+@pytest.mark.parametrize("concept", sorted(vocabulary.SHARED_CONCEPTS))
+def test_every_member_serialises_to_the_string_the_dict_records(
+        concept: str) -> None:
+    """`str`-valued so `json.dumps` needs no encoder, on both sides of the wire.
+
+    The journal's on-disk spelling and the exit record's wire spelling are the
+    same string because they are the same object AND that object is a `str`
+    subclass. Drop the `str` base and both contracts still import one enum while
+    `json.dumps` refuses it outright or writes `"Outcome.MERGE"` into the record.
+
+    ⚠ ASSERTED THROUGH `json.dumps` AND NOT THROUGH `str()`, which is a
+    correction this test earned by being run. On 3.11+ `str()` of a `(str, Enum)`
+    member is `"Outcome.MERGE"` while `json.dumps` writes `"merge"` — the
+    serialiser reads the underlying `str` content, not `__str__`. Asserting
+    `str()` failed on all four concepts against code that is correct, which is a
+    test asserting a property nothing depends on.
+    """
+    enum = getattr(vocabulary, concept)
+    assert tuple(m.value for m in enum) == vocabulary.SHARED_CONCEPTS[concept]
+    for member in enum:
+        assert json.dumps(member) == json.dumps(member.value), (
+            f"`{concept}.{member.name}` does not serialise as its value, so "
+            f"`encode_event` writes something other than the shared spelling "
+            f"into the durable record")

--- a/scripts/workflows/temporal/tests/unit/test_the_config_digest_POPULATION_is_read_from_the_installer.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_config_digest_POPULATION_is_read_from_the_installer.py
@@ -188,8 +188,9 @@ def fixture(tmp_path: Path) -> tuple[Path, Path]:
 #
 # The rule, rather than a third correctly-written probe: a skip in this file
 # whose reason is a claim about the MACHINE is guarded by a call that drives the
-# real syscall on the real path. `test_every_SKIP_in_this_file_probes_the_MACHINE`
-# holds that for the class, so the next one fails when it is written.
+# real syscall on the real path.
+# `test_every_SKIP_in_this_file_probes_the_MACHINE_not_the_RESULT` holds that for
+# the class, so the next one fails when it is written.
 
 
 def _hidden(path: Path) -> bool:

--- a/scripts/workflows/temporal/tests/unit/test_the_dependency_graph_is_DERIVED_not_declared.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_dependency_graph_is_DERIVED_not_declared.py
@@ -28,8 +28,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "modules"))
-from assistant.plan import plan_activities as pa  # noqa: E402
+from modules.assistant.plan import plan_activities as pa  # noqa: E402
 
 
 def _planning(tmp_path: Path) -> Path:

--- a/scripts/workflows/temporal/tests/unit/test_the_drain_and_the_merge_are_INDEPENDENT.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_drain_and_the_merge_are_INDEPENDENT.py
@@ -17,9 +17,8 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "modules"))
 
-from assistant.merge import merge_pr  # noqa: E402
+from modules.assistant.merge import merge_pr  # noqa: E402
 
 REPO = Path("/nonexistent-by-design")
 

--- a/scripts/workflows/temporal/tests/unit/test_the_tag_namespace_is_HELD_BY_CODE.py
+++ b/scripts/workflows/temporal/tests/unit/test_the_tag_namespace_is_HELD_BY_CODE.py
@@ -1,0 +1,311 @@
+"""The `Journal-` tag namespace's extension rule — PMP Phase 3 requirement 13.
+
+FOUR QUESTIONS, ONE REQUIREMENT, AND THE FOURTH IS WHAT MAKES THE OTHER THREE
+ENFORCEABLE RATHER THAN ADVISORY. This file asserts (a), (b) and (d) as code; (c)
+is deliberately an open ruling and there is nothing to assert about a decision
+nobody has made — the assertion for it would manufacture the answer the
+requirement declines to give.
+
+WHY THIS IS A SEPARATE FILE FROM `test_journal_tag_lines.py`. That one owns the
+LINE — folding, forging, round-tripping. This owns the NAMESPACE — who may add a
+label and what a reader does with one it does not know. They are different
+questions and they failed independently: the line's rule leaked twice through
+different writers, and the namespace has never had a rule at all because it was
+closed by construction until WD Phase 5 r1 took a tag from outside.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.journal.bag import (BAG_INFO_FILE, DESCRIPTIVE_JOURNAL_LABELS,
+                                 JOURNAL_LABEL_PREFIX, LABEL_GAP,
+                                 LABEL_INCOMPLETE, LABEL_REDACTION,
+                                 LABEL_SCHEMA_VERSION, LABEL_SEALED_AT,
+                                 RESERVED_JOURNAL_LABELS, BagError,
+                                 known_journal_label, open_bag, read_tag_file,
+                                 unrecognised_journal_labels)
+from modules.journal.validate import validate_bag
+
+
+@pytest.fixture()
+def bag(tmp_path: Path):
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700)
+    return open_bag(root, "run-1")
+
+
+# --- (a) who may add one: the two trust classes -----------------------------
+
+@pytest.mark.parametrize("label", sorted(RESERVED_JOURNAL_LABELS))
+def test_a_LIFECYCLE_label_is_REFUSED_from_outside(bag, label: str) -> None:
+    """The integrity space. Every one of these is a FACT about what happened.
+
+    Phase 4, Phase 6 and Phase 7 branch on them, and they are written by the
+    journal package alone from `seal`, `redact` and `mark_incomplete`. An outside
+    contributor asserting one could declare a run complete, or declare a gap that
+    never happened — and in an append-only store that is unfalsifiable after the
+    fact.
+    """
+    with pytest.raises(BagError, match="reserved lifecycle label"):
+        bag.add_tag(label, "true")
+
+
+def test_a_DESCRIPTIVE_label_is_ACCEPTED_from_outside(bag) -> None:
+    """The other trust class. A flat rule over the prefix would block this.
+
+    WD Phase 5 r1 is the trigger: a sixth `Journal-` tag beside the five that
+    exist, and the first field this bag has ever taken from outside. Refusing it
+    would make the namespace closed rather than governed.
+    """
+    bag.add_tag("Journal-Region", "eu-west")
+    assert ("Journal-Region", "eu-west") in read_tag_file(bag.info_path)
+
+
+def test_add_tag_APPENDS_so_a_repeatable_label_stays_repeatable(bag) -> None:
+    """`_set_tag_line` is for the RFC-reserved elements that describe the bag as
+    it stands and must be replaced on a reseal. A contributed tag is a statement
+    made once, and replacing it would silently keep one of three."""
+    bag.add_tag("Journal-Note", "first")
+    bag.add_tag("Journal-Note", "second")
+    values = [v for label, v in read_tag_file(bag.info_path)
+              if label == "Journal-Note"]
+    assert values == ["first", "second"]
+
+
+def test_add_tag_still_REFUSES_a_folded_value_and_a_forged_label(bag) -> None:
+    """(d)'s point: the writer inherits the line rules rather than restating them.
+
+    A component composing a `bag-info.txt` line itself bypasses BOTH the reserved
+    check above and these — which is how the value-forging class comes back
+    through a second author.
+    """
+    with pytest.raises(BagError, match="does not survive a round trip"):
+        bag.add_tag("Journal-Note", "x\nJournal-Incomplete: true")
+    with pytest.raises(BagError, match="does not survive a round trip"):
+        bag.add_tag("x\nJournal-Incomplete: true", "y")
+
+
+def test_the_reserved_set_is_exactly_the_five_the_package_writes() -> None:
+    """A reserved set with a hole in it is not a reserved set.
+
+    `Event-Schema-Version` is in it despite carrying no `Journal-` prefix because
+    it is the same KIND of thing — a fact about the record rather than about the
+    run — and a reader who has to remember one exception will eventually not.
+    """
+    assert RESERVED_JOURNAL_LABELS == {
+        LABEL_SCHEMA_VERSION, LABEL_REDACTION, LABEL_INCOMPLETE, LABEL_GAP,
+        LABEL_SEALED_AT}
+
+
+def test_the_five_descriptive_labels_a_real_bag_carries_are_all_KNOWN(
+        tmp_path: Path) -> None:
+    """The census that keeps `DESCRIPTIVE_JOURNAL_LABELS` from going stale.
+
+    ⚠ A NON-ZERO COUNT IS ASSERTED, because this walk could scope itself wrongly
+    and report a clean sweep over nothing. That is the vacuity every
+    tree-scanning guard in this package is written against.
+    """
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700)
+    written = open_bag(root, "r", info={
+        "Journal-Workflow": "build", "Journal-Origin-Repo": "/repo",
+        "Journal-Origin-Remote": "git@x:y.git", "Journal-Origin-Commit": "abc",
+        "Journal-Worktree": "wt-1"})
+    journal_labels = [label for label, _ in read_tag_file(written.info_path)
+                      if label.startswith(JOURNAL_LABEL_PREFIX)]
+    assert len(journal_labels) >= 5, (
+        f"the walk found {len(journal_labels)} `Journal-` labels on a real bag; "
+        f"a census over nothing proves nothing")
+    assert all(known_journal_label(label) for label in journal_labels), (
+        f"a label this fleet writes is not in either declared class: "
+        f"{[l for l in journal_labels if not known_journal_label(l)]}")
+
+
+# --- (b) what a reader does with one it does not recognise ------------------
+
+def test_an_UNRECOGNISED_tag_VALIDATES_rather_than_failing(bag) -> None:
+    """RFC 8493 permits arbitrary `bag-info.txt` labels, so a bag carrying a
+    newer fleet's tag is a VALID bag. Failing it would make the namespace's
+    stated extensibility false the first time anyone used it."""
+    bag.add_tag("Journal-From-The-Future", "v2")
+    bag.seal()
+    assert validate_bag(bag.path).ok
+
+
+def test_an_UNRECOGNISED_tag_is_REPORTED_rather_than_silently_dropped(bag) -> None:
+    """The other half, and the one this phase's own § Dependencies argues for.
+
+    A rule written only as prose has never once prevented the thing it forbids —
+    so the reader half is a function with a test rather than a sentence saying
+    readers *should* surface unknown labels.
+    """
+    bag.add_tag("Journal-From-The-Future", "v2")
+    report = validate_bag(bag.path)
+    assert report.unrecognised_tags == ("Journal-From-The-Future",)
+
+
+def test_the_report_RENDERS_the_unrecognised_tag(bag) -> None:
+    """Reported into a tuple nobody prints is the observable-with-no-reader
+    failure this fleet has already committed three times."""
+    from modules.journal.validate import render_report
+    bag.add_tag("Journal-From-The-Future", "v2")
+    assert "Journal-From-The-Future" in render_report(validate_bag(bag.path))
+
+
+def test_a_KNOWN_tag_is_NOT_reported_as_unrecognised(bag) -> None:
+    """The discriminator. Without it the assertion above passes for a function
+    that reports every tag, which would bury the one that matters."""
+    assert unrecognised_journal_labels(read_tag_file(bag.info_path)) == ()
+
+
+def test_an_RFC_reserved_element_is_NOT_reported(bag) -> None:
+    """`Payload-Oxum` and `Bagging-Date` are the STANDARD's namespace.
+
+    Reporting them would be this fleet reporting that RFC 8493 exists, on every
+    sealed bag — noise that teaches a reader to stop reading the line.
+    """
+    bag.seal()
+    assert validate_bag(bag.path).unrecognised_tags == ()
+
+
+def test_a_REPEATED_unrecognised_tag_is_reported_ONCE(bag) -> None:
+    bag.add_tag("Journal-Note", "a")
+    bag.add_tag("Journal-Note", "b")
+    assert unrecognised_journal_labels(read_tag_file(bag.info_path)) == \
+        ("Journal-Note",)
+
+
+# --- (d) the mechanism is the writer, not just the owner --------------------
+
+def test_the_reserved_refusal_lives_in_bag_py_and_not_in_a_caller() -> None:
+    """(d): THE RULE NAMES THE WRITER. A caller-side check is one a second author
+    does not inherit, which is exactly how this package's line rule leaked twice.
+
+    Asserted on the module source rather than by behaviour, because the property
+    is about WHERE the control lives — a behavioural test passes equally well
+    when every caller happens to check.
+    """
+    source = (Path(__file__).resolve().parents[2] / "modules" / "journal" /
+              "bag.py").read_text(encoding="utf-8")
+    assert "RESERVED_JOURNAL_LABELS" in source
+    assert "def add_tag" in source
+
+
+def test_the_bag_info_file_name_is_the_one_this_test_reads(bag) -> None:
+    """A trivial pin, and it is here because this file's every assertion goes
+    through `bag.info_path`: if that stopped being `bag-info.txt` the namespace
+    tests would still pass against whatever it became."""
+    assert bag.info_path.name == BAG_INFO_FILE
+
+
+# --- (c) is deliberately open -----------------------------------------------
+
+def test_no_bag_level_version_field_was_invented(bag) -> None:
+    """⚠ THE ASSERTION IS THAT THE QUESTION STAYS OPEN.
+
+    Requirement 13(c) asks whether bag metadata carries a version distinct from
+    the per-event one, and rules NOTHING — the fleet declares one version field
+    today and Phase 1 describes it two ways ("the event schema version" and "the
+    bag-level version"). A tag addition changes bag metadata and changes no
+    event, so *"bump it"* and *"do not"* are both wrong answers to a question
+    with an ambiguous subject.
+
+    Nobody has verified that a bump is needed, so this phase manufactures no
+    decision — and this test is what goes red if a later change quietly makes
+    one, which is the only way an open ruling can be held open in code.
+    """
+    version_labels = [label for label, _ in read_tag_file(bag.info_path)
+                      if "version" in label.lower()]
+    assert version_labels == [LABEL_SCHEMA_VERSION], (
+        f"a second version field appeared: {version_labels}. Requirement 13(c) "
+        f"is an OPEN ruling; adding one here settles it without the evidence "
+        f"the requirement says is missing.")
+
+
+def test_adding_a_tag_does_NOT_change_the_declared_version(bag) -> None:
+    before = dict(read_tag_file(bag.info_path))[LABEL_SCHEMA_VERSION]
+    bag.add_tag("Journal-Region", "eu-west")
+    assert dict(read_tag_file(bag.info_path))[LABEL_SCHEMA_VERSION] == before
+
+
+def test_the_descriptive_class_is_not_a_PERMITTED_SET(bag) -> None:
+    """A label outside it is contributable and merely UNRECOGNISED to a reader.
+
+    Treating the declared descriptive set as an allow-list would close the
+    namespace again — the state requirement 13 exists to move off.
+    """
+    assert "Journal-Region" not in DESCRIPTIVE_JOURNAL_LABELS
+    bag.add_tag("Journal-Region", "eu-west")     # accepted anyway
+    assert "Journal-Region" in unrecognised_journal_labels(
+        read_tag_file(bag.info_path))
+
+
+# --- the file the per-writer isolation does not cover ------------------------
+
+def test_a_gap_appended_WHILE_the_parent_SEALS_survives(tmp_path: Path) -> None:
+    """⚠ THE RACE PHASE 1 COULD NOT REACH AND PHASE 3 CREATES.
+
+    Phase 1 gives each writer its own payload subfolder so no two writers share a
+    file — but **every writer shares `bag-info.txt`**, and `_set_tag_line` is a
+    read-modify-write that truncates. Nothing called `seal()` outside tests, so
+    the race was unreachable until emitters existed; the day they do, a gap
+    record appended while the parent seals is **lost along with the `incomplete`
+    flag**, and the bag then validates clean. That is precisely the *"a bag that
+    lost data reads as complete"* outcome Phase 1's four-state design exists to
+    prevent, arriving through the one file its per-writer isolation does not
+    cover.
+
+    ⚠ THE FIXTURE IS ASYMMETRIC UNDER THE DEFECT, WHICH IS WHAT MAKES IT SEE IT.
+    A test that sealed and then marked would pass with or without the lock,
+    because the two writes would not overlap. This runs them from separate
+    PROCESSES with real contention — an advisory `flock` is a cross-process
+    control and a threading test would exercise the GIL rather than the lock.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    root = tmp_path / "journal"
+    root.mkdir(mode=0o700)
+    open_bag(root, "race")
+
+    component = Path(__file__).resolve().parents[2]
+    driver = textwrap.dedent(f"""
+        import sys
+        sys.path.insert(0, {str(component)!r})
+        # `Bag(path, run_id)` DIRECTLY, never `open_bag`: that function refuses
+        # to re-open a SEALED bag, which is correct and is not what this drives.
+        # The subject here is two live writers of one `bag-info.txt`, which is
+        # the state a parent and its emitting children are in.
+        from modules.journal.bag import Bag
+        which, root = sys.argv[1], {str(root)!r}
+        import pathlib
+        bag = Bag(path=pathlib.Path(root) / "race", run_id="race")
+        for _ in range(40):
+            if which == "seal":
+                bag.seal()
+            else:
+                bag.mark_incomplete("the transcript", "disk full")
+    """)
+    script = tmp_path / "driver.py"
+    script.write_text(driver, encoding="utf-8")
+
+    workers = [subprocess.Popen([sys.executable, str(script), which],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+               for which in ("seal", "gap", "gap")]
+    for worker in workers:
+        out, err = worker.communicate(timeout=120)
+        assert worker.returncode == 0, err.decode()
+
+    from modules.journal.bag import Bag
+    reopened = Bag(path=root / "race", run_id="race")
+    gaps = [v for label, v in read_tag_file(reopened.info_path)
+            if label == LABEL_GAP]
+    assert len(gaps) == 80, (
+        f"{len(gaps)} of 80 gap records survived concurrent seals — a gap "
+        f"record lost to a read-modify-write is a bag that lost data and reads "
+        f"as complete")
+    assert reopened.incomplete, "the `incomplete` flag was truncated away"

--- a/testing/scripts/tests/unit/gfm_table_scan.py
+++ b/testing/scripts/tests/unit/gfm_table_scan.py
@@ -87,7 +87,8 @@ def ends_the_table(line: str) -> bool:
         and a blanket `s.startswith("<")` would therefore invent a boundary
         GitHub does not draw and report the rows after a `<span>` as stranded.
         That residual is named in the cell-count check's limits list and held
-        by `test_an_HTML_BLOCK_opener_is_the_residual_this_scan_does_NOT_see`;
+        by `test_an_HTML_BLOCK_opener_is_the_residual_TREE_WIDE_TOO` in
+        `test_markdown_tables_render_whole.py`;
         it is disclosed rather than implemented because `candidates.md` has
         ZERO lines opening with `<` today and the repo-wide question is C-oe0gc9x6's
         to rule, not this pass's to guess at.
@@ -226,7 +227,8 @@ def blank_fenced(lines: list[str]) -> list[str]:
     fence nested inside a list item can legitimately sit at four or more
     absolute spaces and still be a fence rather than an indented code block;
     this reads it as the latter and leaves it unblanked. Held by
-    `test_a_CONTAINER_INDENTED_FENCE_is_the_residual_this_scan_does_NOT_see`.
+    `test_a_CONTAINER_INDENTED_FENCE_is_the_residual_this_gate_does_NOT_see` in
+    `test_markdown_tables_render_whole.py`.
     Container tracking is a block parser, which is a different program from
     this one.
     """

--- a/testing/scripts/tests/unit/test_markdown_tables_render_whole.py
+++ b/testing/scripts/tests/unit/test_markdown_tables_render_whole.py
@@ -1,9 +1,9 @@
 """Every markdown table in the repo renders WHOLE, not just in one file.
 
-WHY THIS IS TREE-WIDE AND ITS SIBLING IS NOT. The cell-count check in
-`test_candidates_prose_matches_the_table.py` was built for `candidates.md`
-because that is where the defect was first measured. The DEFECT is not
-file-shaped. GitHub-flavoured markdown splits a table row on `|` before it
+WHY THIS IS TREE-WIDE. The cell-count check began as a per-file one, built for
+`candidates.md` because that is where the defect was first measured; that file
+and its gate were both deleted in `91925af` and this is the survivor. The DEFECT
+is not file-shaped. GitHub-flavoured markdown splits a table row on `|` before it
 parses inline content, so a pipe inside an inline code span — a regex
 alternation, a shell pipeline, a `true|false` enumeration — is a cell break.
 GFM then DROPS every cell past the header's count and CUTS the last survivor at
@@ -663,12 +663,13 @@ def test_an_HTML_BLOCK_opener_is_the_residual_TREE_WIDE_TOO() -> None:
     UNEXERCISED, and if a `<`-opening line ever lands inside a table block the
     count below moves and this test says so.
 
-    COMPANION: `test_an_HTML_BLOCK_opener_is_the_residual_this_scan_does_NOT_see`
-    in `test_candidates_prose_matches_the_table.py` holds the same residual for
-    that file. Both are claims about `ends_the_table`, which they now share, so
-    teaching it CommonMark's block-tag list retires BOTH tests and BOTH
-    docstring bullets — delete them in one commit or the surviving one starts
-    describing a residual that no longer exists.
+    THERE USED TO BE A COMPANION, and this paragraph asked a future maintainer
+    to delete it in the same commit as this one. It held the same residual for
+    `candidates.md`, and both it and that corpus were deleted in `91925af` — so
+    the instruction outlived its object and would have sent its reader looking
+    for a file to delete that is already gone. This test is now the only claim
+    about `ends_the_table`'s residual: teaching it CommonMark's block-tag list
+    retires THIS test and THIS bullet, and nothing else.
     """
     require_planning_corpus()
     doc = ["| a | b |", "|---|---|", "| x | y |", "<div>html</div>", "| p | q |"]

--- a/testing/scripts/tests/unit/test_markdown_tables_render_whole.py
+++ b/testing/scripts/tests/unit/test_markdown_tables_render_whole.py
@@ -80,15 +80,23 @@ here, held by `test_the_VENDORED_SET_is_read_off_the_script_that_defines_it`,
 because a hard-coded list is exactly the hand-kept declaration this repo's
 gates exist to catch.
 
-WHAT THIS GATE DOES NOT COVER THAT ITS SIBLING DOES — one thing, deliberately,
-and this paragraph SAID "nothing" FOR ONE REVISION WHILE THAT WAS FALSE. The
-sibling asserts `test_EVERY_PIPE_OPENING_LINE_SITS_INSIDE_A_TABLE_BLOCK`: in
-`candidates.md`, a curated table file, EVERY `|`-opening line must be a row.
-That bar is correct there and wrong here — three tracked files carry a
-deliberate one-line row-shape illustration under a heading, which is not a
-defect and which the strict bar would fail. This module asserts the weaker,
-tree-safe half of the same property via `severed_rows`. The gap is one bar, not
-one shape, and the shape itself IS gated here.
+WHAT THIS GATE DOES NOT COVER THAT ITS SIBLING DID — one thing, deliberately,
+and this paragraph SAID "nothing" FOR ONE REVISION WHILE THAT WAS FALSE. ⚠ THE
+SIBLING NO LONGER EXISTS: `test_candidates_prose_matches_the_table.py` was
+deleted in `91925af` with the `candidates.md` corpus it read, so the strict bar
+described below is asserted NOWHERE today and this paragraph is a record of a
+gap rather than of a division of labour. It asserted that in `candidates.md`, a
+curated table file, EVERY `|`-opening line must be a row. That bar was correct
+there and is wrong here — three tracked files carry a deliberate one-line
+row-shape illustration under a heading, which is not a defect and which the
+strict bar would fail. This module asserts the weaker, tree-safe half of the
+same property via `severed_rows`. The gap is one bar, not one shape, and the
+shape itself IS gated here.
+
+(The present-tense version of that paragraph survived the correction that took
+the deleted module's FILENAME out of it, because the claim's remaining subject
+was a bare test-FUNCTION name — the half the citation gate does not key on. That
+asymmetry is the whole of `#178`.)
 
 The false "nothing" claim is worth recording rather than quietly deleting,
 because the paragraph diagnosed its own error one shape over while making it:

--- a/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
+++ b/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
@@ -238,6 +238,14 @@ _BARE_TEST_NAME = re.compile(r"`([A-Za-z0-9_/]*\btest_[A-Za-z0-9_]+)`")
 # mentions below are three ROWS, and a fourth site naming any of them is a
 # finding.
 _DECLARED_TEST_MODULES: dict[tuple[str, str], str] = {
+    ("scripts/helpers/tests/unit/test_every_producer_NAMES_ITS_CONSUMER.py",
+     "test_measure_readme_names_a_consumer.py"):
+        "DELETED when WD Phase 6's gate (this file, PR #170) SUPERSEDED it — the "
+        "deleted module's six properties were carried by name into this file, and "
+        "its line 39 records the supersession. Narrated as history: naming the "
+        "file IS the record that its coverage moved here. Surfaced when PR #175 "
+        "rebased onto #170's merge, putting this gate and #175's citation check in "
+        "one tree for the first time.",
     ("testing/scripts/tests/unit/gfm_table_scan.py",
      "test_candidates_prose_matches_the_table.py"):
         "DELETED in `91925af` with the `candidates.md` corpus it gated. Narrated "
@@ -588,7 +596,7 @@ _BARE_NAME_CENSUS = 9
 #: refuses any that is not. Pinned anyway, because a declared row is a claim
 #: that a citation is HISTORY and a growing count of them is the shape that
 #: turns a gate into an allowlist.
-_FILENAME_CENSUS = 8
+_FILENAME_CENSUS = 9
 
 
 def _census() -> tuple[list[str], list[str]]:

--- a/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
+++ b/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
@@ -70,9 +70,16 @@ bar `test_journal_regex_anchors` sets for its own exemptions.
     the 193-line scratch-delete elision that `block-dangerous.sh` deleted on
     2026-08-15. That is a live instance of this exact class, and correcting it
     is not a rename — the sentence's whole premise is a mechanism that no longer
-    exists, so it needs a read of what that sweep is still for. It is SURFACED
-    on the PR that added this file rather than laundered into a row below.
-    Widening the scope is what closes it.
+    exists, so it needs a read of what that sweep is still for. It is tracked at
+    issue #178 with the other disclosed blind spot, rather than laundered into a
+    row below. Widening the scope is what closes it.
+
+    ⚠ THAT SENTENCE PREVIOUSLY SAID THE INSTANCE WAS *"SURFACED on the PR that
+    added this file"*, AND IT WAS NOT — not in the body, not in any comment. So
+    the only record of a disclosed live defect was this paragraph, in the file
+    whose own docstring calls a permanent list of dead names the thing the guard
+    exists to prevent. A reader checking whether the disclosure had been actioned
+    would have found the PR silent and concluded it was handled off-thread.
   * IT RESOLVES AGAINST THIS TREE'S BINDINGS AND NOTHING ELSE, so a prose
     reference to a name the RUNTIME provides — `_replace`, `_field_defaults` on
     a `NamedTuple` — needs a row below. That is two rows across the whole tree,
@@ -168,17 +175,56 @@ _DECLARED: dict[str, str] = {
 
 
 # A backticked TEST MODULE FILENAME, optionally path-qualified. The `.py` is the
-# discriminator and it is why this half is decidable while bare test-FUNCTION
-# names are not: a citation carrying the suffix is unambiguously a file, whereas
-# a bare one is also a parametrize id, a prompt-variant stem and a section
-# heading. (An illustrative example cannot be written here, because this gate
-# reads its own comments and would report the example as a ghost — which it did,
-# to this paragraph's first draft.) Measured
-# over the swept tree: 32 bare-name citations do not resolve and almost all are
-# false positives, against 11 filename citations of which every one was a real
-# question. Keying on the half that discriminates is the whole lesson of the
-# `_ROOTS` recogniser two files over.
-_TEST_MODULE = re.compile(r"`([A-Za-z0-9_/]*\btest_[A-Za-z0-9_]+\.py)`")
+# discriminator and it is why this half is GATED while the bare test-FUNCTION
+# half is only MEASURED: a citation carrying the suffix is unambiguously a file,
+# whereas a bare one is also a parametrize id, a prompt-variant stem and a
+# section heading. (An illustrative example cannot be written here, because this
+# gate reads its own comments and would report the example as a ghost — which it
+# did, to this paragraph's first draft.)
+#
+# ⚠ THIS COMMENT USED TO CARRY TWO MEASURED FIGURES — "32 bare-name citations do
+# not resolve and almost all are false positives, against 11 filename citations
+# of which every one was a real question" — AND NEITHER COULD BE RE-DERIVED. A
+# review pass ran the stated method and got 129 sites on one reading of "bare
+# name" and 17 on the other; the `11` was plausible and unrefutable. The
+# conclusion those figures supported is right, and it is the reason this
+# pattern keys on `.py`. What was wrong is that the sole stated evidence for
+# leaving half a class ungated sat, uncheckable, in the file whose whole thesis
+# is that an unbacked claim in a trusted block stops the next reader checking.
+#
+# So the figures are DERIVED now, by `test_the_CITATION_CLASS_census_is_DERIVED`
+# below, and the predicate is `unresolved_bare_test_names` rather than a phrase.
+# `_BARE_NAME_CENSUS` and `_FILENAME_CENSUS` are the pinned counts; a maintainer
+# re-measuring runs that test and gets the same number or a red one, and can
+# tell which of "the class grew", "the measurement was wrong" and "the predicate
+# moved" they are looking at.
+#
+# Keying on the half that discriminates is the whole lesson of the `_ROOTS`
+# recogniser two files over.
+#
+# ⚠ A THIRD CITATION SHAPE EXISTS AND BOTH PREDICATES WERE BLIND TO IT — a
+# pytest node id, a path and a `::` and a function name. (Written out it would
+# be reported here, like the two examples above it; the pattern below is the
+# specification.) It was neither: the module pattern wanted a backtick straight
+# after the suffix, and the bare pattern has no `.` in its class. Six sites carry it, and PR #175's third pass found the sixth was
+# a LIVE present-tense claim naming a module deleted in `6a59500`, in a workflow
+# docstring, inside the swept tree and invisible to a sweep that had just been
+# run over that tree twice. The optional group below is what makes the FILENAME
+# half of a node id gate exactly like a bare filename does; the function half
+# stays ungated for the same reason the bare half does.
+_TEST_MODULE = re.compile(
+    r"`([A-Za-z0-9_/]*\btest_[A-Za-z0-9_]+\.py)(?:::[A-Za-z0-9_]+)?`")
+
+# THE BARE HALF, as a predicate rather than as a phrase. The same span as
+# `_TEST_MODULE` with no suffix — and it excludes a filename citation by
+# CONSTRUCTION rather than by a lookahead: `.` is not in the character class, so
+# a span carrying the suffix has no closing backtick where this pattern wants
+# one. (The example cannot be written out — this gate reads its own comments and
+# would report it, which it did, to this paragraph's first draft.)
+# "Does not resolve" is spelled out in `unresolved_bare_test_names` below,
+# because the two readings of it differ by a factor of seven and the prose this
+# replaces stated neither.
+_BARE_TEST_NAME = re.compile(r"`([A-Za-z0-9_/]*\btest_[A-Za-z0-9_]+)`")
 
 # Test modules named in prose that are NOT in the tree and are NOT defects.
 #
@@ -199,12 +245,14 @@ _DECLARED_TEST_MODULES: dict[tuple[str, str], str] = {
         "gate needed the same boundary, and naming the file IS that explanation.",
     ("testing/scripts/tests/unit/test_markdown_tables_render_whole.py",
      "test_candidates_prose_matches_the_table.py"):
-        "same deletion, narrated as history at ONE remaining site — the first "
-        "draft of this gate path-loaded it, which is the PR #96 coupling "
-        "`test_test_tree_hygiene.py` was widened for. The other three mentions "
-        "in this file made LIVE claims (a \"sibling\" comparison, a COMPANION "
-        "instruction to delete it in one commit) and were corrected, not "
-        "declared.",
+        "same deletion, narrated as history at TWO sites. One: the first draft "
+        "of this gate path-loaded it, which is the PR #96 coupling "
+        "`test_test_tree_hygiene.py` was widened for. Two: the \"what this gate "
+        "does not cover\" paragraph, which named the deleted module's ASSERTION "
+        "by bare function name and so survived the pass that took the filename "
+        "out — it now records the bar as UNASSERTED rather than as the "
+        "sibling's job. The COMPANION instruction to delete it in one commit "
+        "was corrected, not declared.",
     ("testing/scripts/tests/unit/test_test_tree_hygiene.py",
      "test_candidates_prose_matches_the_table.py"):
         "same deletion. This is the MEASUREMENT that produced this file's "
@@ -216,6 +264,14 @@ _DECLARED_TEST_MODULES: dict[tuple[str, str], str] = {
         "a file that NEVER EXISTED. `verify.py` names it in the act of saying so "
         "— the sentence IS the correction, and blanking the name leaves it "
         "without a subject.",
+    ("scripts/workflows/temporal/tests/unit/test_promoted_fragments_render_for_every_consumer.py",
+     "test_research_minor.py"):
+        "DELETED in `6a59500`, when two research write-children became one that "
+        "sizes its own cycle. Narrated as history: it is the module whose "
+        "drive-the-entry-point shape this one reuses, and its reasoning is the "
+        "reason given, so naming it IS the explanation. Cited without the `.py` "
+        "until PR #175's third pass, which is how a present-tense claim about a "
+        "deleted module sat outside this gate.",
     ("testing/scripts/tests/unit/test_mutate.py",
      "test_subject.py"):
         "a fixture WRITTEN AT RUN TIME into a `tmp_path` sandbox by this file, "
@@ -231,6 +287,35 @@ def unresolved_test_modules(source: str, filenames: set[str]) -> list[tuple[int,
         for match in _TEST_MODULE.finditer(text):
             if match.group(1).split("/")[-1] not in filenames:
                 found.append((lineno, match.group(1).split("/")[-1]))
+    return found
+
+
+def unresolved_bare_test_names(source: str, names: set[str],
+                               filenames: set[str]) -> list[tuple[int, str]]:
+    """`(lineno, name)` for every backticked bare `test_*` span that resolves to nothing.
+
+    "RESOLVES TO NOTHING" IS TWO CONDITIONS, AND SAYING SO IS THE POINT OF THIS
+    FUNCTION EXISTING. A bare span is unresolved only when it is neither a name
+    BOUND anywhere in the tree — so a span naming a real test function resolves
+    — nor the STEM of a tracked file, which is how this tree cites a test module
+    without its suffix. The prose this replaces said "bare-name
+    citations do not resolve" and meant one of those two readings without
+    saying which; they differ by a factor of seven (129 sites against 17), which
+    is why the figure it quoted could not be reproduced by the pass that checked
+    it.
+
+    NOT A GATE. `test_EVERY_TEST_MODULE_PROSE_CITES_EXISTS` refuses an unresolved
+    `.py` citation; this half is COUNTED, not refused, because the population is
+    dominated by legitimate history narration and a gate over it would be
+    answered by exemption rows. Widening it into a gate is proposed at issue
+    #178, with a resolver rather than a list.
+    """
+    found: list[tuple[int, str]] = []
+    for lineno, text in prose_of(source):
+        for match in _BARE_TEST_NAME.finditer(text):
+            name = match.group(1).split("/")[-1]
+            if name not in names and f"{name}.py" not in filenames:
+                found.append((lineno, name))
     return found
 
 
@@ -483,6 +568,103 @@ def test_every_DECLARED_TEST_MODULE_row_is_still_REACHED(
         f"prose that needed the exemption is gone; delete the row with it.")
 
 
+#: THE CITATION CLASS, IN SITES, DERIVED BY THE TEST BELOW AND PINNED HERE.
+#: These two numbers replace a pair of prose figures that could not be
+#: re-derived from their own stated method. They are SITES, not unique names —
+#: the distinction the earlier prose also left open — and each is produced by a
+#: named predicate in this module rather than by a phrase.
+#:
+#: `_BARE_NAME_CENSUS` is the ungated half: every site is history narration
+#: today (a RETIRED marker, a "WAS HERE", an "it used to be"), which is the
+#: measured reason this half is counted rather than refused. PR #175's third
+#: pass took it from 17 to 9 by correcting the eight LIVE claims in it —
+#: including two coverage claims whose "held by" named functions that went with
+#: the deleted corpus gate three `_DECLARED_TEST_MODULES` rows above describe.
+#: That is what shows this half is not merely noise.
+_BARE_NAME_CENSUS = 9
+
+#: `_FILENAME_CENSUS` is the GATED half, and every site in it is covered by a
+#: `_DECLARED_TEST_MODULES` row — `test_EVERY_TEST_MODULE_PROSE_CITES_EXISTS`
+#: refuses any that is not. Pinned anyway, because a declared row is a claim
+#: that a citation is HISTORY and a growing count of them is the shape that
+#: turns a gate into an allowlist.
+_FILENAME_CENSUS = 8
+
+
+def _census() -> tuple[list[str], list[str]]:
+    """`(bare sites, filename sites)` over the swept tree, as `path:lineno:name`."""
+    names = bound_names(_tracked("*.py"), _tracked("*.sh"))
+    files = {path.name for path in _tracked("*")}
+    bare: list[str] = []
+    filename: list[str] = []
+    for path in _swept():
+        source = path.read_text(encoding="utf-8", errors="replace")
+        relpath = str(path.relative_to(ROOT))
+        bare += [f"{relpath}:{line}: `{name}`"
+                 for line, name in unresolved_bare_test_names(source, names, files)]
+        filename += [f"{relpath}:{line}: `{name}`"
+                     for line, name in unresolved_test_modules(source, files)]
+    return bare, filename
+
+
+def test_the_CITATION_CLASS_census_is_DERIVED() -> None:
+    """The evidence for gating one half and not the other is re-derivable HERE.
+
+    THE DEFECT THIS REPLACES WAS NOT A WRONG NUMBER. It was a measurement stated
+    as prose, in the file whose thesis is that an unbacked claim in a trusted
+    block stops the next reader checking — so the one decision the file makes
+    about its own scope rested on a figure a maintainer could not reproduce. Two
+    reconstructions of its stated method gave 129 and 17; it said 32.
+
+    BOTH DIRECTIONS ARE LOAD-BEARING. A count that GREW means somebody wrote a
+    citation naming something that does not exist: read it, and if it is a live
+    claim — "held by", "asserted by", "the sibling asserts" — correct it rather
+    than counting it. A count that SHRANK means citations were fixed or prose was
+    deleted, and the number moves down with a line in the commit message. Either
+    way the bump is a decision somebody made on purpose, which is the whole
+    difference between this and the sentence it replaces.
+    """
+    bare, filename = _census()
+    assert len(bare) == _BARE_NAME_CENSUS, (
+        f"the bare-name citation census is {len(bare)}, pinned at "
+        f"{_BARE_NAME_CENSUS}. Every site is listed below. If a new one makes a "
+        f"LIVE claim (a residual 'held by' a test, a property 'asserted by' one) "
+        f"the citation is a defect — correct it. If it narrates history, bump "
+        f"the constant and say which site in the commit message. This half is "
+        f"counted rather than gated on purpose; widening it is issue #178:"
+        "\n  " + "\n  ".join(bare))
+    assert len(filename) == _FILENAME_CENSUS, (
+        f"the filename citation census is {len(filename)}, pinned at "
+        f"{_FILENAME_CENSUS}. Every one of these is a DECLARED historical "
+        f"mention — `test_EVERY_TEST_MODULE_PROSE_CITES_EXISTS` refuses the rest "
+        f"— so a rise here means the allowlist grew and is worth reading:"
+        "\n  " + "\n  ".join(filename))
+
+
+def test_the_bare_name_predicate_DISCRIMINATES() -> None:
+    """A predicate that answered "unresolved" to everything would make the census
+    above a headcount of citations rather than of ghosts, and one that answered
+    "resolved" to everything would pin it at zero forever.
+
+    Three cases, because "resolves" has two arms and both were left ambiguous by
+    the prose this replaces: a BOUND name resolves, a tracked module STEM
+    resolves, and a span that is neither does not.
+    """
+    snippet = "# Held by `test_a_gate_that_never_was`.\nX = 1\n"
+    assert [name for _, name in unresolved_bare_test_names(snippet, set(), set())] \
+        == ["test_a_gate_that_never_was"]
+    assert unresolved_bare_test_names(
+        snippet, {"test_a_gate_that_never_was"}, set()) == []
+    assert unresolved_bare_test_names(
+        snippet, set(), {"test_a_gate_that_never_was.py"}) == []
+
+
+def test_the_bare_name_predicate_IGNORES_a_FILENAME_citation() -> None:
+    """The two halves must not double-count: a `.py` span belongs to the gate."""
+    snippet = "# Held by `test_a_gate_that_never_was.py`.\nX = 1\n"
+    assert unresolved_bare_test_names(snippet, set(), set()) == []
+
+
 _GHOST_TEST_MODULE = '''
 # Held by `test_a_gate_that_was_deleted.py`, which does not exist.
 X = 1
@@ -510,11 +692,50 @@ def test_the_test_module_predicate_PASSES_a_gate_that_exists() -> None:
         {"test_prose_NAMES_a_symbol_that_RESOLVES.py"}) == []
 
 
+_GHOST_NODE_ID = '''
+# Pinned by `tests/unit/test_a_gate_that_was_deleted.py::test_the_property`.
+X = 1
+'''
+
+_REAL_NODE_ID = '''
+# Pinned by `tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py::test_x`.
+X = 1
+'''
+
+
+def test_the_test_module_predicate_CATCHES_a_deleted_gate_in_a_NODE_ID() -> None:
+    """The third citation shape, which both predicates were blind to.
+
+    MEASURED, NOT ANTICIPATED. Six sites in the swept tree cite a test as a
+    pytest node id, and one of them was a live present-tense claim naming a
+    module deleted in `6a59500` — inside a workflow docstring, inside the swept
+    tree, and invisible to a sweep of this class that had just been run over that
+    tree twice. The FILENAME is what gates; the function half after `::` is
+    consumed and discarded, for the same reason the bare half is not gated.
+    """
+    found = unresolved_test_modules(_GHOST_NODE_ID, {"anything.py"})
+    assert [name for _, name in found] == ["test_a_gate_that_was_deleted.py"]
+
+
+def test_the_test_module_predicate_PASSES_a_NODE_ID_that_resolves() -> None:
+    assert unresolved_test_modules(
+        _REAL_NODE_ID,
+        {"test_prose_NAMES_a_symbol_that_RESOLVES.py"}) == []
+
+
+def test_the_bare_name_predicate_IGNORES_a_NODE_ID() -> None:
+    """The two halves must not double-count a node id either: it is a filename
+    citation carrying a function name, and it belongs to the gated half."""
+    assert unresolved_bare_test_names(_GHOST_NODE_ID, set(), set()) == []
+
+
 def test_the_test_module_predicate_IGNORES_a_bare_FUNCTION_name() -> None:
-    """The `.py` is the discriminator. Bare `test_*` spans are also parametrize
-    ids, prompt-variant stems and section headings — 32 of them do not resolve in
-    this tree and almost none is a defect, so matching them would make this gate
-    answered by suppression, which is worse than no gate."""
+    """The `.py` is the discriminator. A bare span is also a parametrize id, a
+    prompt-variant stem and a section heading, so matching them here would make
+    this gate answered by exemption rows, which is worse than no gate. The
+    population is not ignored, though — it is COUNTED by
+    `test_the_CITATION_CLASS_census_is_DERIVED`, whose pinned figure replaces the
+    unreproducible one this docstring used to quote."""
     assert unresolved_test_modules(_TEST_FUNCTION_NOT_A_MODULE, set()) == []
 
 

--- a/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
+++ b/testing/scripts/tests/unit/test_prose_NAMES_a_symbol_that_RESOLVES.py
@@ -167,6 +167,73 @@ _DECLARED: dict[str, str] = {
 }
 
 
+# A backticked TEST MODULE FILENAME, optionally path-qualified. The `.py` is the
+# discriminator and it is why this half is decidable while bare test-FUNCTION
+# names are not: a citation carrying the suffix is unambiguously a file, whereas
+# a bare one is also a parametrize id, a prompt-variant stem and a section
+# heading. (An illustrative example cannot be written here, because this gate
+# reads its own comments and would report the example as a ghost — which it did,
+# to this paragraph's first draft.) Measured
+# over the swept tree: 32 bare-name citations do not resolve and almost all are
+# false positives, against 11 filename citations of which every one was a real
+# question. Keying on the half that discriminates is the whole lesson of the
+# `_ROOTS` recogniser two files over.
+_TEST_MODULE = re.compile(r"`([A-Za-z0-9_/]*\btest_[A-Za-z0-9_]+\.py)`")
+
+# Test modules named in prose that are NOT in the tree and are NOT defects.
+#
+# ⚠ KEYED BY (FILE, NAME) AND NOT BY NAME, AND THE FIRST DRAFT WAS KEYED BY NAME.
+# That draft's negative control PASSED when the deleted citation was put back at
+# the exact site a reviewer had just found it — because one row exempting the
+# name covered every site in the tree, including sites that did not exist when
+# the row was written. A deleted test module is cited in HISTORY at a handful of
+# known places and in ERROR anywhere; an exemption that cannot tell those apart
+# retires the gate for the one name it most needs to watch. The three historical
+# mentions below are three ROWS, and a fourth site naming any of them is a
+# finding.
+_DECLARED_TEST_MODULES: dict[tuple[str, str], str] = {
+    ("testing/scripts/tests/unit/gfm_table_scan.py",
+     "test_candidates_prose_matches_the_table.py"):
+        "DELETED in `91925af` with the `candidates.md` corpus it gated. Narrated "
+        "as history: these scanning helpers were private to it until a repo-wide "
+        "gate needed the same boundary, and naming the file IS that explanation.",
+    ("testing/scripts/tests/unit/test_markdown_tables_render_whole.py",
+     "test_candidates_prose_matches_the_table.py"):
+        "same deletion, narrated as history at ONE remaining site — the first "
+        "draft of this gate path-loaded it, which is the PR #96 coupling "
+        "`test_test_tree_hygiene.py` was widened for. The other three mentions "
+        "in this file made LIVE claims (a \"sibling\" comparison, a COMPANION "
+        "instruction to delete it in one commit) and were corrected, not "
+        "declared.",
+    ("testing/scripts/tests/unit/test_test_tree_hygiene.py",
+     "test_candidates_prose_matches_the_table.py"):
+        "same deletion. This is the MEASUREMENT that produced this file's "
+        "dynamic-load gate — a correction pass reached four private helpers out "
+        "of it by `spec_from_file_location`. The measurement is about that file "
+        "and cannot be restated without it.",
+    ("scripts/workflows/temporal/modules/journal/verify.py",
+     "test_verify_is_offline.py"):
+        "a file that NEVER EXISTED. `verify.py` names it in the act of saying so "
+        "— the sentence IS the correction, and blanking the name leaves it "
+        "without a subject.",
+    ("testing/scripts/tests/unit/test_mutate.py",
+     "test_subject.py"):
+        "a fixture WRITTEN AT RUN TIME into a `tmp_path` sandbox by this file, "
+        "never a tracked one. A real module that exists only while the test that "
+        "creates it is running.",
+}
+
+
+def unresolved_test_modules(source: str, filenames: set[str]) -> list[tuple[int, str]]:
+    """`(lineno, name)` for every backticked test-module filename that is not a file."""
+    found: list[tuple[int, str]] = []
+    for lineno, text in prose_of(source):
+        for match in _TEST_MODULE.finditer(text):
+            if match.group(1).split("/")[-1] not in filenames:
+                found.append((lineno, match.group(1).split("/")[-1]))
+    return found
+
+
 def _tracked(pattern: str) -> list[Path]:
     """Tracked files AND untracked-but-not-ignored ones. See the docstring.
 
@@ -332,6 +399,123 @@ def test_EVERY_PRIVATE_NAME_PROSE_CITES_RESOLVES_OR_IS_DECLARED(names: set[str])
         "it is deliberately historical — add a row to `_DECLARED` with the reason:"
         "\n  " + "\n  ".join(findings) +
         f"\n\nSCOPE: {SWEPT_PREFIXES}. A name outside it is invisible here.")
+
+
+# ---------------------------------------------------------------------------
+# THE SECOND AXIS: a TEST MODULE named in prose must exist.
+#
+# Added after a review pass found `test_a_census_guard_proves_its_own_predicate`
+# — the file whose thesis is that a coverage claim must be derived or must not be
+# written — enumerating "four corpora" and naming a gate deleted in `91925af`.
+# Sweeping the class found the SAME deleted filename at SEVEN sites in five
+# files, four of them making live claims, plus two other prose-only test modules
+# that do not exist. That is why this is a predicate and not seven corrections:
+# the previous pass corrected the two dead citations it found by script, and this
+# one was in the file class that sweep excluded.
+#
+# A test module named in prose is the strongest possible form of the thing
+# `_REFERENCE` gates: it does not merely read as already-checked, it reads as
+# ALREADY-ENFORCED. A reader auditing what is covered stops at the name.
+
+
+@pytest.fixture(scope="module")
+def filenames() -> set[str]:
+    """Every file basename in the tree — uncommitted ones included, per `_tracked`."""
+    return {path.name for path in _tracked("*")}
+
+
+def test_the_test_module_extractor_FINDS_references_at_all(
+        filenames: set[str]) -> None:
+    """A floor on the second extractor, which the first one's floor does not give."""
+    resolving = 0
+    for path in _swept():
+        source = path.read_text(encoding="utf-8", errors="replace")
+        for _, text in prose_of(source):
+            resolving += sum(1 for m in _TEST_MODULE.finditer(text)
+                             if m.group(1).split("/")[-1] in filenames)
+    assert resolving > 50, (
+        f"only {resolving} resolving test-module citations found in the tree's "
+        f"prose — the extractor is not reading what it claims to read")
+
+
+def test_EVERY_TEST_MODULE_PROSE_CITES_EXISTS(filenames: set[str]) -> None:
+    """THE RULE: a backticked `test_*.py` in a comment or docstring must be a file."""
+    findings: list[str] = []
+    for path in _swept():
+        source = path.read_text(encoding="utf-8", errors="replace")
+        relpath = str(path.relative_to(ROOT))
+        for lineno, name in unresolved_test_modules(source, filenames):
+            if (relpath, name) in _DECLARED_TEST_MODULES:
+                continue
+            findings.append(f"{relpath}:{lineno}: `{name}`")
+    assert not findings, (
+        "prose names a test module that is not in the tree. A named test reads "
+        "as already-ENFORCED, so a deleted one stops the next reader checking "
+        "whether the property is covered at all. Correct it to the gate that "
+        "ships, or — if the mention is deliberately historical — add a row to "
+        "`_DECLARED_TEST_MODULES` for THIS FILE with the reason (rows are keyed "
+        "by site, so declaring a name elsewhere does not cover this one):"
+        "\n  " + "\n  ".join(findings) +
+        f"\n\nSCOPE: {SWEPT_PREFIXES}. A file outside it is invisible here.")
+
+
+def test_no_DECLARED_TEST_MODULE_row_has_gone_stale(filenames: set[str]) -> None:
+    """A row claims the module does not exist. Re-creating it expires the row."""
+    live = sorted(name for _, name in _DECLARED_TEST_MODULES if name in filenames)
+    assert not live, (
+        f"these `_DECLARED_TEST_MODULES` rows name files that NOW EXIST: {live}. "
+        f"The row's reason is no longer true — delete it, and check the prose it "
+        f"was exempting still says the right thing about the file that now exists.")
+
+
+def test_every_DECLARED_TEST_MODULE_row_is_still_REACHED(
+        filenames: set[str]) -> None:
+    """A row for a module nobody cites is dead weight that reads as coverage."""
+    cited: set[tuple[str, str]] = set()
+    for path in _swept():
+        source = path.read_text(encoding="utf-8", errors="replace")
+        relpath = str(path.relative_to(ROOT))
+        cited.update((relpath, name)
+                     for _, name in unresolved_test_modules(source, filenames))
+    orphaned = sorted(set(_DECLARED_TEST_MODULES) - cited)
+    assert not orphaned, (
+        f"`_DECLARED_TEST_MODULES` rows nothing cites any more: {orphaned}. The "
+        f"prose that needed the exemption is gone; delete the row with it.")
+
+
+_GHOST_TEST_MODULE = '''
+# Held by `test_a_gate_that_was_deleted.py`, which does not exist.
+X = 1
+'''
+
+_REAL_TEST_MODULE = '''
+# Held by `test_prose_NAMES_a_symbol_that_RESOLVES.py`.
+X = 1
+'''
+
+_TEST_FUNCTION_NOT_A_MODULE = '''
+# The property is held by `test_the_thing_is_held`, a function and not a file.
+X = 1
+'''
+
+
+def test_the_test_module_predicate_CATCHES_a_deleted_gate() -> None:
+    found = unresolved_test_modules(_GHOST_TEST_MODULE, {"anything.py"})
+    assert [name for _, name in found] == ["test_a_gate_that_was_deleted.py"]
+
+
+def test_the_test_module_predicate_PASSES_a_gate_that_exists() -> None:
+    assert unresolved_test_modules(
+        _REAL_TEST_MODULE,
+        {"test_prose_NAMES_a_symbol_that_RESOLVES.py"}) == []
+
+
+def test_the_test_module_predicate_IGNORES_a_bare_FUNCTION_name() -> None:
+    """The `.py` is the discriminator. Bare `test_*` spans are also parametrize
+    ids, prompt-variant stems and section headings — 32 of them do not resolve in
+    this tree and almost none is a defect, so matching them would make this gate
+    answered by suppression, which is worse than no gate."""
+    assert unresolved_test_modules(_TEST_FUNCTION_NOT_A_MODULE, set()) == []
 
 
 def test_no_DECLARED_row_has_gone_stale(names: set[str]) -> None:


### PR DESCRIPTION
## Summary

Builds PMP Phase 3 — **the emit rule: whenever a run writes anything to any store, it also writes a copy into the journal**. Five new modules, four write paths wired, six new test files.

**The contract (r2, r3, r7, r8).** `modules/journal/events.py` declares the journal event as its **own contract, separate from the typed exit record's**. That separation is forced rather than chosen: `exit-protocol.md` §2 forbids a field added for a consumer that does not exist and §2.5 bounds that record at 4096 bytes, while an event adds six such fields and carries content verbatim (one measured cycle: 39,772 bytes). So the two share **one vocabulary** — `modules/vocabulary.py`, a leaf at `modules/` importable by both, because `modules/journal/` may not import `modules.assistant` and `exit_record.py` is dependency-free by design. `exit_record.Outcome` and `vocabulary.Outcome` are now the *same object*, asserted by identity rather than by value: two enums spelled alike compare unequal member-to-member, so a rebuild diffing them would report a difference that is not one.

Four admission fields land together in version-1 events because **a field absent from version-1 events is absent forever**: event identity (deterministic over `run_id`+write-path+sequence, against at-least-once execution), `edge_id`, `key_epoch`, and provenance class.

**The failure discipline (r4, r11, r12).** `modules/journal/emit.py` is the boundary. Write-ahead ordering: the intent lands *before* the store write, so a journal failure means **neither** side happened. A paired write is **one unit with two events** sharing one identity — intent, then a completion carrying the store-assigned address (which does not exist until the object does), or a typed `store_write_failure` in its place. **Replay applies only an intent that has a completion**, which is what stops Phase 4 materialising unpublished content into a store.

All four write-failure cases ship with tests driven against **real bags on a real filesystem**, never a mocked writer. Case (d)'s durable report has its MECHANISM built — **the single store write permitted with no preceding emit**, because read literally this component's own ordering rule would otherwise suppress the only durable signal that it is broken — and **no production caller yet**, which `CASE_D_CHANNELS` declares rather than leaving to be inferred. **That exception is a flag the caller sets, never a shape read off the content** (see the refine section below).

**Requirement 11 is met on ONE of the three channels, and `CASE_D_CHANNELS` is the declaration that says which — read the table, not this paragraph.** The process exit carries the signal: `JournalUnwritable` subclasses `RuntimeError`, so every entrypoint's existing handler prints a message leading with one declared marker, and `unwritable_journal_in_text` is its committed reader. **The durable working-record line has its producer built and no caller, and the exit-record `CHILD_SCHEMA` field is not built at all** — that one needs a parent branch outside this diff, and shipping a field without its branch is the observable-with-no-reader failure this requirement exists to prevent.

*(This sentence previously said requirement 11 was met on TWO channels. It was the eighth site of a claim that was wrong at all eight — see the second refine section below.)*

**The wiring (r1, r5, r6, r9, r10, r13).** Nine of eleven inventoried fleet-code paths emit, one behavioural test each. `edge_id.py` persists the machine's name at the root, refuses a digest-shaped id (`hash(api_key)` is ruled out twice over: it changes on rotation, and a stored hash of a live credential is an offline confirmation oracle). `capture_filter.py` removes ten named credential shapes **at append**, before any byte reaches the root, emitting a placeholder so the record is not silently shorter. The `Journal-` tag namespace gets its extension rule as **code** — `Bag.add_tag` is the one mechanism, lifecycle labels refused, unrecognised labels validated *and reported*.

---

## What the refine pass changed

A separate run reviewed this diff without having written it. **Every finding below came from running something**, and each ships with a control that goes red if the fix is reverted (nine mutations, listed in the Decision Log comment).

### The failure taxonomy had four escapes from itself

The module's whole thesis is *a gap may exist; a silent gap may not*. Four paths escaped its own four cases:

1. **`_build` appended the redaction placeholder ABOVE the guard.** When the capture filter fired on a read-only mount, a bare `PermissionError` propagated out of `paired_write` — no `EmitFailed`, no gap event, no `incomplete` flag, and past every entrypoint's `except RuntimeError`, because `OSError` is not one. Proven against a real bag with a **discriminating pair**: the identical call with content the filter ignores raised `EmitFailed` correctly. In `unpairable_write` it cost more — the content was lost *and* nothing recorded the loss.
2. **`UnicodeEncodeError` is a `ValueError`**, so content carrying a lone surrogate escaped every `except OSError` the same way, and the byte count on the failure path could itself raise. `APPEND_FAILURES` now names both; `gap_class_for` no longer assumes an `errno`.
3. **`_record_gap` raised only when BOTH writes failed.** A gap event that landed beside an `incomplete` flag that did not returned normally and told nobody — and nothing downstream reads a writer's `events.jsonl` to decide whether a bag is clean. That bag lost data and read as complete, which is the outcome Phase 1's four-state design exists to prevent, reached through the function that exists to prevent it.
4. **The store-write-failure handler swallowed a failed flag entirely**, and its message asserted *"a store-write-failure event was recorded"* on the exact path where recording it had just failed. It now carries the declared marker so the process channel says the journal is gone.

### The case-(d) exception was readable off the content

`gh_attempt` decided a write was the case-(d) report by testing whether its **body contained `JOURNAL-UNWRITABLE`**. Any mutation whose prose quoted the marker — a run citing a previous failure, a bug report about this component, a review comment naming it — **silently skipped the journal entirely**: no intent, no completion, no gap, no error. It is now `case_d_report=True`, a flag the caller asserts, with `test_a_comment_that_QUOTES_the_marker_still_emits` as the false-positive control that nothing had asserted.

### `seal()` wrote the manifest outside the lock this PR added

`_tag_file_lock`'s own docstring claimed *"one lock covers `bag-info.txt` and `manifest-sha256.txt` together, which is what a reseal actually needs"*. `seal()` wrote the manifest **outside** it, through the truncating writer, then took and released the lock three times for its three tag lines — and `mark_incomplete` reseals, which this phase makes reachable from every emitter on a full disk. All four writes now happen under one acquisition, with the manifest going through the atomic rename because `validate_bag` takes no lock at all.

### Three prose citations named things that do not exist

- `vocabulary.py` cited `test_shared_vocabulary_is_declared_once.py`, **which was not in the tree** — so the one invariant the module exists to protect was protected by a paragraph, and `SHARED_CONCEPTS`, built for a conformance test to walk, was imported by nothing. The file now exists (18 tests) and binds the third consumer too: `convergence.py`'s open/closed partition, where an unlisted disposition silently counts as OPEN forever.
- `emit.py` cited `test_the_unwritable_journal_signal_HAS_a_reader.py`; the property *is* tested, in `test_journal_emit.py`. Citation corrected to the real one.
- `capture_filter.py` claimed its shapes were drawn from *"this repo's own `.env`, `gh` auth and 1Password references"* — **two of the three are not in this tree** (no `.env`, no `op://` or 1Password token outside prose).

**Class sweep, exhaustive:** all **214** test-name citations in the changed non-test files were checked against the tree. Exactly **two** were dead, both in files this PR adds; four more matches were line-wrap artifacts and were confirmed present.

### The journal-isolation guard covered four of thirteen modules, and read text rather than imports

`test_the_journal_package_imports_no_workflow_module` was parametrized over a hardcoded four-module list from Phase 1 while the package now holds thirteen — so the property Phase 6's reader depends on was unasserted for the four modules this PR adds. Widened to a directory walk over the **AST**, which immediately found `__init__.py`'s *prose about not importing `modules.assistant`* being read as a violation by the old substring check — the same bug a neighbouring test in that file already exists to rule out. Its denominator now reads the same expression the parametrize does; written twice, a walk narrowed to nothing collapsed the cases to zero while the denominator kept passing on its own second glob (**found by mutation, in this pass's own test**).

### The merge gate was RED — on this PR and on `main`

*(Superseded in part: `main`'s gate has since gone green on the same SHA, and all four checks pass on this PR. The two fixes below stand; the characterisation of `main` as persistently red does not — see the second refine section.)*

`gh pr checks 175` reported `suite: fail`, and `main`'s last two commits show the same. **Neither failure is this PR's**, and both assert facts about the author's machine rather than about the code:

- `test_a_scaffolded_repo_PASSES_ITS_OWN_CHECKS.py` — `init-project.sh` commits the scaffold it writes, and a stock runner has no `user.name`/`user.email`: `128 — empty ident name`, taking three tests with it. The fixture now supplies a committer. **Not fixed in the script**: a scaffold that invents an author identity would put a fabricated name in the first commit of every new project, and git's refusal is the right behaviour.
- `test_sibling_checkouts.py::test_a_CLEAN_WORKSPACE_PASSES` — its fixture's local branch was named by the host's `init.defaultBranch` (`main` on a workstation, `master` on a runner) while it pushed `HEAD:main`, so on CI the checkout genuinely *was* off its default branch and the sweep correctly reported it.

Both were **reproduced locally** under an emulated bare machine (empty `HOME`, no global git config) — the same 1 failure and 3 errors CI reported — then fixed and re-run green there.

### Also fixed

- `plan_project_activities` created the research-pool directory **before** the emit, so a failed journal write left a half-built directory the record does not mention. The draft named this remedy and left it; the `mkdir` is now inside `perform`.
- `gap_class_for` was called twice in `_record_gap`, so the event's class and the flag's reason agreed by accident rather than by construction.

---

## What the SECOND refine pass changed

A `review-pr` pass HELD this PR with three findings and one reviewer lens found three more. **Every runway item turned out to be an INSTANCE**, and the site counts are in each heading. Six negative controls; each fix goes red when reverted.

### A merge that LANDED was journaled, permanently, as a write that failed — 1 site, live

**Not on the runway; found by the review lens.** `gh pr merge <n> --squash --delete-branch` is ONE process whose exit code covers the merge AND the cleanup, and `--delete-branch` fails routinely here because it cannot remove a branch checked out in a worktree — which this fleet always dispatches from. **Measured on the first real invocation: PR #166 MERGED while `gh` exited non-zero.**

`merge_one` already corrected that, in a HANDLER. Before the emit was wired, being one frame late cost only a wrong console message. With it wired, `paired_write` sees `perform` raise and appends a `store_write_failure` **first** — and the journal is append-only, so a completed merge is recorded as a write that did not happen, uncorrectably. `applied_intents` then declines that intent forever: a Phase 4 rebuild concludes the merge never occurred while `run_merge` reports it under `merged` in the same run.

The outcome is now resolved **inside `perform`**, so the journal and the report derive from one `gh pr view` and cannot disagree. **The two existing tests for this scenario ran with no emitter registered**, which is exactly why it shipped past them; the new pair asserts the event kinds both ways — a landed merge is `[intent, completion]`, a genuinely refused one is `[intent, store_write_failure]`. Reverting the fix reproduces `['intent', 'store_write_failure']` on the landed merge.

### The case-(d) message named two channels with no producer — 8 sites, exhaustive, now DERIVED

The runway named one: `_record_gap`'s `JournalUnwritable` message said case (d) *"is reported on the typed exit record and on a durable working-record surface"*. Neither has a live producer. The channel that does — the process exit, by `RuntimeError` inheritance — was named by none of them.

**Sweeping the claim found eight sites:** that message, `emit.py`'s module docstring twice (the case-(d) paragraph and the *"Requirement 11 — each signal ships with its reader"* section, which asserted *"the exit-record field has a named parent branch that reads it"*), `_record_gap`'s own docstring, `unwritable_journal_report`'s docstring (*"PRODUCER for both channels"*), `unwritable_journal_in_text`'s, `journal/__init__.py`'s module map, **and a TEST NAME** — `test_case_d_reports_on_the_exit_record_AND_a_durable_surface`, which is the strongest form of the defect, because a green test asserting a channel is wired reads as proof rather than as prose.

Correcting eight paragraphs does not converge, so **the claim became data**: `CASE_D_CHANNELS` declares the three channels and which has a producer, `case_d_channel_sentence()` composes the operator-facing message from it, and `test_the_case_d_CHANNEL_TABLE_matches_the_tree` **derives each answer from the tree** — `issubclass(JournalUnwritable, RuntimeError)`, an AST walk for a non-test caller passing `case_d_report=True`, and `CHILD_SCHEMA` itself. The day either unbuilt channel acquires a producer the test goes red against the table, and the message changes with it. The message also now names the flag failure's own `strerror`, which it did not.

### `address_of` was evaluated outside the guard — 3 sites in one module

The runway named the completion build. **`address_of` is the caller-supplied half of it** — it parses a store reply (`gh_attempt` reads `stdout.splitlines()[-1]`) — so it raises `IndexError` or a JSON `ValueError`, neither of which is a `RuntimeError`. Evaluated above the `try` it escaped `paired_write` bare **after the store write had landed and was therefore unrecoverable**: no `EmitFailed`, no gap, no `incomplete` flag, past every entrypoint's handler.

**The class is *an operation that can raise, placed outside the guard that types its failure*, and `paired_write`'s intent build was the member already fixed.** Two more were open: the `store_write_failure` event, built in a handler that was already recovering from one failure, and `_record_gap`'s own gap event — both `JournalEvent` constructions, and `__post_init__` is an admission gate that raises. All three now sit inside their guards, and the completion's handler is `except Exception` rather than `APPEND_FAILURES`, because narrowing it to the append's own exception set is what left the caller-supplied callable outside the taxonomy in the first place.

The new test uses `IndexError` deliberately: a `RuntimeError` would be caught by the entrypoints even on the broken code, so it would not discriminate.

### A deleted test module was cited at 7 sites, and the guard for it now exists — 9 citations, exhaustive

The runway named one: `test_a_census_guard_proves_its_own_predicate.py` claimed *"the repository gates this class in four corpora"* and named `test_candidates_prose_matches_the_table.py`, deleted in `91925af` with the `candidates.md` corpus it held. Three corpora exist.

**The prior pass's own sweep was scoped to changed NON-test files.** Extending it to test files and then to the whole swept tree found the same deleted name at **seven sites in five files** — four making live claims (a corpus count, a bullet in a list of gates, a *"sibling"* comparison, and a **COMPANION instruction telling a future maintainer to delete it in one commit**) and three narrating it as history. Two other prose-only test modules turned up beside it: `test_run_log_surface.py`, named as the gate that *"fails in BOTH directions"* over `MEMBER_EVENT_TYPES` (the assertions are in `test_run_log.py`), and `test_a_module_named_only_in_PROSE_is_not_reachable`, cited as the neighbouring test that rules out a substring bug.

**The class check is a widening of `test_prose_NAMES_a_symbol_that_RESOLVES.py`, not a new file.** That guard already gates prose naming a module-private identifier; it keys on the leading underscore, so a test module was outside it. It now also gates backticked `test_*.py` citations against the tree. **The `.py` suffix is the discriminator and the scope stops there deliberately** — measured over the swept tree, bare `test_*` spans have 32 unresolved citations of which almost none is a defect (parametrize ids, prompt-variant stems, section headings), against 11 filename citations of which every one was a real question. A gate answered by suppression is worse than no gate.

**Its exemption rows are keyed by `(file, name)`, and the first draft keyed them by name.** That draft's own negative control **passed** when the deleted citation was put back at the exact site the reviewer had just found it, because one row covered every site in the tree including sites that did not exist yet. A deleted module is cited in history at a handful of known places and in error anywhere; an exemption that cannot tell those apart retires the gate for the one name it most needs to watch.

**And it caught its own author twice on arrival** — an illustrative `test_foo.py` in its own comment, and a dead name left inside the correction made one edit earlier in `run_log.py`. Both were fixed before it went green.

### The identity-collision limit was understated — 1 site

`event_identity`'s docstring said two writers each emitting `seq=1` are *"unordered relative to each other"*. They also derive the **same `event_id`**, because the material is `(run_id, write_path, sequence)` and a writer contributes nothing to it — so `dedupe_on_identity` keeps the first and the second writer's distinct completion is **dropped on replay**. That is data loss, not an ordering ambiguity. The paragraph now states the consequence, states that the wiring which makes it unreachable is a property of the wiring and not an invariant, and names its trigger.

### Also, and reported rather than absorbed

- **`_PINNED` moved 45 → 46 and 35 → 36.** The census guard correctly classified `test_journal_emit.py` as a tree-walking guard once the channel deriver landed, and it arrived with its literal-snippet control.
- **The gate was already GREEN before this pass**, on this PR and on `main` — the previous section's report of a red `main` is superseded by later runs on the same SHA. `gh pr checks 175`: four checks, all pass.

---

---

## What the THIRD refine pass changed

`review-pr` pass 2 HELD this PR with five findings, all `fix-in-place`. **All five are fixed, every one turned out to have a class behind it, and the site counts are in each heading.** One reviewer lens then found a **live sixth instance of the citation class in a third citation shape neither predicate could see** — the strongest evidence in this PR that enumerating instances does not converge and changing what the check keys on does.

Six negative controls; each fix goes red when reverted. **The citation gate caught its own author four separate times while this pass was writing it.**

### One unretried `gh` read decided a permanent journal record — 1 site, exhaustive over `modules/`

`_merge_outcome_after_failure` resolved *"did it actually merge?"* from a single `_gh_json` call that swallows `SubprocessError`, `OSError` and `JSONDecodeError` and returns `None` — and `None` was read as NOT MERGED. `gh pr merge --squash --delete-branch` exiting non-zero is the **normal** case here (the branch is checked out in a worktree, which this fleet always dispatches from), so that read sits on the ordinary path: one transient `gh` failure journaled a merge that LANDED as a `store_write_failure`, into an append-only record, uncorrectably.

**Three outcomes, not two.** The read can say MERGED, say another state, or FAIL. `_merge_state` now keeps the third apart from the second — including a reply that parses but carries no `state`, where `{}.get("state")` returns the same `None` an unreadable call does — and re-asks it a bounded number of times. The direction is unchanged (an unread verdict still fails toward "did not merge"; that is this module's thesis), but the **detail no longer presents `gh pr merge`'s own stderr as the verdict**: `failed to delete local branch` is a sentence about the cleanup, and handing it back as the merge outcome is how it reads as "the PR did not merge". An unread outcome now carries `UNRESOLVED_MERGE_PREFIX` and tells the operator to look.

**The class is "a `gh` read that bypasses the fleet's bounded wrapper", and `_gh_json` was its only member** — swept exhaustively over `modules/`: two direct `subprocess.run(["gh", …])` launches exist, and the other is the merge itself, which must **not** be retried. `_gh_json` now goes through `gh_attempt`, so all of its callers inherit the retry, and the composed worst case is stated in `OUTCOME_RETRIES`'s comment rather than left to be discovered.

*(A `TerminalState` member was deliberately **not** added — the reviewer named that as a v1 schema question this PR does not open.)*

### The case-(d) message would have made a false claim the day a channel was wired — 1 site, exhaustive

`case_d_channel_sentence` composed the channel **names** from `CASE_D_CHANNELS` and spelled the **count** by hand: *"both are declared … NEITHER has a producer … appear on them"*. Driven with a one-dead-channel table that is three false plurals, and `test_the_case_d_CHANNEL_TABLE_matches_the_tree` stays green throughout — it compares the table against the tree and never reads the sentence. The whole clause is now selected by `len(dead)`, and the new test drives **every cardinality the table can hold**, because the defect was invisible at the one cardinality the tree happens to have today. Reverting reproduces the plurals with the table test still green — which is exactly the gap.

Class swept over `modules/`: every other composed message either derives its cardinality already (`{len(vanished)} file(s)`) or refers to a structurally fixed pair. **One member.**

### Two coverage claims were held by tests that do not exist — 17 sites / 15 unique, then a 6th shape

The runway named two, both in `gfm_table_scan.py`: *"held by `test_an_HTML_BLOCK_opener_…`"* and *"Held by `test_a_CONTAINER_INDENTED_FENCE_…`"*, functions deleted in `91925af`. Both are repointed at the surviving tree-wide tests in `test_markdown_tables_render_whole.py`, which is the module that imports these helpers — so each claim now names the test that holds that function's residual.

**Sweeping the class — every backticked bare `test_*` span in the swept tree that resolves neither to a bound name nor to a tracked file stem — found 17 sites, 15 unique. Eight were LIVE claims and all eight are corrected:**

| site | what it claimed |
|---|---|
| `gfm_table_scan.py` ×2 | the two runway items |
| `test_markdown_tables_render_whole.py` | *"WHAT THIS GATE DOES NOT COVER THAT ITS SIBLING DOES"* — the sibling was deleted, so the strict bar is asserted **nowhere**; the paragraph now records a gap rather than a division of labour |
| `assembled_prompt.py` | a resolver property *"held"* by a test deleted with the collision it demonstrated |
| `test_promoted_fragments_render_for_every_consumer.py` | *"the same shape `test_research_minor` uses"*, present tense, about a module deleted in `6a59500` |
| `test_journal_regex_anchors.py`, `test_the_config_digest_POPULATION…py`, `test_a_run_given_a_PR…py` | three truncated names that resolve to nothing as written |

The other nine sites are history narration (`RETIRED 2026-08-26 ·`, *"WAS HERE"*, *"it used to be"*) and are correct as they stand.

**The `test_markdown_tables_render_whole.py` site is the one that proves the shape matters:** the previous pass corrected that paragraph's **filename** citation and left the claim standing, because the remaining subject was a bare function name — the half the gate does not key on. That asymmetry is the whole of **#178**.

**And then a THIRD citation shape, which neither predicate could see.** A pytest node id — a path, `::`, a function name — is not matched by the module pattern (it wants a backtick straight after the suffix) nor by the bare pattern (no `.` in its class). **Six sites carry it and one was a live present-tense claim naming a module deleted in `6a59500`**, in `research_draft_workflow.py`'s docstring: inside the swept tree, and invisible to a sweep of this exact class that had just been run over that tree twice. The filename half of a node id now gates like any other filename, with a catch/pass pair and a no-double-count control; the citation is repointed at the test that actually holds it.

### The measurement justifying half the gate could not be re-derived — 2 sites

The comment above `_TEST_MODULE` justified keying only on `.py` with *"32 bare-name citations do not resolve and almost all are false positives, against 11 filename citations of which every one was a real question."* Re-running the stated method gives **129 sites** on one reading of "bare name" and **17** on the other; neither is 32. The conclusion is right — the dominant category genuinely is module names cited without their suffix — but the sole stated evidence for leaving half a class ungated sat, uncheckable, in the file whose thesis is that an unbacked claim in a trusted block stops the next reader checking.

**The figures are derived now.** `unresolved_bare_test_names` spells out what *"does not resolve"* means — neither bound in the tree nor the stem of a tracked file, the ambiguity that made 129 and 17 both defensible — and `test_the_CITATION_CLASS_census_is_DERIVED` pins both halves as **sites**, with every site printed in the failure message. A count that rises is somebody's new citation to read: a live claim is a defect and gets corrected, history bumps the constant on purpose. The second site of the old figure, in a predicate control's docstring, is corrected with it.

**This is a census, not the gate widening.** Widening the bare half needs a resolver rather than an exemption list and is issue **#178**; nothing here pre-empts that ruling.

### A disclosed live defect was recorded only in a claim that it had been disclosed — 1 site

`test_prose_NAMES_a_symbol_that_RESOLVES.py`'s docstring said its `testing/config-hooks/` instance *"is SURFACED on the PR that added this file"*. It is not — not in the body, not in any comment. So the only record of a real, disclosed, live defect was that paragraph, in the file whose own docstring calls a permanent list of dead names the thing the guard exists to prevent. It now cites **#178**, which carries both blind spots and was verified OPEN.

### Also, and reported rather than absorbed

- **The reviewer found a false claim in this pass's own new prose** — the `_gh_json` docstring said "three callers" and named `thread_verdict` as one. It has two, and `thread_verdict` reaches `gh` through `review_act.pr_review_blocks`. Corrected, with the miscount named so the next reader does not re-derive it.
- **Four sites point deferred work at CLOSED issues** — `test_a_census_guard_proves_its_own_predicate.py:276` at **#103** (CLOSED COMPLETED 2026-08-26) and `test_isolation_invariants.py` ×2 plus `test_delegated_contract.py` at **#36** (CLOSED COMPLETED 2026-08-09). Each says the residual is *"still tracked at"* the issue; `_WITHOUT_A_CONTROL_YET` is a live frozenset in the tree, so at least the first residual is genuinely outstanding with no live home. **SURFACED, not filed** — out of scope for this change, and this run holds no write grant on any store. Same class as the finding above (a placement claim that is not live), different mechanism (a pointer that expired rather than one that never existed).
- **The gate caught its own author four times** while this pass wrote it: an illustrative filename in the new `_BARE_TEST_NAME` comment, an illustrative bare name in `unresolved_bare_test_names`'s docstring, a real deleted filename quoted inside the census constant's comment, and a second illustrative filename in the node-id comment. Each was reported by the guard being extended, before it went green.

## Deviation summary: planned vs built

| Planned | Built | |
|---|---|---|
| Event contract, separate, one shared vocabulary | `events.py` + `modules/vocabulary.py` | matched |
| Four admission fields | identity, `edge_id`, `key_epoch`, provenance | matched |
| Write-ahead ordering, four failure cases | `emit.py`, all four tested against real bags | matched |
| Gap event, bounded and typed | `GapClass` — four classes, byte count, timestamp, never an exception message | matched |
| `edge_id` stable and never key-derived | `edge_id.py`, refusal is code | matched |
| Capture-time filter + placeholder | `capture_filter.py` | matched |
| Tag namespace, four clauses | (a)(b)(d) as code; **(c) deliberately left open** with a test that goes red if a second version field appears | matched |
| Atomic `bag-info.txt` before emitters exist | directory `flock` + write-temp-plus-`os.replace`, **now covering the manifest too** | matched |
| Payload at `0600` through the bag | `Bag.write_payload`, mode at creation, `O_EXCL` | matched |
| Emit as an ACTIVITY, not a call each site remembers | **registered by `open_run_bag`**, process-scoped | **diverged — see below** |
| Report on the typed exit record | non-zero exit + marker; **no `CHILD_SCHEMA` field, and no caller for the durable line** — declared in `CASE_D_CHANNELS`, derived from the tree by a test | **partial** |
| "A retried emit appends once" | appends again; **replay applies once** | **diverged — see below** |
| Wire every inventoried path | 9 of 11 | **partial** |
| Live demonstrations (research cycle, fan-out, integration) | not done | **not met** |
| Measured byte total | coverage denominator instead | **corrected — see below** |

**The activity divergence, and why the alternatives were worse.** The plan says the emit is an activity rather than a helper each write path remembers. The fleet's write paths are reached from dozens of call sites that hold no bag. Threading a `Bag` through every signature changes ~40 of them and every one can still be called without it — the optional control this component's own thesis says is a skipped control. Having each write path open its own bag produces two bags for one `run_id`, which `open_bag` refuses at runtime. So the boundary is **registered once by `open_run_bag`**, where Phase 1 r11 already put the run's first I/O step. `register_emitter`'s docstring states the trade and names what it does not reach. **The refine pass reviewed and kept this**; the one alternative raised against it (`contextvars`) was rejected because a `ContextVar` is not visible to a thread that did not inherit the context, which would silently drop emits the module global does not.

**"A retried emit appends once" is deliberately not met as written.** A retried emit *appends again* — the journal is append-only, and suppressing the append would require the emitter to remember what it wrote, which a retried process does not have. What is guaranteed is that **replay applies it once**, via dedupe-on-identity. Both halves are asserted. Left unchecked in the phase doc so a reviewer rules on the divergence rather than inheriting it.

**The measurement is corrected, not skipped.** § Measurement asks for emitted-vs-written authored bytes. **That ratio is a rebuild diff**, which is Phase 4's assertion; producing it here means building a second, weaker rebuild inside this phase. A coverage denominator is recorded instead. Companion PR: helloskyy-io/skyynet-master-planning#31.

## Test results

`./testing/run-all.sh` — **`RESULT: PASSED`** at the third pass's head — unit **5545 passed, 12 skipped**; integration **242 passed**; e2e skipped (no `tests/e2e` in the tree). No test was skipped to make anything green, and the 12 skips are pre-existing derived-path conditions unrelated to this diff.

The second refine pass added **10** tests on top of the first pass's 37 and the draft's 5,483: the case-(d) channel table and its predicate control, a raising `address_of`, the two merge-journalling directions, and five holding the widened test-module citation gate. **One suite run went RED on the way** — the census guard reclassified `test_journal_emit.py` as a tree-walking guard once its deriver landed, which is the guard doing its job; `_PINNED` moved 45 → 46 and 35 → 36, with the reason recorded beside the four moves before it.

The THIRD refine pass added **12** more: five on the merge-outcome read (the re-asked transient, the unread detail, the read-and-refused discrimination control, the parses-but-stateless reply, and a `gh` read riding out a 503), one driving `case_d_channel_sentence` at every cardinality its table can hold, and six on the citation gate — the derived census, two predicate-discrimination controls for the bare half, and a catch/pass/no-double-count trio for the node-id shape. **The citation gate went red four times against this pass's own prose while it was being written**, each time on an illustrative or quoted test name inside the guard's own comments, which is the shape its docstring already warns about.

New files (collected cases): `test_journal_events.py` (36) · `test_journal_emit.py` (36) · `test_journal_edge_id_and_capture_filter.py` (36) · `test_the_tag_namespace_is_HELD_BY_CODE.py` (22) · `test_every_fleet_write_path_EMITS.py` (16) · `test_shared_vocabulary_is_declared_once.py` (18). Extended: `test_journal_bag.py` (53, including the manifest-lock test), `test_merge_pr_refuses_before_it_merges.py` (28), `test_prose_NAMES_a_symbol_that_RESOLVES.py` (25).

**The suite was also run as a bare machine would see it** — empty `HOME`, no global git config — which is how the two CI-only failures were reproduced and fixed.

## Success criteria

| # | Requirement | |
|---|---|---|
| 1 | every inventoried write path emits, verbatim, destination as a field | **partial — 9 of 11** |
| 2 | the journal is identical regardless of destination | **met** — asserted as key-set equality over six store kinds |
| 3 | one vocabulary, two contracts | **met** — enum *identity* asserted, and now by a test that exists |
| 4 | a failed journal write is never silent — four cases | **met** — all four against real bags, and four escapes from the taxonomy closed |
| 5 | every emitted item records its input item | **met** as a field; **live fan-out not demonstrated** |
| 6 | stable `edge_id`, never key-derived, no key in any event | **met** (buildable half; the key→id mapping is upstream and deferred on its named trigger) |
| 7 | admission contract — identity, authority, epoch, provenance | **met**, with `edge_id`'s self-reported limit stated in code |
| 8 | schema version on every event, none ever changed | **met**; the upcaster stays open and an unknown version is refused rather than misread |
| 9 | inventory complete and enumerated, both halves | **met** — in helloskyy-io/skyynet-master-planning#31 |
| 10 | capture-time filtering, before the root | **met**, with its blind spots asserted as blind spots and its provenance claim corrected |
| 11 | the unwritable-journal signal ships with a committed reader | **partial — ONE of three channels**, declared in `CASE_D_CHANNELS` and derived from the tree by a test. The process exit carries it with its reader; the durable line's producer has no caller; the exit-record field is not built |
| 12 | the emit is an activity | **met with a stated divergence** in mechanism |
| 13 | the tag namespace has an extension rule | **met** — (a)(b)(d) as code, (c) held open by a test |

**Checkpoint 3 is not fully standing, and the residual is named rather than hidden:** until Phase 10 lands, this phase's headline claim — *if any store gets it, the journal gets it* — **is true of files and false of prose.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

